### PR TITLE
fix(web): remove broken Edge auth middleware (PrismaClient on Edge)

### DIFF
--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,5 +1,0 @@
-export { auth as middleware } from "@/auth";
-
-export const config = {
-  matcher: ["/dashboard/:path*"],
-};


### PR DESCRIPTION
Production /dashboard requests threw `PrismaClient is not configured to run in Edge Runtime` + Auth.js `SessionTokenError` — `middleware.ts` ran the Prisma-adapter `auth` on Edge. With database sessions, edge can't validate sessions anyway, and the dashboard layout already guards server-side. Removed the redundant middleware; server-side auth (layout + per-action checks) remains the source of truth. Web build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)