### PR TITLE
fix(web): sync committed Prisma schema for Railway build + drift guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
         cache: 'pnpm'
     - name: Install dependencies
       run: pnpm install
+    - name: Web Prisma schema in sync with root
+      run: diff -q prisma/schema.prisma web/prisma/schema.prisma
     - name: Generate Prisma Client
       run: pnpm prisma generate
     - name: Unit tests

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -27,6 +27,11 @@ enum NudgeKind {
   OVER
 }
 
+enum RecurringKind {
+  INCOME
+  EXPENSE
+}
+
 // ─── Users ───────────────────────────────────────────────────────────────────
 
 model User {
@@ -56,11 +61,13 @@ model User {
   sessions      Session[]
 
   // Core relations
-  expenses     Expense[]
-  budgetConfig BudgetConfig?
-  categories   Category[]
-  logs         ParseLog[]
-  budgetNudges BudgetNudge[]
+  expenses       Expense[]
+  incomes        Income[]
+  budgetConfig   BudgetConfig?
+  categories     Category[]
+  logs           ParseLog[]
+  budgetNudges   BudgetNudge[]
+  recurringRules RecurringRule[]
 
   conversationMessages ConversationMessage[]
   telegramLinkToken    TelegramLinkToken?
@@ -102,11 +109,34 @@ model Category {
   userId String?
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  expenses Expense[]
+  expenses       Expense[]
+  recurringRules RecurringRule[]
 
   createdAt DateTime @default(now())
 
   @@unique([userId, name])
+}
+
+// A repeating income/expense the scheduler auto-posts each month on dayOfMonth.
+model RecurringRule {
+  id         String        @id @default(cuid())
+  userId     String
+  user       User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  kind       RecurringKind
+  amount     Decimal       @db.Decimal(12, 2)
+  dayOfMonth Int // 1–28
+  bucket     Bucket? // for EXPENSE
+  categoryId String?
+  category   Category?     @relation(fields: [categoryId], references: [id])
+  note       String?
+  isActive   Boolean       @default(true)
+  // "YYYY-MM" of the last auto-post — idempotency for the daily job.
+  lastPostedKey String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId, isActive])
 }
 
 model Expense {
@@ -141,6 +171,28 @@ model Expense {
 
   @@index([userId, date])
   @@index([userId, bucket, date])
+}
+
+// Income events (salary, freelance, bonus). The month's effective budget is
+// based on max(expected monthlyIncome, sum of income this month).
+model Income {
+  id     String  @id @default(cuid())
+  amount Decimal @db.Decimal(12, 2)
+  source String? // "salary", "freelance", etc.
+  note   String?
+
+  rawText    String
+  confidence Float
+
+  date DateTime @default(now())
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  isDeleted Boolean   @default(false)
+  deletedAt DateTime?
+
+  @@index([userId, date])
 }
 
 // ─── Infra ────────────────────────────────────────────────────────────────────

--- a/web/railway.toml
+++ b/web/railway.toml
@@ -1,6 +1,8 @@
 [build]
 builder = "RAILPACK"
-buildCommand = "pnpm build"
+# Generate the Prisma client from the committed web/prisma/schema.prisma before
+# the Next build (standalone web context has no ../prisma to sync from).
+buildCommand = "pnpm prisma generate && pnpm build"
 
 [deploy]
 startCommand = "pnpm start"


### PR DESCRIPTION
## Why the web Railway build was failing
The web service builds **standalone** (no `../prisma` in context), so it generates its Prisma client from the committed `web/prisma/schema.prisma`. That file was **stale** (last synced before the income + recurring PRs) → the generated client lacked `Income`/`RecurringRule` → every query typed as `any` → Next `tsc` failed (`dashboard/page.tsx` implicit-any cascade). Local builds passed because the postinstall sync copies the current root schema there.

Net effect: web had been stuck on an old budget-era build since the income PR — so the live web was missing income/recurring/payday UI **and** still ran the Edge-middleware bug PR #20 removed. This deploy unblocks all of it.

## Fix (scalable)
- **Sync** `web/prisma/schema.prisma` to root (byte-identical; includes Income + RecurringRule).
- **Drift guard:** `test.yml` now fails if the two schemas diverge — a future schema change can't ship a stale web copy.
- **Defensive build:** `web/railway.toml` build runs `pnpm prisma generate && pnpm build`.

## Verified
`pnpm prisma generate && pnpm build` in `web/` passes from the committed schema (mirrors Railway's standalone build). No code change in `page.tsx` needed — a correct client makes the types resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)