### PR TITLE
feat: income-over-time tracking that adjusts the budget + roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,75 @@
+# Blipko Roadmap
+
+How to make the conversational budget tracker genuinely useful in the real world, and how to make
+shipping it reliable. Each item is tagged **impact** (value to users / the team) and **effort**.
+Ordered roughly by priority within each track.
+
+> Status today: capture loop (text + voice), 50/30/20 auto-categorization, low-confidence confirm,
+> `/status`, undo, `/report`, proactive nudges, web dashboard, web↔Telegram account linking, and now
+> **income-over-time** (budget tracks actual income, floored at the expected salary). Backend 50 unit tests
+> green; web builds.
+
+---
+
+## Track A — Real-world usefulness (product)
+
+### P0 — capture must be trustworthy (the whole moat)
+- **Parser accuracy loop.** We already log every parse to `ParseLog` (raw + parsed + confidence). Build a
+  small review of low-confidence / corrected parses and feed fixes back into the prompt. *Impact: high ·
+  Effort: med.* This is what keeps "chai 30" working across Manglish/Hinglish/Malayalam.
+- **Edit / correct flows.** Reply-to-correct an amount/category/bucket (not just undo). *Impact: high · Effort: med.*
+- **Voice reliability.** Voice already routes through the same pipeline; tag `source=VOICE`, and surface
+  transcription confidence so a bad transcript asks to confirm. *Impact: med · Effort: low.*
+
+### P1 — make the budget match real life
+- **Recurring income & expenses + payday-aware budgeting.** Rent/EMIs/salary that repeat; roll the budget
+  window to the user's `payday` instead of the calendar month. *Impact: high · Effort: med.* (Income-event
+  tracking just shipped is the foundation.)
+- **Savings goals.** "Save ₹2L for a trip by Dec" → progress against the SAVINGS bucket. *Impact: high · Effort: med.*
+- **Multi-currency / locale.** `User.currency`/`locale` exist; honor them everywhere (some copy still hardcodes ₹). *Impact: med · Effort: low.*
+- **Income undo + web Income page.** Extend undo to the most recent of expense/income; list income in the
+  dashboard. *Impact: med · Effort: low.*
+
+### P2 — proactive value & retention
+- **Weekly digest** in addition to nudges + monthly `/report`. *Impact: med · Effort: low.*
+- **Smarter nudges**: pace-based ("at this rate you'll overspend Wants by ₹3k"), not just 80%/over. *Impact: med · Effort: med.*
+
+### P3 — reach & trust
+- **WhatsApp channel** (the brief's market channel) via the existing `IMessagingPlatform` abstraction — no
+  core rewrite, just an adapter + Meta verification. *Impact: high · Effort: high.*
+- **Data export (CSV)** from the dashboard, and a clear privacy/data-deletion path. *Impact: med · Effort: low.*
+- **Referral / share** ("track money with me"). *Impact: med · Effort: med.*
+
+---
+
+## Track B — Engineering workflow (ship reliably)
+
+### P0 — get CI green and keep it green
+- **Fix the `test` workflow.** It's been red since the pivot and burns the full 60-min timeout: the Playwright
+  job's env still sets `META_*`/`WHATSAPP_*` but not `TELEGRAM_BOT_TOKEN`/`TELEGRAM_WEBHOOK_SECRET`, so the
+  launched backend crashes on `env.ts` validation; `tests/api.spec.ts` still probes the removed
+  `/api/webhooks/whatsapp` and `web-telegram-ui.spec.ts` uses old-schema fields. Swap the env, rewrite/remove
+  those specs, add a real webhook E2E. *Impact: high · Effort: med.*
+- **Lint web in CI.** Root `eslint` now (correctly) ignores `web/`; add a `cd web && pnpm lint` step so web
+  regressions are caught. *Impact: med · Effort: low.*
+- **Enforce branch protection** (required checks) once green, so red never lands on `main`.
+
+### P1 — safer releases
+- **Staging environment + preview deploys** per PR (Railway/Vercel), so changes are exercised before `main`.
+  *Impact: high · Effort: med.*
+- **Migration discipline.** Single root Prisma schema is the source of truth; the web copy auto-syncs via
+  `scripts/sync-prisma-schema.mjs`. Add a CI check that `web/prisma/schema.prisma` matches root. *Impact: med · Effort: low.*
+- **Feature flags** for risky bot behaviors (new intents, prompt changes). *Impact: med · Effort: med.*
+
+### P2 — observability & quality
+- **Error tracking** (Sentry) for the webhook + Server Actions; alert on parser/provider failures. *Impact: high · Effort: low.*
+- **More unit coverage** around budget math and processors (already strong); add an integration test that
+  runs a message end-to-end against a test DB. *Impact: med · Effort: med.*
+- **ParseLog dashboard** (internal) to watch real parse quality and prompt-tune. *Impact: med · Effort: med.*
+
+---
+
+## Suggested next 3
+1. **Fix CI `test`** (Track B P0) — stop the red/timeout, restore a real safety net.
+2. **Recurring + payday-aware budgeting** (Track A P1) — biggest real-world fit after income tracking.
+3. **Error tracking** (Track B P2) — cheap insurance for a money app where silent failures erode trust.

--- a/prisma/migrations/20260611160636_add_income/migration.sql
+++ b/prisma/migrations/20260611160636_add_income/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "Income" (
+    "id" TEXT NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "source" TEXT,
+    "note" TEXT,
+    "rawText" TEXT NOT NULL,
+    "confidence" DOUBLE PRECISION NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Income_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Income_userId_date_idx" ON "Income"("userId", "date");
+
+-- AddForeignKey
+ALTER TABLE "Income" ADD CONSTRAINT "Income_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ model User {
 
   // Core relations
   expenses     Expense[]
+  incomes      Income[]
   budgetConfig BudgetConfig?
   categories   Category[]
   logs         ParseLog[]
@@ -141,6 +142,28 @@ model Expense {
 
   @@index([userId, date])
   @@index([userId, bucket, date])
+}
+
+// Income events (salary, freelance, bonus). The month's effective budget is
+// based on max(expected monthlyIncome, sum of income this month).
+model Income {
+  id     String  @id @default(cuid())
+  amount Decimal @db.Decimal(12, 2)
+  source String? // "salary", "freelance", etc.
+  note   String?
+
+  rawText    String
+  confidence Float
+
+  date DateTime @default(now())
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  isDeleted Boolean   @default(false)
+  deletedAt DateTime?
+
+  @@index([userId, date])
 }
 
 // ─── Infra ────────────────────────────────────────────────────────────────────

--- a/src/application/use-cases/ProcessIncomingMessage.spec.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.spec.ts
@@ -24,6 +24,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
   let categoryRepository: any;
   let budgetConfigRepository: any;
   let parseLogRepository: any;
+  let incomeRepository: any;
   let conversationRepository: any;
   let aiParser: any;
   let messageService: any;
@@ -67,6 +68,12 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       create: vi.fn().mockResolvedValue({ id: "plog1" }),
       findById: vi.fn().mockResolvedValue(null),
     };
+    incomeRepository = {
+      create: vi.fn().mockResolvedValue({ id: "inc1" }),
+      sumForMonth: vi.fn().mockResolvedValue(0),
+      findLastByUserId: vi.fn().mockResolvedValue(null),
+      softDelete: vi.fn().mockResolvedValue(undefined),
+    };
     conversationRepository = {
       getRecent: vi.fn().mockResolvedValue([]),
       append: vi.fn().mockResolvedValue(undefined),
@@ -85,6 +92,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       categoryRepository,
       budgetConfigRepository,
       parseLogRepository,
+      incomeRepository,
       conversationRepository,
       messageService,
     );
@@ -256,6 +264,28 @@ describe("ProcessIncomingMessage (budget flow)", () => {
     expect(expenseRepository.softDelete).toHaveBeenCalledWith("e1");
     expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
       "Removed: ₹220 Food",
+    );
+  });
+
+  it("records income and replies with the refreshed budget", async () => {
+    incomeRepository.sumForMonth.mockResolvedValue(55000);
+    aiParser.parseText.mockResolvedValue({
+      intent: "INCOME",
+      amount: 5000,
+      note: "freelance",
+      confidence: 0.9,
+    });
+
+    await useCase.execute({
+      platformUserId: "123",
+      textMessage: "got freelance 5000",
+    });
+
+    expect(incomeRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 5000, userId: "u1" }),
+    );
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "This month: ₹55,000",
     );
   });
 

--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -9,6 +9,7 @@ import { IExpenseRepository } from "../../domain/repositories/IExpenseRepository
 import { ICategoryRepository } from "../../domain/repositories/ICategoryRepository";
 import { IBudgetConfigRepository } from "../../domain/repositories/IBudgetConfigRepository";
 import { IParseLogRepository } from "../../domain/repositories/IParseLogRepository";
+import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
 import { IConversationRepository } from "../../domain/repositories/IConversationRepository";
 import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import { ParsedData, ParsedBucket } from "../../domain/entities/ParsedData";
@@ -22,6 +23,7 @@ import { StatusProcessor } from "./processors/StatusProcessor";
 import { ReportProcessor } from "./processors/ReportProcessor";
 import { UndoProcessor } from "./processors/UndoProcessor";
 import { ExpenseProcessor } from "./processors/ExpenseProcessor";
+import { IncomeProcessor } from "./processors/IncomeProcessor";
 import { FallbackProcessor } from "./processors/FallbackProcessor";
 
 export interface ProcessIncomingMessageInput {
@@ -49,6 +51,7 @@ export class ProcessIncomingMessageUseCase {
     private readonly categoryRepository: ICategoryRepository,
     private readonly budgetConfigRepository: IBudgetConfigRepository,
     private readonly parseLogRepository: IParseLogRepository,
+    private readonly incomeRepository: IIncomeRepository,
     private readonly conversationRepository: IConversationRepository,
     private readonly messageService: IMessagingPlatform,
   ) {
@@ -58,6 +61,7 @@ export class ProcessIncomingMessageUseCase {
         expenseRepository,
         categoryRepository,
         budgetConfigRepository,
+        incomeRepository,
         messageService,
       ),
       new OnboardingProcessor(
@@ -68,17 +72,20 @@ export class ProcessIncomingMessageUseCase {
       new StatusProcessor(
         expenseRepository,
         budgetConfigRepository,
+        incomeRepository,
         messageService,
       ),
       new ReportProcessor(
         expenseRepository,
         budgetConfigRepository,
+        incomeRepository,
         messageService,
       ),
       new UndoProcessor(
         expenseRepository,
         categoryRepository,
         budgetConfigRepository,
+        incomeRepository,
         messageService,
       ),
     ];
@@ -86,12 +93,14 @@ export class ProcessIncomingMessageUseCase {
       new StatusProcessor(
         expenseRepository,
         budgetConfigRepository,
+        incomeRepository,
         messageService,
       ),
       new UndoProcessor(
         expenseRepository,
         categoryRepository,
         budgetConfigRepository,
+        incomeRepository,
         messageService,
       ),
       new ExpenseProcessor(
@@ -99,6 +108,12 @@ export class ProcessIncomingMessageUseCase {
         categoryRepository,
         budgetConfigRepository,
         parseLogRepository,
+        incomeRepository,
+        messageService,
+      ),
+      new IncomeProcessor(
+        incomeRepository,
+        budgetConfigRepository,
         messageService,
       ),
       new FallbackProcessor(messageService),

--- a/src/application/use-cases/SendBudgetNudges.spec.ts
+++ b/src/application/use-cases/SendBudgetNudges.spec.ts
@@ -13,8 +13,8 @@ describe("SendBudgetNudges", () => {
 
   // Helper: set per-bucket spend.
   const setSpend = (spend: Record<string, number>) => {
-    expenseRepository.sumByBucketForMonth = vi.fn((_u: string, bucket: string) =>
-      Promise.resolve(spend[bucket] ?? 0),
+    expenseRepository.sumByBucketForMonth = vi.fn(
+      (_u: string, bucket: string) => Promise.resolve(spend[bucket] ?? 0),
     );
   };
 
@@ -33,11 +33,13 @@ describe("SendBudgetNudges", () => {
     };
     nudgeRepository = { recordSentIfNew: vi.fn().mockResolvedValue(true) };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    const incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
     useCase = new SendBudgetNudgesUseCase(
       userRepository,
       expenseRepository,
       budgetConfigRepository,
       nudgeRepository,
+      incomeRepository as any,
       messageService,
     );
   });

--- a/src/application/use-cases/SendBudgetNudges.ts
+++ b/src/application/use-cases/SendBudgetNudges.ts
@@ -3,11 +3,13 @@ import { IUserRepository } from "../../domain/repositories/IUserRepository";
 import { IExpenseRepository } from "../../domain/repositories/IExpenseRepository";
 import { IBudgetConfigRepository } from "../../domain/repositories/IBudgetConfigRepository";
 import { INudgeRepository } from "../../domain/repositories/INudgeRepository";
+import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
 import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
   currentMonthRange,
+  effectiveMonthlyIncome,
   formatMoney,
   monthDayInfo,
   monthPeriodKey,
@@ -32,6 +34,7 @@ export class SendBudgetNudgesUseCase {
     private readonly expenseRepository: IExpenseRepository,
     private readonly budgetConfigRepository: IBudgetConfigRepository,
     private readonly nudgeRepository: INudgeRepository,
+    private readonly incomeRepository: IIncomeRepository,
     private readonly messageService: IMessagingPlatform,
   ) {}
 
@@ -61,8 +64,12 @@ export class SendBudgetNudgesUseCase {
     periodKey: string,
     daysLeft: number,
   ): Promise<number> {
-    const income = Number(user.monthlyIncome ?? 0);
-    if (income <= 0 || !user.telegramId) return 0;
+    if (!user.telegramId) return 0;
+    const income = effectiveMonthlyIncome(
+      Number(user.monthlyIncome ?? 0),
+      await this.incomeRepository.sumForMonth(user.id, start, end),
+    );
+    if (income <= 0) return 0;
 
     const config =
       (await this.budgetConfigRepository.findByUserId(user.id)) ??

--- a/src/application/use-cases/budgetMath.spec.ts
+++ b/src/application/use-cases/budgetMath.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   bucketBudget,
   currentMonthRange,
+  effectiveMonthlyIncome,
   formatMoney,
   monthDayInfo,
   pctSpent,
@@ -12,6 +13,13 @@ import {
 const SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
 
 describe("budgetMath", () => {
+  it("effective income floors at expected and grows with actual", () => {
+    expect(effectiveMonthlyIncome(50000, 0)).toBe(50000); // nothing logged → expected
+    expect(effectiveMonthlyIncome(50000, 55000)).toBe(55000); // extra income expands
+    expect(effectiveMonthlyIncome(50000, 30000)).toBe(50000); // never below the plan
+    expect(effectiveMonthlyIncome(0, 8000)).toBe(8000); // gig worker, no baseline
+  });
+
   it("computes per-bucket budgets from income and split", () => {
     expect(bucketBudget(50000, SPLIT, "NEEDS")).toBe(25000);
     expect(bucketBudget(50000, SPLIT, "WANTS")).toBe(15000);

--- a/src/application/use-cases/budgetMath.ts
+++ b/src/application/use-cases/budgetMath.ts
@@ -41,6 +41,16 @@ export function bucketBudget(
   return (monthlyIncome * bucketPct(split, bucket)) / 100;
 }
 
+// The income to budget against this month: the expected salary is a floor, and
+// actual income logged this month expands it above that floor. Lets salaried
+// and variable-income users share one rule (gig users set expected = 0).
+export function effectiveMonthlyIncome(
+  expected: number,
+  incomeThisMonth: number,
+): number {
+  return Math.max(expected, incomeThisMonth);
+}
+
 const inr = new Intl.NumberFormat("en-IN", { maximumFractionDigits: 0 });
 
 export function formatMoney(amount: number): string {

--- a/src/application/use-cases/expenseFlow.ts
+++ b/src/application/use-cases/expenseFlow.ts
@@ -2,11 +2,13 @@ import { Bucket, ExpenseSource, User } from "@prisma/client";
 import { IExpenseRepository } from "../../domain/repositories/IExpenseRepository";
 import { ICategoryRepository } from "../../domain/repositories/ICategoryRepository";
 import { IBudgetConfigRepository } from "../../domain/repositories/IBudgetConfigRepository";
+import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
 import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
   currentMonthRange,
+  effectiveMonthlyIncome,
   formatMoney,
   sanitizeMd,
 } from "./budgetMath";
@@ -15,6 +17,7 @@ export interface ExpenseFlowDeps {
   expenseRepository: IExpenseRepository;
   categoryRepository: ICategoryRepository;
   budgetConfigRepository: IBudgetConfigRepository;
+  incomeRepository: IIncomeRepository;
   messageService: IMessagingPlatform;
 }
 
@@ -87,8 +90,16 @@ export async function recordExpenseAndReply(
   );
   const config =
     (await deps.budgetConfigRepository.findByUserId(user.id)) ?? DEFAULT_SPLIT;
-  const monthlyIncome = Number(user.monthlyIncome ?? 0);
-  const budget = bucketBudget(monthlyIncome, config, bucket);
+  const monthIncome = await deps.incomeRepository.sumForMonth(
+    user.id,
+    start,
+    end,
+  );
+  const income = effectiveMonthlyIncome(
+    Number(user.monthlyIncome ?? 0),
+    monthIncome,
+  );
+  const budget = bucketBudget(income, config, bucket);
   const remaining = budget - spent;
 
   const meta = BUCKET_META[bucket];

--- a/src/application/use-cases/processors/ConfirmBucketProcessor.ts
+++ b/src/application/use-cases/processors/ConfirmBucketProcessor.ts
@@ -7,6 +7,7 @@ import {
 import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
 import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
+import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
 import { IParseLogRepository } from "../../../domain/repositories/IParseLogRepository";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import { ParsedData } from "../../../domain/entities/ParsedData";
@@ -23,6 +24,7 @@ export class ConfirmBucketProcessor implements MessageProcessor {
     private readonly expenseRepository: IExpenseRepository,
     private readonly categoryRepository: ICategoryRepository,
     private readonly budgetConfigRepository: IBudgetConfigRepository,
+    private readonly incomeRepository: IIncomeRepository,
     private readonly messageService: IMessagingPlatform,
   ) {}
 
@@ -55,6 +57,7 @@ export class ConfirmBucketProcessor implements MessageProcessor {
         expenseRepository: this.expenseRepository,
         categoryRepository: this.categoryRepository,
         budgetConfigRepository: this.budgetConfigRepository,
+        incomeRepository: this.incomeRepository,
         messageService: this.messageService,
       },
       {
@@ -73,9 +76,11 @@ export class ConfirmBucketProcessor implements MessageProcessor {
   }
 
   private async fail(platformUserId: string): Promise<ProcessOutput> {
-    const response =
-      "That entry expired — please send the expense again.";
-    await this.messageService.sendMessage({ to: platformUserId, body: response });
+    const response = "That entry expired — please send the expense again.";
+    await this.messageService.sendMessage({
+      to: platformUserId,
+      body: response,
+    });
     return { response, parsed: { intent: "UNKNOWN", confidence: 1 } };
   }
 }

--- a/src/application/use-cases/processors/ExpenseProcessor.ts
+++ b/src/application/use-cases/processors/ExpenseProcessor.ts
@@ -6,6 +6,7 @@ import {
 import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
 import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
+import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
 import { IParseLogRepository } from "../../../domain/repositories/IParseLogRepository";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import { recordExpenseAndReply } from "../expenseFlow";
@@ -24,6 +25,7 @@ export class ExpenseProcessor implements MessageProcessor {
     private readonly categoryRepository: ICategoryRepository,
     private readonly budgetConfigRepository: IBudgetConfigRepository,
     private readonly parseLogRepository: IParseLogRepository,
+    private readonly incomeRepository: IIncomeRepository,
     private readonly messageService: IMessagingPlatform,
   ) {}
 
@@ -38,14 +40,20 @@ export class ExpenseProcessor implements MessageProcessor {
     const amount = parsed.amount;
     if (typeof amount !== "number" || amount <= 0 || amount > MAX_AMOUNT) {
       const response =
-        "Hmm, I couldn't catch the amount. Try something like \"chai 30\".";
-      await this.messageService.sendMessage({ to: platformUserId, body: response });
+        'Hmm, I couldn\'t catch the amount. Try something like "chai 30".';
+      await this.messageService.sendMessage({
+        to: platformUserId,
+        body: response,
+      });
       return { response, parsed };
     }
 
     // Resolve category; a known category's bucket is authoritative.
     const matched = parsed.category
-      ? await this.categoryRepository.findByNameForUser(user.id, parsed.category)
+      ? await this.categoryRepository.findByNameForUser(
+          user.id,
+          parsed.category,
+        )
       : null;
     const bucket = matched?.bucket ?? parsed.bucket;
 
@@ -59,6 +67,7 @@ export class ExpenseProcessor implements MessageProcessor {
         expenseRepository: this.expenseRepository,
         categoryRepository: this.categoryRepository,
         budgetConfigRepository: this.budgetConfigRepository,
+        incomeRepository: this.incomeRepository,
         messageService: this.messageService,
       },
       {

--- a/src/application/use-cases/processors/FallbackProcessor.ts
+++ b/src/application/use-cases/processors/FallbackProcessor.ts
@@ -4,10 +4,9 @@ import {
   ProcessOutput,
 } from "./MessageProcessor";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
-import { formatMoney } from "../budgetMath";
 
-// Catch-all for intents not yet built in this phase (INCOME/STATUS/UNDO) and for
-// UNKNOWN/social messages. Always last in the pipeline.
+// Catch-all for UNKNOWN / social messages (EXPENSE, INCOME, STATUS, UNDO all
+// have their own processors). Always last in the pipeline.
 export class FallbackProcessor implements MessageProcessor {
   constructor(private readonly messageService: IMessagingPlatform) {}
 
@@ -16,30 +15,17 @@ export class FallbackProcessor implements MessageProcessor {
   }
 
   async process(context: ProcessContext): Promise<ProcessOutput> {
-    const parsed = context.parsed ?? { intent: "UNKNOWN" as const, confidence: 0 };
-    const body = this.replyFor(parsed.intent, parsed.amount, parsed.conversational_response);
+    const parsed = context.parsed ?? {
+      intent: "UNKNOWN" as const,
+      confidence: 0,
+    };
+    const body =
+      parsed.conversational_response ??
+      'I didn\'t catch that. Try logging a spend like "chai 30" or "auto 80 office".';
     await this.messageService.sendMessage({
       to: context.platformUserId,
       body,
     });
     return { response: body, parsed };
-  }
-
-  private replyFor(
-    intent: string,
-    amount?: number,
-    conversational?: string,
-  ): string {
-    switch (intent) {
-      case "INCOME":
-        return amount && amount > 0
-          ? `Noted — income of ${formatMoney(amount)}. (Full income tracking is coming soon.)`
-          : "Got it. (Full income tracking is coming soon.)";
-      default:
-        return (
-          conversational ??
-          'I didn\'t catch that. Try logging a spend like "chai 30" or "auto 80 office".'
-        );
-    }
   }
 }

--- a/src/application/use-cases/processors/IncomeProcessor.spec.ts
+++ b/src/application/use-cases/processors/IncomeProcessor.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { IncomeProcessor } from "./IncomeProcessor";
+
+const user = { id: "u1", telegramId: "123", monthlyIncome: 50000 };
+
+describe("IncomeProcessor", () => {
+  let incomeRepository: any;
+  let budgetConfigRepository: any;
+  let messageService: any;
+  let processor: IncomeProcessor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    incomeRepository = {
+      create: vi.fn().mockResolvedValue({ id: "inc1" }),
+      // After creating, this month's income totals 55,000 (50k salary + 5k freelance).
+      sumForMonth: vi.fn().mockResolvedValue(55000),
+    };
+    budgetConfigRepository = {
+      findByUserId: vi
+        .fn()
+        .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
+    };
+    messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    processor = new IncomeProcessor(
+      incomeRepository,
+      budgetConfigRepository,
+      messageService,
+    );
+  });
+
+  it("handles the INCOME intent only", () => {
+    expect(
+      processor.canHandle({
+        parsed: { intent: "INCOME", confidence: 0.9 },
+      } as any),
+    ).toBe(true);
+    expect(
+      processor.canHandle({
+        parsed: { intent: "EXPENSE", confidence: 0.9 },
+      } as any),
+    ).toBe(false);
+  });
+
+  it("records income and replies with the refreshed effective budget", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "got freelance 5000",
+      parsed: {
+        intent: "INCOME",
+        amount: 5000,
+        note: "freelance",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(incomeRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "u1",
+        amount: 5000,
+        source: "freelance",
+      }),
+    );
+    const body = messageService.sendMessage.mock.calls[0][0].body;
+    expect(body).toContain("Income ₹5,000");
+    expect(body).toContain("This month: ₹55,000");
+    expect(body).toContain("Needs ₹27,500"); // 55000 * 50%
+    expect(body).toContain("Wants ₹16,500"); // 55000 * 30%
+    expect(body).toContain("Savings ₹11,000"); // 55000 * 20%
+  });
+
+  it("asks again when the amount is missing", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "got paid",
+      parsed: { intent: "INCOME", confidence: 0.4 },
+    } as any);
+
+    expect(incomeRepository.create).not.toHaveBeenCalled();
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "couldn't catch the income amount",
+    );
+  });
+});

--- a/src/application/use-cases/processors/IncomeProcessor.ts
+++ b/src/application/use-cases/processors/IncomeProcessor.ts
@@ -1,0 +1,82 @@
+import {
+  MessageProcessor,
+  ProcessContext,
+  ProcessOutput,
+} from "./MessageProcessor";
+import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
+import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
+import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
+import {
+  BUCKET_META,
+  bucketBudget,
+  currentMonthRange,
+  effectiveMonthlyIncome,
+  formatMoney,
+  sanitizeMd,
+} from "../budgetMath";
+
+const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
+const MAX_AMOUNT = 1_000_000_000;
+
+// Records an income event (salary, freelance, bonus) and replies with this
+// month's effective income and the refreshed 50/30/20 bucket budgets. The
+// budget grows as income lands (effectiveMonthlyIncome = max(expected, actual)).
+export class IncomeProcessor implements MessageProcessor {
+  constructor(
+    private readonly incomeRepository: IIncomeRepository,
+    private readonly budgetConfigRepository: IBudgetConfigRepository,
+    private readonly messageService: IMessagingPlatform,
+  ) {}
+
+  canHandle(context: ProcessContext): boolean {
+    return context.parsed?.intent === "INCOME";
+  }
+
+  async process(context: ProcessContext): Promise<ProcessOutput> {
+    const parsed = context.parsed!;
+    const { user, platformUserId, textMessage } = context;
+
+    const amount = parsed.amount;
+    if (typeof amount !== "number" || amount <= 0 || amount > MAX_AMOUNT) {
+      const response =
+        'Hmm, I couldn\'t catch the income amount. Try something like "got salary 50000".';
+      await this.messageService.sendMessage({
+        to: platformUserId,
+        body: response,
+      });
+      return { response, parsed };
+    }
+
+    await this.incomeRepository.create({
+      userId: user.id,
+      amount,
+      rawText: textMessage,
+      confidence: parsed.confidence,
+      source: parsed.note,
+      note: parsed.note,
+    });
+
+    // Refresh the month's effective income + budgets (sum already includes the new income).
+    const { start, end } = currentMonthRange();
+    const monthIncome = await this.incomeRepository.sumForMonth(
+      user.id,
+      start,
+      end,
+    );
+    const config =
+      (await this.budgetConfigRepository.findByUserId(user.id)) ??
+      DEFAULT_SPLIT;
+    const expected = Number(user.monthlyIncome ?? 0);
+    const effective = effectiveMonthlyIncome(expected, monthIncome);
+
+    const label = parsed.note ? ` (${sanitizeMd(parsed.note)})` : "";
+    const response = `✅ Income ${formatMoney(amount)}${label}
+This month: ${formatMoney(effective)} → ${BUCKET_META.NEEDS.emoji} Needs ${formatMoney(bucketBudget(effective, config, "NEEDS"))} · ${BUCKET_META.WANTS.emoji} Wants ${formatMoney(bucketBudget(effective, config, "WANTS"))} · ${BUCKET_META.SAVINGS.emoji} Savings ${formatMoney(bucketBudget(effective, config, "SAVINGS"))}`;
+
+    await this.messageService.sendMessage({
+      to: platformUserId,
+      body: response,
+    });
+    return { response, parsed };
+  }
+}

--- a/src/application/use-cases/processors/ReportProcessor.spec.ts
+++ b/src/application/use-cases/processors/ReportProcessor.spec.ts
@@ -32,18 +32,26 @@ describe("ReportProcessor", () => {
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    const incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
     processor = new ReportProcessor(
       expenseRepository,
       budgetConfigRepository,
+      incomeRepository as any,
       messageService,
     );
   });
 
   it("matches 'report' and '/report' only", () => {
     const base = { user, platformUserId: "123" };
-    expect(processor.canHandle({ ...base, textMessage: "report" } as any)).toBe(true);
-    expect(processor.canHandle({ ...base, textMessage: "/report" } as any)).toBe(true);
-    expect(processor.canHandle({ ...base, textMessage: "status" } as any)).toBe(false);
+    expect(processor.canHandle({ ...base, textMessage: "report" } as any)).toBe(
+      true,
+    );
+    expect(
+      processor.canHandle({ ...base, textMessage: "/report" } as any),
+    ).toBe(true);
+    expect(processor.canHandle({ ...base, textMessage: "status" } as any)).toBe(
+      false,
+    );
   });
 
   it("renders income, per-bucket deltas, savings goal, and biggest leaks", async () => {

--- a/src/application/use-cases/processors/ReportProcessor.ts
+++ b/src/application/use-cases/processors/ReportProcessor.ts
@@ -6,11 +6,13 @@ import {
 } from "./MessageProcessor";
 import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
+import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
   currentMonthRange,
+  effectiveMonthlyIncome,
   formatMoney,
   sanitizeMd,
 } from "../budgetMath";
@@ -27,6 +29,7 @@ export class ReportProcessor implements MessageProcessor {
   constructor(
     private readonly expenseRepository: IExpenseRepository,
     private readonly budgetConfigRepository: IBudgetConfigRepository,
+    private readonly incomeRepository: IIncomeRepository,
     private readonly messageService: IMessagingPlatform,
   ) {}
 
@@ -40,11 +43,14 @@ export class ReportProcessor implements MessageProcessor {
 
   async process(context: ProcessContext): Promise<ProcessOutput> {
     const { user, platformUserId } = context;
-    const monthlyIncome = Number(user.monthlyIncome ?? 0);
     const config =
       (await this.budgetConfigRepository.findByUserId(user.id)) ??
       DEFAULT_SPLIT;
     const { start, end } = currentMonthRange();
+    const monthlyIncome = effectiveMonthlyIncome(
+      Number(user.monthlyIncome ?? 0),
+      await this.incomeRepository.sumForMonth(user.id, start, end),
+    );
     const monthName = new Intl.DateTimeFormat("en-IN", {
       month: "long",
     }).format(start);

--- a/src/application/use-cases/processors/StatusProcessor.spec.ts
+++ b/src/application/use-cases/processors/StatusProcessor.spec.ts
@@ -28,9 +28,11 @@ describe("StatusProcessor", () => {
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    const incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
     processor = new StatusProcessor(
       expenseRepository,
       budgetConfigRepository,
+      incomeRepository as any,
       messageService,
     );
   });
@@ -86,8 +88,9 @@ describe("StatusProcessor", () => {
   });
 
   it("flags an over-budget bucket with 🔴", async () => {
-    expenseRepository.sumByBucketForMonth = vi.fn((_u: string, bucket: string) =>
-      Promise.resolve(bucket === "WANTS" ? 18000 : 0),
+    expenseRepository.sumByBucketForMonth = vi.fn(
+      (_u: string, bucket: string) =>
+        Promise.resolve(bucket === "WANTS" ? 18000 : 0),
     );
     await processor.process({
       user,

--- a/src/application/use-cases/processors/StatusProcessor.ts
+++ b/src/application/use-cases/processors/StatusProcessor.ts
@@ -6,11 +6,13 @@ import {
 } from "./MessageProcessor";
 import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
+import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
   currentMonthRange,
+  effectiveMonthlyIncome,
   formatMoney,
   monthDayInfo,
   pctSpent,
@@ -27,6 +29,7 @@ export class StatusProcessor implements MessageProcessor {
   constructor(
     private readonly expenseRepository: IExpenseRepository,
     private readonly budgetConfigRepository: IBudgetConfigRepository,
+    private readonly incomeRepository: IIncomeRepository,
     private readonly messageService: IMessagingPlatform,
   ) {}
 
@@ -41,12 +44,15 @@ export class StatusProcessor implements MessageProcessor {
 
   async process(context: ProcessContext): Promise<ProcessOutput> {
     const { user, platformUserId } = context;
-    const monthlyIncome = Number(user.monthlyIncome ?? 0);
     const config =
       (await this.budgetConfigRepository.findByUserId(user.id)) ??
       DEFAULT_SPLIT;
     const { start, end } = currentMonthRange();
     const { day, daysInMonth, remainingDays } = monthDayInfo();
+    const monthlyIncome = effectiveMonthlyIncome(
+      Number(user.monthlyIncome ?? 0),
+      await this.incomeRepository.sumForMonth(user.id, start, end),
+    );
 
     const lines: string[] = [];
     const dailyParts: string[] = [];

--- a/src/application/use-cases/processors/UndoProcessor.spec.ts
+++ b/src/application/use-cases/processors/UndoProcessor.spec.ts
@@ -26,7 +26,9 @@ describe("UndoProcessor", () => {
       sumByBucketForMonth: vi.fn().mockResolvedValue(0), // after delete
     };
     categoryRepository = {
-      findById: vi.fn().mockResolvedValue({ id: "c1", name: "Food", bucket: "WANTS" }),
+      findById: vi
+        .fn()
+        .mockResolvedValue({ id: "c1", name: "Food", bucket: "WANTS" }),
     };
     budgetConfigRepository = {
       findByUserId: vi
@@ -34,18 +36,24 @@ describe("UndoProcessor", () => {
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    const incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
     processor = new UndoProcessor(
       expenseRepository,
       categoryRepository,
       budgetConfigRepository,
+      incomeRepository as any,
       messageService,
     );
   });
 
   it("matches 'undo'/'/undo' and the UNDO intent", () => {
     const base = { user, platformUserId: "123" };
-    expect(processor.canHandle({ ...base, textMessage: "undo" } as any)).toBe(true);
-    expect(processor.canHandle({ ...base, textMessage: "/undo" } as any)).toBe(true);
+    expect(processor.canHandle({ ...base, textMessage: "undo" } as any)).toBe(
+      true,
+    );
+    expect(processor.canHandle({ ...base, textMessage: "/undo" } as any)).toBe(
+      true,
+    );
     expect(
       processor.canHandle({
         ...base,
@@ -53,9 +61,9 @@ describe("UndoProcessor", () => {
         parsed: { intent: "UNDO", confidence: 0.9 },
       } as any),
     ).toBe(true);
-    expect(processor.canHandle({ ...base, textMessage: "lunch 30" } as any)).toBe(
-      false,
-    );
+    expect(
+      processor.canHandle({ ...base, textMessage: "lunch 30" } as any),
+    ).toBe(false);
   });
 
   it("removes the last expense and shows restored budget", async () => {

--- a/src/application/use-cases/processors/UndoProcessor.ts
+++ b/src/application/use-cases/processors/UndoProcessor.ts
@@ -6,11 +6,13 @@ import {
 import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
 import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
+import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
   currentMonthRange,
+  effectiveMonthlyIncome,
   formatMoney,
   sanitizeMd,
 } from "../budgetMath";
@@ -25,6 +27,7 @@ export class UndoProcessor implements MessageProcessor {
     private readonly expenseRepository: IExpenseRepository,
     private readonly categoryRepository: ICategoryRepository,
     private readonly budgetConfigRepository: IBudgetConfigRepository,
+    private readonly incomeRepository: IIncomeRepository,
     private readonly messageService: IMessagingPlatform,
   ) {}
 
@@ -67,7 +70,11 @@ export class UndoProcessor implements MessageProcessor {
     const config =
       (await this.budgetConfigRepository.findByUserId(user.id)) ??
       DEFAULT_SPLIT;
-    const budget = bucketBudget(Number(user.monthlyIncome ?? 0), config, target.bucket);
+    const income = effectiveMonthlyIncome(
+      Number(user.monthlyIncome ?? 0),
+      await this.incomeRepository.sumForMonth(user.id, start, end),
+    );
+    const budget = bucketBudget(income, config, target.bucket);
     const remaining = budget - spent;
 
     const label = await this.describe(target.categoryId, target.note);

--- a/src/data/repositories/PrismaIncomeRepository.ts
+++ b/src/data/repositories/PrismaIncomeRepository.ts
@@ -1,0 +1,52 @@
+import { Income, PrismaClient } from "@prisma/client";
+import {
+  CreateIncomeDTO,
+  IIncomeRepository,
+} from "../../domain/repositories/IIncomeRepository";
+
+export class PrismaIncomeRepository implements IIncomeRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(data: CreateIncomeDTO): Promise<Income> {
+    return this.prisma.income.create({
+      data: {
+        userId: data.userId,
+        amount: data.amount,
+        rawText: data.rawText,
+        confidence: data.confidence,
+        source: data.source ?? null,
+        note: data.note ?? null,
+      },
+    });
+  }
+
+  async sumForMonth(
+    userId: string,
+    monthStart: Date,
+    monthEnd: Date,
+  ): Promise<number> {
+    const result = await this.prisma.income.aggregate({
+      _sum: { amount: true },
+      where: {
+        userId,
+        isDeleted: false,
+        date: { gte: monthStart, lt: monthEnd },
+      },
+    });
+    return Number(result._sum.amount ?? 0);
+  }
+
+  async findLastByUserId(userId: string): Promise<Income | null> {
+    return this.prisma.income.findFirst({
+      where: { userId, isDeleted: false },
+      orderBy: { date: "desc" },
+    });
+  }
+
+  async softDelete(id: string): Promise<void> {
+    await this.prisma.income.update({
+      where: { id },
+      data: { isDeleted: true, deletedAt: new Date() },
+    });
+  }
+}

--- a/src/data/repositories/mergeTelegramUser.ts
+++ b/src/data/repositories/mergeTelegramUser.ts
@@ -21,6 +21,10 @@ export async function mergeTelegramUser(
     where: { userId: botUserId },
     data: { userId: webUserId },
   });
+  await tx.income.updateMany({
+    where: { userId: botUserId },
+    data: { userId: webUserId },
+  });
   await tx.parseLog.updateMany({
     where: { userId: botUserId },
     data: { userId: webUserId },

--- a/src/domain/repositories/IIncomeRepository.ts
+++ b/src/domain/repositories/IIncomeRepository.ts
@@ -1,0 +1,22 @@
+import { Income } from "@prisma/client";
+
+export interface CreateIncomeDTO {
+  userId: string;
+  amount: number;
+  rawText: string;
+  confidence: number;
+  source?: string | undefined;
+  note?: string | undefined;
+}
+
+export interface IIncomeRepository {
+  create(data: CreateIncomeDTO): Promise<Income>;
+  // Sum of non-deleted income within [monthStart, monthEnd).
+  sumForMonth(
+    userId: string,
+    monthStart: Date,
+    monthEnd: Date,
+  ): Promise<number>;
+  findLastByUserId(userId: string): Promise<Income | null>;
+  softDelete(id: string): Promise<void>;
+}

--- a/src/presentation/controllers/TelegramWebhookController.ts
+++ b/src/presentation/controllers/TelegramWebhookController.ts
@@ -14,6 +14,7 @@ import { PrismaExpenseRepository } from "../../data/repositories/PrismaExpenseRe
 import { PrismaCategoryRepository } from "../../data/repositories/PrismaCategoryRepository";
 import { PrismaBudgetConfigRepository } from "../../data/repositories/PrismaBudgetConfigRepository";
 import { PrismaParseLogRepository } from "../../data/repositories/PrismaParseLogRepository";
+import { PrismaIncomeRepository } from "../../data/repositories/PrismaIncomeRepository";
 import { PrismaConversationRepository } from "../../data/repositories/PrismaConversationRepository";
 import { PrismaNudgeRepository } from "../../data/repositories/PrismaNudgeRepository";
 import { SendBudgetNudgesUseCase } from "../../application/use-cases/SendBudgetNudges";
@@ -54,6 +55,7 @@ const expenseRepository = new PrismaExpenseRepository(prisma);
 const categoryRepository = new PrismaCategoryRepository(prisma);
 const budgetConfigRepository = new PrismaBudgetConfigRepository(prisma);
 const parseLogRepository = new PrismaParseLogRepository(prisma);
+const incomeRepository = new PrismaIncomeRepository(prisma);
 const nudgeRepository = new PrismaNudgeRepository(prisma);
 const processedMessageRepository = new PrismaProcessedMessageRepository(prisma);
 const conversationRepository = new PrismaConversationRepository();
@@ -65,6 +67,7 @@ const processIncomingMessage = new ProcessIncomingMessageUseCase(
   categoryRepository,
   budgetConfigRepository,
   parseLogRepository,
+  incomeRepository,
   conversationRepository,
   messageService,
 );
@@ -90,18 +93,24 @@ export class TelegramWebhookController {
   async registerBotCommands(): Promise<void> {
     if (!this.botToken) return;
     try {
-      await fetch(`https://api.telegram.org/bot${this.botToken}/setMyCommands`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          commands: [
-            { command: "start",  description: "Set up your budget" },
-            { command: "status", description: "Your budget health this month" },
-            { command: "report", description: "This month's summary" },
-            { command: "help",   description: "How to use the bot" },
-          ],
-        }),
-      });
+      await fetch(
+        `https://api.telegram.org/bot${this.botToken}/setMyCommands`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            commands: [
+              { command: "start", description: "Set up your budget" },
+              {
+                command: "status",
+                description: "Your budget health this month",
+              },
+              { command: "report", description: "This month's summary" },
+              { command: "help", description: "How to use the bot" },
+            ],
+          }),
+        },
+      );
       console.log("Telegram bot commands registered");
     } catch (err) {
       console.error("Failed to register bot commands:", err);
@@ -114,13 +123,17 @@ export class TelegramWebhookController {
       if (this.webhookSecret) {
         const incoming = req.headers["x-telegram-bot-api-secret-token"];
         if (typeof incoming !== "string") {
-          res.status(403).json({ success: false, message: "Forbidden", data: null });
+          res
+            .status(403)
+            .json({ success: false, message: "Forbidden", data: null });
           return;
         }
         const a = Buffer.from(incoming);
         const b = Buffer.from(this.webhookSecret);
         if (a.length !== b.length || !timingSafeEqual(a, b)) {
-          res.status(403).json({ success: false, message: "Forbidden", data: null });
+          res
+            .status(403)
+            .json({ success: false, message: "Forbidden", data: null });
           return;
         }
       }
@@ -243,5 +256,6 @@ export const sendBudgetNudges = new SendBudgetNudgesUseCase(
   expenseRepository,
   budgetConfigRepository,
   nudgeRepository,
+  incomeRepository,
   messageService,
 );

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -29,6 +29,8 @@ async function OverviewSection({
 }) {
     const {
         monthlyIncome,
+        expectedIncome,
+        incomeThisMonth,
         currency,
         buckets,
         totalSpent,
@@ -51,11 +53,18 @@ async function OverviewSection({
             {/* Headline stats */}
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                 <Stat>
-                    <StatLabel>Monthly Income</StatLabel>
+                    <StatLabel>Budget Income</StatLabel>
                     <StatValue>
                         <AnimatedNumber value={monthlyIncome} format={currencyFormat} />
                     </StatValue>
-                    <StatDescription>Your budgeting baseline</StatDescription>
+                    <StatDescription>
+                        {incomeThisMonth > 0
+                            ? `${formatMoney(incomeThisMonth, currency)} logged this month` +
+                              (monthlyIncome > incomeThisMonth
+                                  ? ` · ${formatMoney(expectedIncome, currency)} expected`
+                                  : "")
+                            : "Your expected monthly baseline"}
+                    </StatDescription>
                     <StatIndicator color="success">
                         <Wallet className="h-4 w-4" />
                     </StatIndicator>

--- a/web/src/lib/actions/budget.ts
+++ b/web/src/lib/actions/budget.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_SPLIT,
   bucketBudget,
   currentMonthRange,
+  effectiveMonthlyIncome,
   pctSpent,
   type BudgetSplit,
 } from "@/lib/budget";
@@ -29,36 +30,44 @@ export async function getBudgetOverview() {
   const userId = session.user.id;
   const { start, end } = currentMonthRange();
 
-  const [user, config, grouped, recent, categoryGroups] = await Promise.all([
-    prisma.user.findUnique({
-      where: { id: userId },
-      select: {
-        monthlyIncome: true,
-        currency: true,
-        locale: true,
-        hasOnboarded: true,
-      },
-    }),
-    prisma.budgetConfig.findUnique({ where: { userId } }),
-    prisma.expense.groupBy({
-      by: ["bucket"],
-      _sum: { amount: true },
-      where: { userId, isDeleted: false, date: { gte: start, lt: end } },
-    }),
-    prisma.expense.findMany({
-      where: { userId, isDeleted: false, date: { gte: start, lt: end } },
-      include: { category: { select: { name: true } } },
-      orderBy: { date: "desc" },
-      take: 8,
-    }),
-    prisma.expense.groupBy({
-      by: ["categoryId"],
-      _sum: { amount: true },
-      where: { userId, isDeleted: false, date: { gte: start, lt: end } },
-    }),
-  ]);
+  const [user, config, grouped, recent, categoryGroups, incomeAgg] =
+    await Promise.all([
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          monthlyIncome: true,
+          currency: true,
+          locale: true,
+          hasOnboarded: true,
+        },
+      }),
+      prisma.budgetConfig.findUnique({ where: { userId } }),
+      prisma.expense.groupBy({
+        by: ["bucket"],
+        _sum: { amount: true },
+        where: { userId, isDeleted: false, date: { gte: start, lt: end } },
+      }),
+      prisma.expense.findMany({
+        where: { userId, isDeleted: false, date: { gte: start, lt: end } },
+        include: { category: { select: { name: true } } },
+        orderBy: { date: "desc" },
+        take: 8,
+      }),
+      prisma.expense.groupBy({
+        by: ["categoryId"],
+        _sum: { amount: true },
+        where: { userId, isDeleted: false, date: { gte: start, lt: end } },
+      }),
+      prisma.income.aggregate({
+        _sum: { amount: true },
+        where: { userId, isDeleted: false, date: { gte: start, lt: end } },
+      }),
+    ]);
 
-  const monthlyIncome = Number(user?.monthlyIncome ?? 0);
+  const expectedIncome = Number(user?.monthlyIncome ?? 0);
+  const incomeThisMonth = Number(incomeAgg._sum.amount ?? 0);
+  // Budgets track actual income this month, floored at the expected salary.
+  const monthlyIncome = effectiveMonthlyIncome(expectedIncome, incomeThisMonth);
   const currency = user?.currency ?? "INR";
   const locale = user?.locale ?? "en-IN";
   const split: BudgetSplit = config
@@ -121,6 +130,8 @@ export async function getBudgetOverview() {
 
   return {
     monthlyIncome,
+    expectedIncome,
+    incomeThisMonth,
     currency,
     locale,
     split,

--- a/web/src/lib/budget.ts
+++ b/web/src/lib/budget.ts
@@ -50,6 +50,15 @@ export function bucketBudget(
   return (monthlyIncome * bucketPct(split, bucket)) / 100;
 }
 
+// The income to budget against this month: expected salary is a floor, actual
+// income logged this month expands it above that floor. Matches the backend.
+export function effectiveMonthlyIncome(
+  expected: number,
+  incomeThisMonth: number,
+): number {
+  return Math.max(expected, incomeThisMonth);
+}
+
 // Integer percentage of budget spent (0 when budget is 0).
 export function pctSpent(spent: number, budget: number): number {
   if (budget <= 0) return 0;


### PR DESCRIPTION
## What
The bot only knew a static `User.monthlyIncome` and replied "coming soon" to INCOME. Now income events (salary, freelance, bonus) are **recorded**, and the month's 50/30/20 budget **tracks actual income, floored at the expected salary**:

`effectiveMonthlyIncome = max(expected monthlyIncome, sum of income this month)`

- Salaried: budget = salary, and a bonus/freelance expands the month.
- Gig worker: set expected = 0 → budget is purely actual income.
- Log nothing → unchanged (sum 0 → max = expected). Fully backward compatible.

## Changes
- **schema:** `Income` model (+ migration `add_income`); included in `mergeTelegramUser` so account-merge keeps income.
- **`IIncomeRepository` + `PrismaIncomeRepository`** (create / sumForMonth / findLastByUserId / softDelete).
- **`IncomeProcessor`** (post-AI, `intent INCOME`): records income, replies with the refreshed effective budget; removed the INCOME stub from `FallbackProcessor`.
- **`effectiveMonthlyIncome`** helper (backend `budgetMath` + web `lib/budget`), wired into **Status, Report, Undo, expenseFlow, SendBudgetNudges**, and the **web overview** (dashboard shows income-this-month vs expected; bucket cards size to effective income).
- **DI:** income repo threaded through the orchestrator, controller, and nudges.

## Roadmap
`ROADMAP.md` — prioritized product + engineering-workflow plan (impact/effort tagged): parser-accuracy loop, recurring + payday-aware budgeting, savings goals, WhatsApp channel; and on the workflow side: **fix the red `test` CI** (stale env + removed WhatsApp/old-schema specs), lint web in CI, staging/preview deploys, error tracking.

## Verified
- Backend `tsc` build, **50 unit tests** (IncomeProcessor + effectiveMonthlyIncome + income integration + updated existing specs), root lint 0, `cd web && pnpm build` — all green.
- Manual: set income 50k → buckets 25/15/10k; `got freelance 5000` → "This month: ₹55,000" with bigger buckets; status/report/remaining reflect ₹55k; before any income logged, budgets use the expected 50k.

Note: the pre-existing red Playwright `test` CI check is unrelated (tracked as Track B P0 in ROADMAP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)