### PR TITLE
feat: recurring auto-posting + payday-aware budgeting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,9 +22,10 @@ Ordered roughly by priority within each track.
   transcription confidence so a bad transcript asks to confirm. *Impact: med · Effort: low.*
 
 ### P1 — make the budget match real life
-- **Recurring income & expenses + payday-aware budgeting.** Rent/EMIs/salary that repeat; roll the budget
-  window to the user's `payday` instead of the calendar month. *Impact: high · Effort: med.* (Income-event
-  tracking just shipped is the foundation.)
+- ✅ **Recurring income & expenses + payday-aware budgeting (shipped).** Recurring rules auto-post + notify
+  each month (bot RECURRING intent + web `/dashboard/recurring`); the budget window now follows the user's
+  `payday` (payday→payday cycle; payday=1 = calendar month). Variable-amount bills (reminder-to-confirm) are
+  the remaining fast-follow.
 - **Savings goals.** "Save ₹2L for a trip by Dec" → progress against the SAVINGS bucket. *Impact: high · Effort: med.*
 - **Multi-currency / locale.** `User.currency`/`locale` exist; honor them everywhere (some copy still hardcodes ₹). *Impact: med · Effort: low.*
 - **Income undo + web Income page.** Extend undo to the most recent of expense/income; list income in the

--- a/prisma/migrations/20260612054822_add_recurring_rule/migration.sql
+++ b/prisma/migrations/20260612054822_add_recurring_rule/migration.sql
@@ -1,0 +1,29 @@
+-- CreateEnum
+CREATE TYPE "RecurringKind" AS ENUM ('INCOME', 'EXPENSE');
+
+-- CreateTable
+CREATE TABLE "RecurringRule" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "kind" "RecurringKind" NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "dayOfMonth" INTEGER NOT NULL,
+    "bucket" "Bucket",
+    "categoryId" TEXT,
+    "note" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "lastPostedKey" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecurringRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "RecurringRule_userId_isActive_idx" ON "RecurringRule"("userId", "isActive");
+
+-- AddForeignKey
+ALTER TABLE "RecurringRule" ADD CONSTRAINT "RecurringRule_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RecurringRule" ADD CONSTRAINT "RecurringRule_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,11 @@ enum NudgeKind {
   OVER
 }
 
+enum RecurringKind {
+  INCOME
+  EXPENSE
+}
+
 // ─── Users ───────────────────────────────────────────────────────────────────
 
 model User {
@@ -56,12 +61,13 @@ model User {
   sessions      Session[]
 
   // Core relations
-  expenses     Expense[]
-  incomes      Income[]
-  budgetConfig BudgetConfig?
-  categories   Category[]
-  logs         ParseLog[]
-  budgetNudges BudgetNudge[]
+  expenses       Expense[]
+  incomes        Income[]
+  budgetConfig   BudgetConfig?
+  categories     Category[]
+  logs           ParseLog[]
+  budgetNudges   BudgetNudge[]
+  recurringRules RecurringRule[]
 
   conversationMessages ConversationMessage[]
   telegramLinkToken    TelegramLinkToken?
@@ -103,11 +109,34 @@ model Category {
   userId String?
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  expenses Expense[]
+  expenses       Expense[]
+  recurringRules RecurringRule[]
 
   createdAt DateTime @default(now())
 
   @@unique([userId, name])
+}
+
+// A repeating income/expense the scheduler auto-posts each month on dayOfMonth.
+model RecurringRule {
+  id         String        @id @default(cuid())
+  userId     String
+  user       User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  kind       RecurringKind
+  amount     Decimal       @db.Decimal(12, 2)
+  dayOfMonth Int // 1–28
+  bucket     Bucket? // for EXPENSE
+  categoryId String?
+  category   Category?     @relation(fields: [categoryId], references: [id])
+  note       String?
+  isActive   Boolean       @default(true)
+  // "YYYY-MM" of the last auto-post — idempotency for the daily job.
+  lastPostedKey String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId, isActive])
 }
 
 model Expense {

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import { telegramRoutes } from "./presentation/routes/telegramRoutes";
 import {
   telegramWebhookController,
   sendBudgetNudges,
+  postRecurringCharges,
 } from "./presentation/controllers/TelegramWebhookController";
 import { startScheduler } from "./infrastructure/scheduler";
 
@@ -43,7 +44,7 @@ const port = env.PORT;
 if (process.env.NODE_ENV !== "test") {
   const server = app.listen(port, () => {
     process.stdout.write(`🚀 Blipko budget bot listening on port ${port}\n`);
-    startScheduler(sendBudgetNudges);
+    startScheduler(sendBudgetNudges, postRecurringCharges);
     telegramWebhookController.registerBotCommands().catch(console.error);
   });
 

--- a/src/application/use-cases/PostRecurringCharges.spec.ts
+++ b/src/application/use-cases/PostRecurringCharges.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PostRecurringChargesUseCase } from "./PostRecurringCharges";
+
+describe("PostRecurringCharges", () => {
+  let recurringRuleRepository: any;
+  let expenseRepository: any;
+  let incomeRepository: any;
+  let userRepository: any;
+  let categoryRepository: any;
+  let messageService: any;
+  let useCase: PostRecurringChargesUseCase;
+
+  const expenseRule = {
+    id: "rr1",
+    userId: "u1",
+    kind: "EXPENSE",
+    amount: 8000,
+    dayOfMonth: 1,
+    bucket: "NEEDS",
+    categoryId: "c1",
+    note: "rent",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recurringRuleRepository = {
+      findActiveUnpostedForMonth: vi.fn().mockResolvedValue([expenseRule]),
+      markPosted: vi.fn().mockResolvedValue(undefined),
+    };
+    expenseRepository = { create: vi.fn().mockResolvedValue({ id: "e1" }) };
+    incomeRepository = { create: vi.fn().mockResolvedValue({ id: "i1" }) };
+    userRepository = {
+      findById: vi.fn().mockResolvedValue({ id: "u1", telegramId: "123" }),
+    };
+    categoryRepository = {
+      findById: vi.fn().mockResolvedValue({ id: "c1", name: "Rent" }),
+    };
+    messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    useCase = new PostRecurringChargesUseCase(
+      recurringRuleRepository,
+      expenseRepository,
+      incomeRepository,
+      userRepository,
+      categoryRepository,
+      messageService,
+    );
+  });
+
+  it("posts a due expense, marks it, and notifies", async () => {
+    const { posted } = await useCase.execute(new Date(2026, 5, 15)); // day 15 >= dueDay 1
+
+    expect(posted).toBe(1);
+    expect(expenseRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u1", amount: 8000, bucket: "NEEDS" }),
+    );
+    expect(recurringRuleRepository.markPosted).toHaveBeenCalledWith(
+      "rr1",
+      "2026-06",
+    );
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "Auto-logged",
+    );
+  });
+
+  it("skips a rule before its due day", async () => {
+    recurringRuleRepository.findActiveUnpostedForMonth.mockResolvedValue([
+      { ...expenseRule, dayOfMonth: 28 },
+    ]);
+
+    const { posted } = await useCase.execute(new Date(2026, 5, 15)); // day 15 < 28
+
+    expect(posted).toBe(0);
+    expect(expenseRepository.create).not.toHaveBeenCalled();
+    expect(recurringRuleRepository.markPosted).not.toHaveBeenCalled();
+  });
+
+  it("posts a due income via the income repository", async () => {
+    recurringRuleRepository.findActiveUnpostedForMonth.mockResolvedValue([
+      {
+        id: "rr2",
+        userId: "u1",
+        kind: "INCOME",
+        amount: 50000,
+        dayOfMonth: 25,
+        note: "salary",
+      },
+    ]);
+
+    const { posted } = await useCase.execute(new Date(2026, 5, 26)); // day 26 >= 25
+
+    expect(posted).toBe(1);
+    expect(incomeRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u1", amount: 50000 }),
+    );
+    expect(expenseRepository.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/application/use-cases/PostRecurringCharges.ts
+++ b/src/application/use-cases/PostRecurringCharges.ts
@@ -1,0 +1,97 @@
+import { RecurringRule } from "@prisma/client";
+import { IRecurringRuleRepository } from "../../domain/repositories/IRecurringRuleRepository";
+import { IExpenseRepository } from "../../domain/repositories/IExpenseRepository";
+import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
+import { IUserRepository } from "../../domain/repositories/IUserRepository";
+import { ICategoryRepository } from "../../domain/repositories/ICategoryRepository";
+import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
+import { BUCKET_META, formatMoney, sanitizeMd } from "./budgetMath";
+
+export interface PostRecurringChargesResult {
+  posted: number;
+}
+
+// Daily job: auto-posts each active recurring rule once per calendar month, on
+// or after its dayOfMonth, and DMs the user. Idempotent via lastPostedKey
+// ("YYYY-MM"); posting is monthly-on-dayOfMonth (independent of the payday cycle).
+export class PostRecurringChargesUseCase {
+  constructor(
+    private readonly recurringRuleRepository: IRecurringRuleRepository,
+    private readonly expenseRepository: IExpenseRepository,
+    private readonly incomeRepository: IIncomeRepository,
+    private readonly userRepository: IUserRepository,
+    private readonly categoryRepository: ICategoryRepository,
+    private readonly messageService: IMessagingPlatform,
+  ) {}
+
+  async execute(now: Date = new Date()): Promise<PostRecurringChargesResult> {
+    const monthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+    const daysInMonth = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+    ).getDate();
+    const today = now.getDate();
+
+    const rules =
+      await this.recurringRuleRepository.findActiveUnpostedForMonth(monthKey);
+
+    let posted = 0;
+    for (const rule of rules) {
+      const dueDay = Math.min(rule.dayOfMonth, daysInMonth);
+      if (today < dueDay) continue;
+      try {
+        await this.post(rule, monthKey);
+        posted++;
+      } catch (err) {
+        // One rule's failure must not abort the batch.
+        console.error(`Recurring post failed for rule ${rule.id}:`, err);
+      }
+    }
+    return { posted };
+  }
+
+  private async post(rule: RecurringRule, monthKey: string): Promise<void> {
+    const amount = Number(rule.amount);
+    const rawText = `[recurring] ${rule.note ?? rule.kind.toLowerCase()}`;
+
+    let body: string;
+    if (rule.kind === "INCOME") {
+      await this.incomeRepository.create({
+        userId: rule.userId,
+        amount,
+        rawText,
+        confidence: 1,
+        source: rule.note ?? "recurring",
+        note: rule.note ?? undefined,
+      });
+      const label = rule.note ? ` (${sanitizeMd(rule.note)})` : "";
+      body = `📌 Auto-logged income ${formatMoney(amount)}${label} — reply "undo" to remove.`;
+    } else {
+      const bucket = rule.bucket ?? "NEEDS";
+      await this.expenseRepository.create({
+        userId: rule.userId,
+        amount,
+        bucket,
+        note: rule.note ?? undefined,
+        rawText,
+        confidence: 1,
+        categoryId: rule.categoryId ?? undefined,
+      });
+      const categoryName = rule.categoryId
+        ? ((await this.categoryRepository.findById(rule.categoryId))?.name ??
+          null)
+        : null;
+      const where = categoryName ? ` · ${sanitizeMd(categoryName)}` : "";
+      body = `📌 Auto-logged ${formatMoney(amount)} → ${BUCKET_META[bucket].label}${where}${rule.note ? ` (${sanitizeMd(rule.note)})` : ""} — reply "undo" to remove.`;
+    }
+
+    // Record idempotency before notifying (a duplicate is worse than a missed DM).
+    await this.recurringRuleRepository.markPosted(rule.id, monthKey);
+
+    const user = await this.userRepository.findById(rule.userId);
+    if (user?.telegramId) {
+      await this.messageService.sendMessage({ to: user.telegramId, body });
+    }
+  }
+}

--- a/src/application/use-cases/ProcessIncomingMessage.spec.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.spec.ts
@@ -25,6 +25,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
   let budgetConfigRepository: any;
   let parseLogRepository: any;
   let incomeRepository: any;
+  let recurringRuleRepository: any;
   let conversationRepository: any;
   let aiParser: any;
   let messageService: any;
@@ -74,6 +75,14 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       findLastByUserId: vi.fn().mockResolvedValue(null),
       softDelete: vi.fn().mockResolvedValue(undefined),
     };
+    recurringRuleRepository = {
+      create: vi.fn().mockResolvedValue({ id: "rr1" }),
+      findByUserId: vi.fn().mockResolvedValue([]),
+      findById: vi.fn().mockResolvedValue(null),
+      findActiveUnpostedForMonth: vi.fn().mockResolvedValue([]),
+      markPosted: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
     conversationRepository = {
       getRecent: vi.fn().mockResolvedValue([]),
       append: vi.fn().mockResolvedValue(undefined),
@@ -93,6 +102,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       budgetConfigRepository,
       parseLogRepository,
       incomeRepository,
+      recurringRuleRepository,
       conversationRepository,
       messageService,
     );
@@ -213,7 +223,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
     expect(aiParser.parseText).not.toHaveBeenCalled();
     expect(expenseRepository.create).not.toHaveBeenCalled();
     expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
-      "This month — Day",
+      "This cycle — Day",
     );
   });
 

--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -10,6 +10,7 @@ import { ICategoryRepository } from "../../domain/repositories/ICategoryReposito
 import { IBudgetConfigRepository } from "../../domain/repositories/IBudgetConfigRepository";
 import { IParseLogRepository } from "../../domain/repositories/IParseLogRepository";
 import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
+import { IRecurringRuleRepository } from "../../domain/repositories/IRecurringRuleRepository";
 import { IConversationRepository } from "../../domain/repositories/IConversationRepository";
 import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import { ParsedData, ParsedBucket } from "../../domain/entities/ParsedData";
@@ -24,6 +25,7 @@ import { ReportProcessor } from "./processors/ReportProcessor";
 import { UndoProcessor } from "./processors/UndoProcessor";
 import { ExpenseProcessor } from "./processors/ExpenseProcessor";
 import { IncomeProcessor } from "./processors/IncomeProcessor";
+import { RecurringSetupProcessor } from "./processors/RecurringSetupProcessor";
 import { FallbackProcessor } from "./processors/FallbackProcessor";
 
 export interface ProcessIncomingMessageInput {
@@ -52,6 +54,7 @@ export class ProcessIncomingMessageUseCase {
     private readonly budgetConfigRepository: IBudgetConfigRepository,
     private readonly parseLogRepository: IParseLogRepository,
     private readonly incomeRepository: IIncomeRepository,
+    private readonly recurringRuleRepository: IRecurringRuleRepository,
     private readonly conversationRepository: IConversationRepository,
     private readonly messageService: IMessagingPlatform,
   ) {
@@ -114,6 +117,11 @@ export class ProcessIncomingMessageUseCase {
       new IncomeProcessor(
         incomeRepository,
         budgetConfigRepository,
+        messageService,
+      ),
+      new RecurringSetupProcessor(
+        recurringRuleRepository,
+        categoryRepository,
         messageService,
       ),
       new FallbackProcessor(messageService),

--- a/src/application/use-cases/SendBudgetNudges.ts
+++ b/src/application/use-cases/SendBudgetNudges.ts
@@ -8,11 +8,11 @@ import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
-  currentMonthRange,
+  currentBudgetPeriod,
   effectiveMonthlyIncome,
   formatMoney,
-  monthDayInfo,
-  monthPeriodKey,
+  periodDayInfo,
+  periodKey,
   pctSpent,
 } from "./budgetMath";
 
@@ -40,15 +40,11 @@ export class SendBudgetNudgesUseCase {
 
   async execute(): Promise<SendBudgetNudgesResult> {
     const users = await this.userRepository.findOnboardedWithTelegram();
-    const { start, end } = currentMonthRange();
-    const periodKey = monthPeriodKey();
-    const { day, daysInMonth } = monthDayInfo();
-    const daysLeft = daysInMonth - day;
 
     let sent = 0;
     for (const user of users) {
       try {
-        sent += await this.nudgeUser(user, start, end, periodKey, daysLeft);
+        sent += await this.nudgeUser(user);
       } catch (err) {
         // One user's failure must not abort the batch.
         console.error(`Nudge failed for user ${user.id}:`, err);
@@ -57,14 +53,20 @@ export class SendBudgetNudgesUseCase {
     return { sent };
   }
 
-  private async nudgeUser(
-    user: { id: string; telegramId: string | null; monthlyIncome: unknown },
-    start: Date,
-    end: Date,
-    periodKey: string,
-    daysLeft: number,
-  ): Promise<number> {
+  private async nudgeUser(user: {
+    id: string;
+    telegramId: string | null;
+    monthlyIncome: unknown;
+    payday: number;
+  }): Promise<number> {
     if (!user.telegramId) return 0;
+
+    // Per-user payday cycle.
+    const { start, end } = currentBudgetPeriod(user.payday);
+    const cycleKey = periodKey(user.payday);
+    const { day, daysInPeriod } = periodDayInfo(user.payday);
+    const daysLeft = daysInPeriod - day;
+
     const income = effectiveMonthlyIncome(
       Number(user.monthlyIncome ?? 0),
       await this.incomeRepository.sumForMonth(user.id, start, end),
@@ -93,7 +95,7 @@ export class SendBudgetNudgesUseCase {
           user.id,
           bucket,
           "OVER",
-          periodKey,
+          cycleKey,
         );
         if (isNew) {
           await this.send(
@@ -107,7 +109,7 @@ export class SendBudgetNudgesUseCase {
           user.id,
           bucket,
           "WARN_80",
-          periodKey,
+          cycleKey,
         );
         if (isNew) {
           await this.send(

--- a/src/application/use-cases/budgetMath.spec.ts
+++ b/src/application/use-cases/budgetMath.spec.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   bucketBudget,
   currentMonthRange,
+  currentBudgetPeriod,
+  periodDayInfo,
+  periodKey,
   effectiveMonthlyIncome,
   formatMoney,
-  monthDayInfo,
   pctSpent,
   progressBar,
   sanitizeMd,
@@ -54,10 +56,33 @@ describe("budgetMath", () => {
     expect(progressBar(150)).toBe("██████████"); // clamped
   });
 
-  it("reports day-of-month info with at least one remaining day", () => {
-    const info = monthDayInfo(new Date(2026, 4, 10)); // May 10, 31-day month
+  it("payday=1 budget period equals the calendar month", () => {
+    const { start, end } = currentBudgetPeriod(1, new Date(2026, 4, 10));
+    expect(start).toEqual(new Date(2026, 4, 1));
+    expect(end).toEqual(new Date(2026, 5, 1));
+  });
+
+  it("payday cycle spans payday→payday across the month boundary", () => {
+    // June 12 with payday 25 → cycle is May 25 .. Jun 25
+    const before = currentBudgetPeriod(25, new Date(2026, 5, 12));
+    expect(before.start).toEqual(new Date(2026, 4, 25));
+    expect(before.end).toEqual(new Date(2026, 5, 25));
+    // June 26 with payday 25 → cycle is Jun 25 .. Jul 25
+    const after = currentBudgetPeriod(25, new Date(2026, 5, 26));
+    expect(after.start).toEqual(new Date(2026, 5, 25));
+    expect(after.end).toEqual(new Date(2026, 6, 25));
+  });
+
+  it("periodDayInfo counts days within the cycle", () => {
+    const info = periodDayInfo(1, new Date(2026, 4, 10)); // May 10, payday 1
     expect(info.day).toBe(10);
-    expect(info.daysInMonth).toBe(31);
+    expect(info.daysInPeriod).toBe(31);
     expect(info.remainingDays).toBe(22); // 31 - 10 + 1
+  });
+
+  it("periodKey is the cycle start date and differs across cycles", () => {
+    expect(periodKey(25, new Date(2026, 5, 12))).toBe("2026-05-25");
+    expect(periodKey(25, new Date(2026, 5, 26))).toBe("2026-06-25");
+    expect(periodKey(1, new Date(2026, 5, 12))).toBe("2026-06-01");
   });
 });

--- a/src/application/use-cases/budgetMath.ts
+++ b/src/application/use-cases/budgetMath.ts
@@ -22,6 +22,26 @@ export function currentMonthRange(now: Date = new Date()): {
   return { start, end };
 }
 
+// Clamp a payday to a safe 1–28 (no Feb/30-day edge cases).
+function clampPayday(payday: number): number {
+  return Math.min(Math.max(Math.floor(payday) || 1, 1), 28);
+}
+
+// The current budget cycle [start, end): from the most recent payday on/before
+// `now` to the next payday. payday=1 reproduces the calendar month.
+export function currentBudgetPeriod(
+  payday: number,
+  now: Date = new Date(),
+): { start: Date; end: Date } {
+  const d = clampPayday(payday);
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  if (now.getDate() >= d) {
+    return { start: new Date(y, m, d), end: new Date(y, m + 1, d) };
+  }
+  return { start: new Date(y, m - 1, d), end: new Date(y, m, d) };
+}
+
 export function bucketPct(split: BudgetSplit, bucket: Bucket): number {
   switch (bucket) {
     case "NEEDS":
@@ -57,27 +77,38 @@ export function formatMoney(amount: number): string {
   return `₹${inr.format(Math.round(amount))}`;
 }
 
-export interface MonthDayInfo {
-  day: number; // 1-based day of month
-  daysInMonth: number;
+export interface PeriodDayInfo {
+  day: number; // 1-based day within the cycle
+  daysInPeriod: number;
   remainingDays: number; // days left including today (>= 1)
 }
 
-// "YYYY-MM" key for the given month — used to scope once-per-month nudges.
-export function monthPeriodKey(now: Date = new Date()): string {
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  return `${year}-${month}`;
+// Opaque per-cycle key (the period start date) — scopes once-per-cycle nudges
+// and could key other per-period state. payday=1 → e.g. "2026-06-01".
+export function periodKey(payday: number, now: Date = new Date()): string {
+  const { start } = currentBudgetPeriod(payday, now);
+  const y = start.getFullYear();
+  const mo = String(start.getMonth() + 1).padStart(2, "0");
+  const d = String(start.getDate()).padStart(2, "0");
+  return `${y}-${mo}-${d}`;
 }
 
-export function monthDayInfo(now: Date = new Date()): MonthDayInfo {
-  const day = now.getDate();
-  const daysInMonth = new Date(
-    now.getFullYear(),
-    now.getMonth() + 1,
-    0,
-  ).getDate();
-  return { day, daysInMonth, remainingDays: daysInMonth - day + 1 };
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function periodDayInfo(
+  payday: number,
+  now: Date = new Date(),
+): PeriodDayInfo {
+  const { start, end } = currentBudgetPeriod(payday, now);
+  const daysInPeriod = Math.round(
+    (end.getTime() - start.getTime()) / MS_PER_DAY,
+  );
+  const day = Math.floor((now.getTime() - start.getTime()) / MS_PER_DAY) + 1;
+  return {
+    day,
+    daysInPeriod,
+    remainingDays: Math.max(1, daysInPeriod - day + 1),
+  };
 }
 
 // Integer percentage of budget spent (0 when budget is 0).

--- a/src/application/use-cases/expenseFlow.ts
+++ b/src/application/use-cases/expenseFlow.ts
@@ -7,7 +7,7 @@ import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
-  currentMonthRange,
+  currentBudgetPeriod,
   effectiveMonthlyIncome,
   formatMoney,
   sanitizeMd,
@@ -81,7 +81,7 @@ export async function recordExpenseAndReply(
   });
 
   // Remaining budget for this bucket this month (sum already includes the new expense).
-  const { start, end } = currentMonthRange();
+  const { start, end } = currentBudgetPeriod(user.payday);
   const spent = await deps.expenseRepository.sumByBucketForMonth(
     user.id,
     bucket,

--- a/src/application/use-cases/processors/IncomeProcessor.ts
+++ b/src/application/use-cases/processors/IncomeProcessor.ts
@@ -9,7 +9,7 @@ import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
-  currentMonthRange,
+  currentBudgetPeriod,
   effectiveMonthlyIncome,
   formatMoney,
   sanitizeMd,
@@ -57,7 +57,7 @@ export class IncomeProcessor implements MessageProcessor {
     });
 
     // Refresh the month's effective income + budgets (sum already includes the new income).
-    const { start, end } = currentMonthRange();
+    const { start, end } = currentBudgetPeriod(user.payday);
     const monthIncome = await this.incomeRepository.sumForMonth(
       user.id,
       start,

--- a/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RecurringSetupProcessor } from "./RecurringSetupProcessor";
+
+const user = { id: "u1", telegramId: "123" };
+
+describe("RecurringSetupProcessor", () => {
+  let recurringRuleRepository: any;
+  let categoryRepository: any;
+  let messageService: any;
+  let processor: RecurringSetupProcessor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recurringRuleRepository = {
+      create: vi.fn().mockResolvedValue({ id: "rr1" }),
+    };
+    categoryRepository = {
+      findByNameForUser: vi.fn().mockResolvedValue(null),
+      create: vi
+        .fn()
+        .mockResolvedValue({ id: "c1", name: "Rent", bucket: "NEEDS" }),
+    };
+    messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    processor = new RecurringSetupProcessor(
+      recurringRuleRepository,
+      categoryRepository,
+      messageService,
+    );
+  });
+
+  it("handles only the RECURRING intent", () => {
+    expect(
+      processor.canHandle({
+        parsed: { intent: "RECURRING", confidence: 1 },
+      } as any),
+    ).toBe(true);
+    expect(
+      processor.canHandle({
+        parsed: { intent: "EXPENSE", confidence: 1 },
+      } as any),
+    ).toBe(false);
+  });
+
+  it("creates a recurring expense with resolved category + bucket", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "rent 8000 on 1st every month",
+      parsed: {
+        intent: "RECURRING",
+        recurringKind: "EXPENSE",
+        amount: 8000,
+        dayOfMonth: 1,
+        category: "Rent",
+        bucket: "NEEDS",
+        note: "rent",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(recurringRuleRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "u1",
+        kind: "EXPENSE",
+        amount: 8000,
+        dayOfMonth: 1,
+        bucket: "NEEDS",
+        categoryId: "c1",
+      }),
+    );
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "Recurring set",
+    );
+  });
+
+  it("creates a recurring income", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "salary 50000 on 25th monthly",
+      parsed: {
+        intent: "RECURRING",
+        recurringKind: "INCOME",
+        amount: 50000,
+        dayOfMonth: 25,
+        note: "salary",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(recurringRuleRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "INCOME",
+        amount: 50000,
+        dayOfMonth: 25,
+      }),
+    );
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "Recurring income",
+    );
+  });
+
+  it("asks for a day when dayOfMonth is missing", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "rent 8000 monthly",
+      parsed: {
+        intent: "RECURRING",
+        recurringKind: "EXPENSE",
+        amount: 8000,
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(recurringRuleRepository.create).not.toHaveBeenCalled();
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain("day");
+  });
+});

--- a/src/application/use-cases/processors/RecurringSetupProcessor.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.ts
@@ -1,0 +1,107 @@
+import { Bucket } from "@prisma/client";
+import {
+  MessageProcessor,
+  ProcessContext,
+  ProcessOutput,
+} from "./MessageProcessor";
+import { IRecurringRuleRepository } from "../../../domain/repositories/IRecurringRuleRepository";
+import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
+import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
+import { BUCKET_META, formatMoney, sanitizeMd } from "../budgetMath";
+
+const MAX_AMOUNT = 1_000_000_000;
+
+// Handles the RECURRING intent: sets up a repeating income/expense the daily job
+// auto-logs each month. Resolves category/bucket like ExpenseProcessor.
+export class RecurringSetupProcessor implements MessageProcessor {
+  constructor(
+    private readonly recurringRuleRepository: IRecurringRuleRepository,
+    private readonly categoryRepository: ICategoryRepository,
+    private readonly messageService: IMessagingPlatform,
+  ) {}
+
+  canHandle(context: ProcessContext): boolean {
+    return context.parsed?.intent === "RECURRING";
+  }
+
+  async process(context: ProcessContext): Promise<ProcessOutput> {
+    const parsed = context.parsed!;
+    const { user, platformUserId } = context;
+
+    const amount = parsed.amount;
+    if (typeof amount !== "number" || amount <= 0 || amount > MAX_AMOUNT) {
+      return this.reply(
+        platformUserId,
+        'I couldn\'t catch the amount. Try "rent 8000 on 1st every month".',
+      );
+    }
+
+    const day = parsed.dayOfMonth;
+    if (typeof day !== "number" || day < 1 || day > 28) {
+      return this.reply(
+        platformUserId,
+        'Which day each month? Try "rent 8000 on 1st every month" (1–28).',
+      );
+    }
+
+    const kind = parsed.recurringKind ?? "EXPENSE";
+
+    if (kind === "INCOME") {
+      await this.recurringRuleRepository.create({
+        userId: user.id,
+        kind: "INCOME",
+        amount,
+        dayOfMonth: day,
+        note: parsed.note,
+      });
+      return this.reply(
+        platformUserId,
+        `🔁 Recurring income set: ${formatMoney(amount)}${parsed.note ? ` (${sanitizeMd(parsed.note)})` : ""} on day ${day} — I'll auto-log it each month.`,
+      );
+    }
+
+    // EXPENSE: resolve category; a known category's bucket is authoritative.
+    const matched = parsed.category
+      ? await this.categoryRepository.findByNameForUser(
+          user.id,
+          parsed.category,
+        )
+      : null;
+    const bucket: Bucket = matched?.bucket ?? parsed.bucket ?? "NEEDS";
+    let categoryId = matched?.id;
+    let categoryName = matched?.name ?? parsed.category;
+    if (!categoryId && parsed.category) {
+      const created = await this.categoryRepository.create({
+        userId: user.id,
+        name: parsed.category,
+        bucket,
+      });
+      categoryId = created.id;
+      categoryName = created.name;
+    }
+
+    await this.recurringRuleRepository.create({
+      userId: user.id,
+      kind: "EXPENSE",
+      amount,
+      dayOfMonth: day,
+      bucket,
+      categoryId,
+      note: parsed.note,
+    });
+
+    const where = categoryName ? ` · ${sanitizeMd(categoryName)}` : "";
+    return this.reply(
+      platformUserId,
+      `🔁 Recurring set: ${formatMoney(amount)} → ${BUCKET_META[bucket].label}${where} on day ${day} — I'll auto-log it each month.`,
+    );
+  }
+
+  private async reply(
+    platformUserId: string,
+    body: string,
+  ): Promise<ProcessOutput> {
+    await this.messageService.sendMessage({ to: platformUserId, body });
+    return { response: body, parsed: { intent: "RECURRING", confidence: 1 } };
+  }
+}

--- a/src/application/use-cases/processors/ReportProcessor.ts
+++ b/src/application/use-cases/processors/ReportProcessor.ts
@@ -11,7 +11,7 @@ import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
-  currentMonthRange,
+  currentBudgetPeriod,
   effectiveMonthlyIncome,
   formatMoney,
   sanitizeMd,
@@ -46,7 +46,7 @@ export class ReportProcessor implements MessageProcessor {
     const config =
       (await this.budgetConfigRepository.findByUserId(user.id)) ??
       DEFAULT_SPLIT;
-    const { start, end } = currentMonthRange();
+    const { start, end } = currentBudgetPeriod(user.payday);
     const monthlyIncome = effectiveMonthlyIncome(
       Number(user.monthlyIncome ?? 0),
       await this.incomeRepository.sumForMonth(user.id, start, end),

--- a/src/application/use-cases/processors/StatusProcessor.spec.ts
+++ b/src/application/use-cases/processors/StatusProcessor.spec.ts
@@ -77,7 +77,7 @@ describe("StatusProcessor", () => {
     } as any);
 
     const body = messageService.sendMessage.mock.calls[0][0].body;
-    expect(body).toContain("This month — Day");
+    expect(body).toContain("This cycle — Day");
     expect(body).toContain("₹21,400 / ₹25,000");
     expect(body).toContain("(86%)"); // 21400/25000
     expect(body).toContain("(61%)"); // 9200/15000

--- a/src/application/use-cases/processors/StatusProcessor.ts
+++ b/src/application/use-cases/processors/StatusProcessor.ts
@@ -11,10 +11,10 @@ import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
-  currentMonthRange,
+  currentBudgetPeriod,
   effectiveMonthlyIncome,
   formatMoney,
-  monthDayInfo,
+  periodDayInfo,
   pctSpent,
   progressBar,
 } from "../budgetMath";
@@ -47,8 +47,8 @@ export class StatusProcessor implements MessageProcessor {
     const config =
       (await this.budgetConfigRepository.findByUserId(user.id)) ??
       DEFAULT_SPLIT;
-    const { start, end } = currentMonthRange();
-    const { day, daysInMonth, remainingDays } = monthDayInfo();
+    const { start, end } = currentBudgetPeriod(user.payday);
+    const { day, daysInPeriod, remainingDays } = periodDayInfo(user.payday);
     const monthlyIncome = effectiveMonthlyIncome(
       Number(user.monthlyIncome ?? 0),
       await this.incomeRepository.sumForMonth(user.id, start, end),
@@ -89,7 +89,7 @@ export class StatusProcessor implements MessageProcessor {
       }
     }
 
-    let body = `📊 This month — Day ${day} of ${daysInMonth}\n\n${lines.join("\n")}`;
+    let body = `📊 This cycle — Day ${day} of ${daysInPeriod}\n\n${lines.join("\n")}`;
     if (dailyParts.length > 0) {
       body += `\n\nSafe daily spend left:  ${dailyParts.join(" · ")}`;
     }

--- a/src/application/use-cases/processors/UndoProcessor.ts
+++ b/src/application/use-cases/processors/UndoProcessor.ts
@@ -11,7 +11,7 @@ import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import {
   BUCKET_META,
   bucketBudget,
-  currentMonthRange,
+  currentBudgetPeriod,
   effectiveMonthlyIncome,
   formatMoney,
   sanitizeMd,
@@ -60,7 +60,7 @@ export class UndoProcessor implements MessageProcessor {
     await this.expenseRepository.softDelete(target.id);
 
     // Budget auto-corrects: sumByBucketForMonth excludes deleted expenses.
-    const { start, end } = currentMonthRange();
+    const { start, end } = currentBudgetPeriod(user.payday);
     const spent = await this.expenseRepository.sumByBucketForMonth(
       user.id,
       target.bucket,

--- a/src/data/ai/GeminiParser.ts
+++ b/src/data/ai/GeminiParser.ts
@@ -1,8 +1,5 @@
 import { GoogleGenAI, Type, Schema } from "@google/genai";
-import {
-  IAiParser,
-  ParseContext,
-} from "../../domain/services/IAiParser";
+import { IAiParser, ParseContext } from "../../domain/services/IAiParser";
 import { ParsedData, ParsedDataSchema } from "../../domain/entities/ParsedData";
 import { buildBudgetSystemPrompt } from "./budgetParserPrompt";
 import { env } from "../../config/env";
@@ -13,9 +10,9 @@ const budgetSchema: Schema = {
   properties: {
     intent: {
       type: Type.STRING,
-      enum: ["EXPENSE", "INCOME", "UNDO", "STATUS", "UNKNOWN"],
+      enum: ["EXPENSE", "INCOME", "UNDO", "STATUS", "RECURRING", "UNKNOWN"],
       description:
-        "EXPENSE if the user spent money. INCOME if they received money/declared salary. STATUS for budget-health questions. UNDO to remove the last entry. UNKNOWN for social/non-financial messages.",
+        'EXPENSE if the user spent money. INCOME if they received money/declared salary. STATUS for budget-health questions. UNDO to remove the last entry. RECURRING to set up a repeating monthly income/expense ("every month", "monthly", "on the Nth"). UNKNOWN for social/non-financial messages.',
     },
     amount: {
       type: Type.NUMBER,
@@ -34,6 +31,16 @@ const budgetSchema: Schema = {
     note: {
       type: Type.STRING,
       description: "Short free-text note (e.g. 'lunch', 'auto to office').",
+    },
+    dayOfMonth: {
+      type: Type.NUMBER,
+      description: "RECURRING only: day of month (1-28) it repeats.",
+    },
+    recurringKind: {
+      type: Type.STRING,
+      enum: ["INCOME", "EXPENSE"],
+      description:
+        "RECURRING only: whether the repeating item is income or expense.",
     },
     confidence: {
       type: Type.NUMBER,

--- a/src/data/ai/budgetParserPrompt.ts
+++ b/src/data/ai/budgetParserPrompt.ts
@@ -21,12 +21,14 @@ ${categoryList}
 
 ### OUTPUT (strict JSON, no prose):
 {
-  "intent": "EXPENSE | INCOME | UNDO | STATUS | UNKNOWN",
+  "intent": "EXPENSE | INCOME | UNDO | STATUS | RECURRING | UNKNOWN",
   "amount": <number>,            // the spend/income amount; omit if none
   "currency": "INR",
   "category": "<best category>", // prefer one from the list above; else propose a short new one
   "bucket": "NEEDS | WANTS | SAVINGS",
   "note": "<short free-text note, e.g. 'lunch', 'auto to office'>",
+  "dayOfMonth": <1-28>,          // RECURRING only: day it repeats
+  "recurringKind": "INCOME | EXPENSE", // RECURRING only
   "confidence": <0..1>,          // your confidence in amount + category + bucket
   "conversational_response": "<only for UNKNOWN/social messages>"
 }
@@ -49,7 +51,13 @@ ${categoryList}
 4. UNDO — wants to remove/correct the last entry.
    - "undo", "delete that", "galti se", "thett—maati".
    - { "intent":"UNDO", "confidence":0.9 }
-5. UNKNOWN — social/non-financial or unintelligible.
+5. RECURRING — set up a repeating income/expense that auto-logs each month.
+   - Triggers: "every month", "monthly", "recurring", "on the Nth", "auto".
+   - "rent 8000 on 1st every month" → { "intent":"RECURRING", "recurringKind":"EXPENSE", "amount":8000, "dayOfMonth":1, "category":"Rent", "bucket":"NEEDS", "note":"rent", "confidence":0.9 }
+   - "netflix 199 every month on 5th" → { "intent":"RECURRING", "recurringKind":"EXPENSE", "amount":199, "dayOfMonth":5, "category":"Subscriptions", "bucket":"WANTS", "note":"netflix", "confidence":0.9 }
+   - "salary 50000 on 25th monthly" → { "intent":"RECURRING", "recurringKind":"INCOME", "amount":50000, "dayOfMonth":25, "note":"salary", "confidence":0.9 }
+   - Cap dayOfMonth at 28. Use EXPENSE intent (not RECURRING) for a one-off spend with no "every month".
+6. UNKNOWN — social/non-financial or unintelligible.
    - "hi", "thanks", "what can you do".
    - { "intent":"UNKNOWN", "confidence":0.9, "conversational_response":"Hi! Text me a spend like \\"chai 30\\" and I'll track it." }
 

--- a/src/data/repositories/PrismaRecurringRuleRepository.ts
+++ b/src/data/repositories/PrismaRecurringRuleRepository.ts
@@ -1,0 +1,51 @@
+import { PrismaClient, RecurringRule } from "@prisma/client";
+import {
+  CreateRecurringRuleDTO,
+  IRecurringRuleRepository,
+} from "../../domain/repositories/IRecurringRuleRepository";
+
+export class PrismaRecurringRuleRepository implements IRecurringRuleRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(data: CreateRecurringRuleDTO): Promise<RecurringRule> {
+    return this.prisma.recurringRule.create({
+      data: {
+        userId: data.userId,
+        kind: data.kind,
+        amount: data.amount,
+        dayOfMonth: data.dayOfMonth,
+        bucket: data.bucket ?? null,
+        categoryId: data.categoryId ?? null,
+        note: data.note ?? null,
+      },
+    });
+  }
+
+  async findByUserId(userId: string): Promise<RecurringRule[]> {
+    return this.prisma.recurringRule.findMany({
+      where: { userId, isActive: true },
+      orderBy: { dayOfMonth: "asc" },
+    });
+  }
+
+  async findById(id: string): Promise<RecurringRule | null> {
+    return this.prisma.recurringRule.findUnique({ where: { id } });
+  }
+
+  async findActiveUnpostedForMonth(monthKey: string): Promise<RecurringRule[]> {
+    return this.prisma.recurringRule.findMany({
+      where: { isActive: true, NOT: { lastPostedKey: monthKey } },
+    });
+  }
+
+  async markPosted(id: string, monthKey: string): Promise<void> {
+    await this.prisma.recurringRule.update({
+      where: { id },
+      data: { lastPostedKey: monthKey },
+    });
+  }
+
+  async delete(id: string, userId: string): Promise<void> {
+    await this.prisma.recurringRule.deleteMany({ where: { id, userId } });
+  }
+}

--- a/src/data/repositories/mergeTelegramUser.ts
+++ b/src/data/repositories/mergeTelegramUser.ts
@@ -25,6 +25,10 @@ export async function mergeTelegramUser(
     where: { userId: botUserId },
     data: { userId: webUserId },
   });
+  await tx.recurringRule.updateMany({
+    where: { userId: botUserId },
+    data: { userId: webUserId },
+  });
   await tx.parseLog.updateMany({
     where: { userId: botUserId },
     data: { userId: webUserId },

--- a/src/domain/entities/ParsedData.spec.ts
+++ b/src/domain/entities/ParsedData.spec.ts
@@ -14,6 +14,19 @@ describe("ParsedDataSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a RECURRING parse with dayOfMonth + recurringKind", () => {
+    const result = ParsedDataSchema.safeParse({
+      intent: "RECURRING",
+      recurringKind: "EXPENSE",
+      amount: 8000,
+      dayOfMonth: 1,
+      category: "Rent",
+      bucket: "NEEDS",
+      confidence: 0.9,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("rejects an unknown intent", () => {
     const result = ParsedDataSchema.safeParse({
       intent: "PAID",

--- a/src/domain/entities/ParsedData.ts
+++ b/src/domain/entities/ParsedData.ts
@@ -10,6 +10,7 @@ export const PARSED_INTENTS = [
   "INCOME",
   "UNDO",
   "STATUS",
+  "RECURRING",
   "UNKNOWN",
 ] as const;
 export type ParsedIntent = (typeof PARSED_INTENTS)[number];
@@ -23,6 +24,9 @@ export const ParsedDataSchema = z.object({
   category: z.string().optional(),
   bucket: z.enum(BUCKETS).optional(),
   note: z.string().optional(),
+  // For RECURRING: which day of the month it recurs, and income vs expense.
+  dayOfMonth: z.number().optional(),
+  recurringKind: z.enum(["INCOME", "EXPENSE"]).optional(),
   confidence: z.number().min(0).max(1),
   conversational_response: z.string().optional(),
 });

--- a/src/domain/repositories/IRecurringRuleRepository.ts
+++ b/src/domain/repositories/IRecurringRuleRepository.ts
@@ -1,0 +1,21 @@
+import { Bucket, RecurringKind, RecurringRule } from "@prisma/client";
+
+export interface CreateRecurringRuleDTO {
+  userId: string;
+  kind: RecurringKind;
+  amount: number;
+  dayOfMonth: number;
+  bucket?: Bucket | undefined;
+  categoryId?: string | undefined;
+  note?: string | undefined;
+}
+
+export interface IRecurringRuleRepository {
+  create(data: CreateRecurringRuleDTO): Promise<RecurringRule>;
+  findByUserId(userId: string): Promise<RecurringRule[]>;
+  findById(id: string): Promise<RecurringRule | null>;
+  // Active rules not yet posted for the given "YYYY-MM" key.
+  findActiveUnpostedForMonth(monthKey: string): Promise<RecurringRule[]>;
+  markPosted(id: string, monthKey: string): Promise<void>;
+  delete(id: string, userId: string): Promise<void>;
+}

--- a/src/infrastructure/scheduler.ts
+++ b/src/infrastructure/scheduler.ts
@@ -1,10 +1,23 @@
 import cron from "node-cron";
 import { prisma } from "../data/prisma/client";
 import { SendBudgetNudgesUseCase } from "../application/use-cases/SendBudgetNudges";
+import { PostRecurringChargesUseCase } from "../application/use-cases/PostRecurringCharges";
 
 export function startScheduler(
   sendBudgetNudges: SendBudgetNudgesUseCase,
+  postRecurringCharges: PostRecurringChargesUseCase,
 ): void {
+  // Daily recurring auto-post at 6 AM IST (00:30 UTC).
+  cron.schedule("30 0 * * *", async () => {
+    console.log("Scheduler: running PostRecurringCharges");
+    try {
+      const { posted } = await postRecurringCharges.execute();
+      console.log(`Scheduler: PostRecurringCharges posted ${posted} item(s)`);
+    } catch (err) {
+      console.error("Scheduler: PostRecurringCharges failed", err);
+    }
+  });
+
   // Daily budget nudges at 7 PM IST (13:30 UTC).
   cron.schedule("30 13 * * *", async () => {
     console.log("Scheduler: running SendBudgetNudges");
@@ -30,6 +43,6 @@ export function startScheduler(
   });
 
   console.log(
-    "Scheduler started — budget nudges daily 7 PM IST, history pruning weekly",
+    "Scheduler started — recurring auto-post 6 AM IST, budget nudges 7 PM IST, history pruning weekly",
   );
 }

--- a/src/presentation/controllers/TelegramWebhookController.ts
+++ b/src/presentation/controllers/TelegramWebhookController.ts
@@ -15,9 +15,11 @@ import { PrismaCategoryRepository } from "../../data/repositories/PrismaCategory
 import { PrismaBudgetConfigRepository } from "../../data/repositories/PrismaBudgetConfigRepository";
 import { PrismaParseLogRepository } from "../../data/repositories/PrismaParseLogRepository";
 import { PrismaIncomeRepository } from "../../data/repositories/PrismaIncomeRepository";
+import { PrismaRecurringRuleRepository } from "../../data/repositories/PrismaRecurringRuleRepository";
 import { PrismaConversationRepository } from "../../data/repositories/PrismaConversationRepository";
 import { PrismaNudgeRepository } from "../../data/repositories/PrismaNudgeRepository";
 import { SendBudgetNudgesUseCase } from "../../application/use-cases/SendBudgetNudges";
+import { PostRecurringChargesUseCase } from "../../application/use-cases/PostRecurringCharges";
 import { prisma } from "../../data/prisma/client";
 import { env } from "../../config/env";
 
@@ -56,6 +58,7 @@ const categoryRepository = new PrismaCategoryRepository(prisma);
 const budgetConfigRepository = new PrismaBudgetConfigRepository(prisma);
 const parseLogRepository = new PrismaParseLogRepository(prisma);
 const incomeRepository = new PrismaIncomeRepository(prisma);
+const recurringRuleRepository = new PrismaRecurringRuleRepository(prisma);
 const nudgeRepository = new PrismaNudgeRepository(prisma);
 const processedMessageRepository = new PrismaProcessedMessageRepository(prisma);
 const conversationRepository = new PrismaConversationRepository();
@@ -68,6 +71,7 @@ const processIncomingMessage = new ProcessIncomingMessageUseCase(
   budgetConfigRepository,
   parseLogRepository,
   incomeRepository,
+  recurringRuleRepository,
   conversationRepository,
   messageService,
 );
@@ -106,6 +110,10 @@ export class TelegramWebhookController {
                 description: "Your budget health this month",
               },
               { command: "report", description: "This month's summary" },
+              {
+                command: "recurring",
+                description: "Manage repeating income/expenses",
+              },
               { command: "help", description: "How to use the bot" },
             ],
           }),
@@ -257,5 +265,14 @@ export const sendBudgetNudges = new SendBudgetNudgesUseCase(
   budgetConfigRepository,
   nudgeRepository,
   incomeRepository,
+  messageService,
+);
+
+export const postRecurringCharges = new PostRecurringChargesUseCase(
+  recurringRuleRepository,
+  expenseRepository,
+  incomeRepository,
+  userRepository,
+  categoryRepository,
   messageService,
 );

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -31,6 +31,7 @@ async function OverviewSection({
         monthlyIncome,
         expectedIncome,
         incomeThisMonth,
+        periodLabel,
         currency,
         buckets,
         totalSpent,
@@ -71,11 +72,11 @@ async function OverviewSection({
                 </Stat>
 
                 <Stat>
-                    <StatLabel>Spent This Month</StatLabel>
+                    <StatLabel>Spent This Cycle</StatLabel>
                     <StatValue>
                         <AnimatedNumber value={totalSpent} format={currencyFormat} />
                     </StatValue>
-                    <StatDescription>Across all buckets</StatDescription>
+                    <StatDescription>{periodLabel}</StatDescription>
                     <StatIndicator color="warning">
                         <TrendingDown className="h-4 w-4" />
                     </StatIndicator>

--- a/web/src/app/dashboard/recurring/page.tsx
+++ b/web/src/app/dashboard/recurring/page.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { ContentLayout } from "@/components/admin-panel/content-layout";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Trash2, Plus, RefreshCw } from "lucide-react";
+import {
+  getRecurringRules,
+  createRecurringRule,
+  deleteRecurringRule,
+  type RecurringRuleView,
+} from "@/lib/actions/recurring";
+
+export default function RecurringPage() {
+  const [rules, setRules] = useState<RecurringRuleView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  // form state
+  const [kind, setKind] = useState<"INCOME" | "EXPENSE">("EXPENSE");
+  const [amount, setAmount] = useState("");
+  const [day, setDay] = useState("1");
+  const [bucket, setBucket] = useState<"NEEDS" | "WANTS" | "SAVINGS">("NEEDS");
+  const [category, setCategory] = useState("");
+  const [note, setNote] = useState("");
+
+  const load = () => getRecurringRules().then(setRules).finally(() => setLoading(false));
+  useEffect(() => {
+    load();
+  }, []);
+
+  const add = () => {
+    setError(null);
+    const amt = Number(amount);
+    const d = Number(day);
+    if (!(amt > 0)) return setError("Enter a valid amount.");
+    if (!(d >= 1 && d <= 28)) return setError("Day must be 1–28.");
+    startTransition(async () => {
+      const res = await createRecurringRule({
+        kind,
+        amount: amt,
+        dayOfMonth: d,
+        bucket: kind === "EXPENSE" ? bucket : undefined,
+        category: kind === "EXPENSE" ? category.trim() || undefined : undefined,
+        note: note.trim() || undefined,
+      });
+      if (!res.success) return setError(res.error ?? "Failed to add.");
+      setAmount("");
+      setCategory("");
+      setNote("");
+      await load();
+    });
+  };
+
+  const remove = (id: string) => {
+    startTransition(async () => {
+      await deleteRecurringRule(id);
+      await load();
+    });
+  };
+
+  return (
+    <ContentLayout title="Recurring">
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Add a recurring item</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Type</Label>
+                <Select value={kind} onValueChange={(v) => setKind(v as "INCOME" | "EXPENSE")}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="EXPENSE">Expense</SelectItem>
+                    <SelectItem value="INCOME">Income</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="amount">Amount</Label>
+                <Input
+                  id="amount"
+                  type="number"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  placeholder="8000"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="day">Day of month (1–28)</Label>
+                <Input
+                  id="day"
+                  type="number"
+                  min={1}
+                  max={28}
+                  value={day}
+                  onChange={(e) => setDay(e.target.value)}
+                />
+              </div>
+              {kind === "EXPENSE" && (
+                <div className="space-y-2">
+                  <Label>Bucket</Label>
+                  <Select value={bucket} onValueChange={(v) => setBucket(v as typeof bucket)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="NEEDS">Needs</SelectItem>
+                      <SelectItem value="WANTS">Wants</SelectItem>
+                      <SelectItem value="SAVINGS">Savings</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+              {kind === "EXPENSE" && (
+                <div className="space-y-2">
+                  <Label htmlFor="category">Category (optional)</Label>
+                  <Input
+                    id="category"
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                    placeholder="Rent"
+                  />
+                </div>
+              )}
+              <div className="space-y-2">
+                <Label htmlFor="note">Note (optional)</Label>
+                <Input
+                  id="note"
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  placeholder="rent"
+                />
+              </div>
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <Button onClick={add} disabled={pending}>
+              <Plus className="mr-2 size-4" /> Add recurring
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Your recurring items</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : rules.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                None yet. Add one above, or tell the bot &quot;rent 8000 on 1st every month&quot;.
+              </p>
+            ) : (
+              <ul className="divide-y">
+                {rules.map((r) => (
+                  <li key={r.id} className="flex items-center justify-between py-3">
+                    <div className="flex items-center gap-3">
+                      <RefreshCw className="size-4 text-muted-foreground" />
+                      <div>
+                        <div className="font-medium">
+                          {r.kind === "INCOME" ? "Income" : r.categoryName ?? r.note ?? "Expense"}
+                          {" · "}₹{r.amount.toLocaleString("en-IN")}
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          Day {r.dayOfMonth}
+                          {r.bucket ? ` · ${r.bucket[0]}${r.bucket.slice(1).toLowerCase()}` : ""}
+                        </div>
+                      </div>
+                      <Badge variant="outline">{r.kind.toLowerCase()}</Badge>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => remove(r.id)}
+                      disabled={pending}
+                    >
+                      <Trash2 className="size-4" />
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </ContentLayout>
+  );
+}

--- a/web/src/lib/actions/budget.ts
+++ b/web/src/lib/actions/budget.ts
@@ -10,7 +10,7 @@ import {
   BUCKETS,
   DEFAULT_SPLIT,
   bucketBudget,
-  currentMonthRange,
+  currentBudgetPeriod,
   effectiveMonthlyIncome,
   pctSpent,
   type BudgetSplit,
@@ -28,19 +28,22 @@ export async function getBudgetOverview() {
   const session = await auth();
   if (!session?.user?.id) redirect("/");
   const userId = session.user.id;
-  const { start, end } = currentMonthRange();
 
-  const [user, config, grouped, recent, categoryGroups, incomeAgg] =
+  // Fetch the user first so the budget window can follow their payday cycle.
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      monthlyIncome: true,
+      currency: true,
+      locale: true,
+      hasOnboarded: true,
+      payday: true,
+    },
+  });
+  const { start, end } = currentBudgetPeriod(user?.payday ?? 1);
+
+  const [config, grouped, recent, categoryGroups, incomeAgg] =
     await Promise.all([
-      prisma.user.findUnique({
-        where: { id: userId },
-        select: {
-          monthlyIncome: true,
-          currency: true,
-          locale: true,
-          hasOnboarded: true,
-        },
-      }),
       prisma.budgetConfig.findUnique({ where: { userId } }),
       prisma.expense.groupBy({
         by: ["bucket"],
@@ -128,10 +131,18 @@ export async function getBudgetOverview() {
     date: e.date,
   }));
 
+  // Human label for the current cycle, e.g. "Jun 25 – Jul 24".
+  const fmt = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+  });
+  const periodLabel = `${fmt.format(start)} – ${fmt.format(new Date(end.getTime() - 86400000))}`;
+
   return {
     monthlyIncome,
     expectedIncome,
     incomeThisMonth,
+    periodLabel,
     currency,
     locale,
     split,

--- a/web/src/lib/actions/categories.ts
+++ b/web/src/lib/actions/categories.ts
@@ -5,7 +5,7 @@ import { auth } from "@/auth";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { Bucket } from "@prisma/client";
-import { currentMonthRange } from "@/lib/budget";
+import { currentBudgetPeriod } from "@/lib/budget";
 
 export type CategoryStat = {
   id: string;
@@ -22,7 +22,11 @@ export async function getCategories(): Promise<CategoryStat[]> {
   const session = await auth();
   if (!session?.user?.id) return [];
   const userId = session.user.id;
-  const { start, end } = currentMonthRange();
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { payday: true },
+  });
+  const { start, end } = currentBudgetPeriod(user?.payday ?? 1);
 
   const [categories, spendGroups] = await Promise.all([
     prisma.category.findMany({

--- a/web/src/lib/actions/recurring.ts
+++ b/web/src/lib/actions/recurring.ts
@@ -1,0 +1,112 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/auth";
+import { revalidatePath } from "next/cache";
+import { Bucket, RecurringKind } from "@prisma/client";
+import {
+  recurringRuleSchema,
+  type RecurringRuleInput,
+} from "@/lib/validations/recurring";
+
+export type RecurringRuleView = {
+  id: string;
+  kind: RecurringKind;
+  amount: number;
+  dayOfMonth: number;
+  bucket: Bucket | null;
+  categoryName: string | null;
+  note: string | null;
+};
+
+export async function getRecurringRules(): Promise<RecurringRuleView[]> {
+  const session = await auth();
+  if (!session?.user?.id) return [];
+
+  const rules = await prisma.recurringRule.findMany({
+    where: { userId: session.user.id, isActive: true },
+    include: { category: { select: { name: true } } },
+    orderBy: [{ kind: "asc" }, { dayOfMonth: "asc" }],
+  });
+
+  return rules.map((r) => ({
+    id: r.id,
+    kind: r.kind,
+    amount: Number(r.amount),
+    dayOfMonth: r.dayOfMonth,
+    bucket: r.bucket,
+    categoryName: r.category?.name ?? null,
+    note: r.note,
+  }));
+}
+
+export async function createRecurringRule(
+  input: RecurringRuleInput,
+): Promise<{ success: boolean; error?: string }> {
+  const session = await auth();
+  if (!session?.user?.id) return { success: false, error: "Unauthorized" };
+  const userId = session.user.id;
+
+  const parsed = recurringRuleSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid input",
+    };
+  }
+  const data = parsed.data;
+
+  let bucket: Bucket | null = null;
+  let categoryId: string | null = null;
+
+  if (data.kind === "EXPENSE") {
+    bucket = (data.bucket as Bucket | undefined) ?? "NEEDS";
+    if (data.category) {
+      // Find-or-create the category (system categories have userId null).
+      const existing = await prisma.category.findFirst({
+        where: {
+          name: { equals: data.category, mode: "insensitive" },
+          OR: [{ userId: null }, { userId }],
+        },
+      });
+      if (existing) {
+        categoryId = existing.id;
+        bucket = existing.bucket;
+      } else {
+        const created = await prisma.category.create({
+          data: { userId, name: data.category, bucket },
+        });
+        categoryId = created.id;
+      }
+    }
+  }
+
+  await prisma.recurringRule.create({
+    data: {
+      userId,
+      kind: data.kind,
+      amount: data.amount,
+      dayOfMonth: data.dayOfMonth,
+      bucket,
+      categoryId,
+      note: data.note ?? null,
+    },
+  });
+
+  revalidatePath("/dashboard/recurring");
+  revalidatePath("/dashboard");
+  return { success: true };
+}
+
+export async function deleteRecurringRule(
+  id: string,
+): Promise<{ success: boolean }> {
+  const session = await auth();
+  if (!session?.user?.id) return { success: false };
+
+  await prisma.recurringRule.deleteMany({
+    where: { id, userId: session.user.id },
+  });
+  revalidatePath("/dashboard/recurring");
+  return { success: true };
+}

--- a/web/src/lib/budget.ts
+++ b/web/src/lib/budget.ts
@@ -31,6 +31,21 @@ export function currentMonthRange(now: Date = new Date()): {
   return { start, end };
 }
 
+// The current budget cycle [start, end): most recent payday on/before `now` to
+// the next payday. payday=1 reproduces the calendar month. Mirrors the backend.
+export function currentBudgetPeriod(
+  payday: number,
+  now: Date = new Date(),
+): { start: Date; end: Date } {
+  const d = Math.min(Math.max(Math.floor(payday) || 1, 1), 28);
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  if (now.getDate() >= d) {
+    return { start: new Date(y, m, d), end: new Date(y, m + 1, d) };
+  }
+  return { start: new Date(y, m - 1, d), end: new Date(y, m, d) };
+}
+
 export function bucketPct(split: BudgetSplit, bucket: Bucket): number {
   switch (bucket) {
     case "NEEDS":

--- a/web/src/lib/menu-list.ts
+++ b/web/src/lib/menu-list.ts
@@ -5,6 +5,7 @@ import {
   PieChart,
   Settings,
   Tag,
+  RefreshCw,
 } from "lucide-react";
 
 type Submenu = {
@@ -56,6 +57,11 @@ export function getMenuList(): Group[] {
           href: "/dashboard/categories",
           label: "Categories",
           icon: Tag,
+        },
+        {
+          href: "/dashboard/recurring",
+          label: "Recurring",
+          icon: RefreshCw,
         },
       ],
     },

--- a/web/src/lib/validations/recurring.ts
+++ b/web/src/lib/validations/recurring.ts
@@ -1,19 +1,17 @@
 import { z } from "zod";
 
-export const createRecurringChargeSchema = z.object({
-  description: z.string().min(1, "Description is required").max(100),
-  amount: z.number().positive("Must be positive"),
-  direction: z.enum(["INCOME", "EXPENSE"]),
-  period: z.enum(["MONTHLY", "QUARTERLY"]),
+// A repeating income/expense the bot auto-logs each month on dayOfMonth.
+export const recurringRuleSchema = z.object({
+  kind: z.enum(["INCOME", "EXPENSE"]),
+  amount: z.number().positive("Must be positive").max(1_000_000_000),
   dayOfMonth: z
     .number()
     .int()
     .min(1)
     .max(28, "Use 1–28 to avoid month-end issues"),
-  walletId: z.string().optional().nullable(),
-  notifyDaysBefore: z.number().int().min(0).max(7),
+  bucket: z.enum(["NEEDS", "WANTS", "SAVINGS"]).optional(),
+  category: z.string().trim().max(50).optional(),
+  note: z.string().trim().max(100).optional(),
 });
 
-export type CreateRecurringChargeSchema = z.infer<
-  typeof createRecurringChargeSchema
->;
+export type RecurringRuleInput = z.infer<typeof recurringRuleSchema>;


### PR DESCRIPTION
## Payday-aware budgeting
Every current-period budget calc now runs over the user's **[payday, next payday)** cycle instead of the calendar month. `payday = 1` reproduces the calendar month (clamped 1–28, so no Feb/30-day edges). New `budgetMath` helpers `currentBudgetPeriod` / `periodDayInfo` / `periodKey` replace the month-based ones; rewired through `/status`, `/report`, undo, income, expenseFlow, and nudges (per-user payday), plus the web overview (shows the cycle label, e.g. "Jun 25 – Jul 24") and categories.

## Recurring rules (auto-post + notify)
- **schema:** `RecurringKind` enum + `RecurringRule` model (+ migration, included in account-merge).
- **`PostRecurringChargesUseCase`:** daily cron (06:00 IST) auto-creates the Expense/Income on the rule's `dayOfMonth` (clamped), **idempotent per calendar month** via `lastPostedKey`, and DMs the user (`📌 Auto-logged rent ₹8,000 → Needs · Rent — reply "undo" to remove`).
- **bot:** new `RECURRING` intent (ParsedData + Zod + shared prompt + Gemini schema) and `RecurringSetupProcessor` ("rent 8000 on 1st every month"); `/recurring` command.
- **web:** `/dashboard/recurring` page + Server Actions (list/create/delete) + nav.

Composes with income tracking: a recurring salary auto-posts Income → feeds `effectiveMonthlyIncome` → the payday-cycle budget reflects it hands-free.

## Verified
Backend build + **61 unit tests** (period helpers, RecurringSetupProcessor, PostRecurringCharges, parser RECURRING; existing specs updated for payday); web build; root + web lint 0. ROADMAP updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)