### PR TITLE
feat: surface logged income everywhere + recurring add-this-month prompt

### DIFF
--- a/src/application/use-cases/PostRecurringCharges.ts
+++ b/src/application/use-cases/PostRecurringCharges.ts
@@ -5,7 +5,7 @@ import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
 import { IUserRepository } from "../../domain/repositories/IUserRepository";
 import { ICategoryRepository } from "../../domain/repositories/ICategoryRepository";
 import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
-import { BUCKET_META, formatMoney, sanitizeMd } from "./budgetMath";
+import { postRecurringRule } from "./postRecurringRule";
 
 export interface PostRecurringChargesResult {
   posted: number;
@@ -52,46 +52,23 @@ export class PostRecurringChargesUseCase {
   }
 
   private async post(rule: RecurringRule, monthKey: string): Promise<void> {
-    const amount = Number(rule.amount);
-    const rawText = `[recurring] ${rule.note ?? rule.kind.toLowerCase()}`;
-
-    let body: string;
-    if (rule.kind === "INCOME") {
-      await this.incomeRepository.create({
-        userId: rule.userId,
-        amount,
-        rawText,
-        confidence: 1,
-        source: rule.note ?? "recurring",
-        note: rule.note ?? undefined,
-      });
-      const label = rule.note ? ` (${sanitizeMd(rule.note)})` : "";
-      body = `📌 Auto-logged income ${formatMoney(amount)}${label} — reply "undo" to remove.`;
-    } else {
-      const bucket = rule.bucket ?? "NEEDS";
-      await this.expenseRepository.create({
-        userId: rule.userId,
-        amount,
-        bucket,
-        note: rule.note ?? undefined,
-        rawText,
-        confidence: 1,
-        categoryId: rule.categoryId ?? undefined,
-      });
-      const categoryName = rule.categoryId
-        ? ((await this.categoryRepository.findById(rule.categoryId))?.name ??
-          null)
-        : null;
-      const where = categoryName ? ` · ${sanitizeMd(categoryName)}` : "";
-      body = `📌 Auto-logged ${formatMoney(amount)} → ${BUCKET_META[bucket].label}${where}${rule.note ? ` (${sanitizeMd(rule.note)})` : ""} — reply "undo" to remove.`;
-    }
-
-    // Record idempotency before notifying (a duplicate is worse than a missed DM).
-    await this.recurringRuleRepository.markPosted(rule.id, monthKey);
+    const summary = await postRecurringRule(
+      {
+        recurringRuleRepository: this.recurringRuleRepository,
+        expenseRepository: this.expenseRepository,
+        incomeRepository: this.incomeRepository,
+        categoryRepository: this.categoryRepository,
+      },
+      rule,
+      monthKey,
+    );
 
     const user = await this.userRepository.findById(rule.userId);
     if (user?.telegramId) {
-      await this.messageService.sendMessage({ to: user.telegramId, body });
+      await this.messageService.sendMessage({
+        to: user.telegramId,
+        body: `📌 Auto-logged ${summary} — reply "undo" to remove.`,
+      });
     }
   }
 }

--- a/src/application/use-cases/ProcessIncomingMessage.spec.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.spec.ts
@@ -295,7 +295,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       expect.objectContaining({ amount: 5000, userId: "u1" }),
     );
     expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
-      "This month: ₹55,000",
+      "Income this cycle: ₹55,000",
     );
   });
 

--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -19,6 +19,7 @@ import {
   ProcessContext,
 } from "./processors/MessageProcessor";
 import { ConfirmBucketProcessor } from "./processors/ConfirmBucketProcessor";
+import { RecurringConfirmProcessor } from "./processors/RecurringConfirmProcessor";
 import { OnboardingProcessor } from "./processors/OnboardingProcessor";
 import { StatusProcessor } from "./processors/StatusProcessor";
 import { ReportProcessor } from "./processors/ReportProcessor";
@@ -65,6 +66,13 @@ export class ProcessIncomingMessageUseCase {
         categoryRepository,
         budgetConfigRepository,
         incomeRepository,
+        messageService,
+      ),
+      new RecurringConfirmProcessor(
+        recurringRuleRepository,
+        expenseRepository,
+        incomeRepository,
+        categoryRepository,
         messageService,
       ),
       new OnboardingProcessor(

--- a/src/application/use-cases/postRecurringRule.ts
+++ b/src/application/use-cases/postRecurringRule.ts
@@ -1,0 +1,61 @@
+import { RecurringRule } from "@prisma/client";
+import { IRecurringRuleRepository } from "../../domain/repositories/IRecurringRuleRepository";
+import { IExpenseRepository } from "../../domain/repositories/IExpenseRepository";
+import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
+import { ICategoryRepository } from "../../domain/repositories/ICategoryRepository";
+import { BUCKET_META, formatMoney, sanitizeMd } from "./budgetMath";
+
+export interface PostRecurringRuleDeps {
+  recurringRuleRepository: IRecurringRuleRepository;
+  expenseRepository: IExpenseRepository;
+  incomeRepository: IIncomeRepository;
+  categoryRepository: ICategoryRepository;
+}
+
+// Creates the Expense/Income for one recurring rule and marks it posted for the
+// given "YYYY-MM" key. Returns a short human summary (caller decides the wrapper
+// copy). Shared by the daily cron (PostRecurringCharges) and the setup
+// "add for this month" confirmation (RecurringConfirmProcessor).
+export async function postRecurringRule(
+  deps: PostRecurringRuleDeps,
+  rule: RecurringRule,
+  monthKey: string,
+): Promise<string> {
+  const amount = Number(rule.amount);
+  const rawText = `[recurring] ${rule.note ?? rule.kind.toLowerCase()}`;
+
+  let summary: string;
+  if (rule.kind === "INCOME") {
+    await deps.incomeRepository.create({
+      userId: rule.userId,
+      amount,
+      rawText,
+      confidence: 1,
+      source: rule.note ?? "recurring",
+      note: rule.note ?? undefined,
+    });
+    const label = rule.note ? ` (${sanitizeMd(rule.note)})` : "";
+    summary = `income ${formatMoney(amount)}${label}`;
+  } else {
+    const bucket = rule.bucket ?? "NEEDS";
+    await deps.expenseRepository.create({
+      userId: rule.userId,
+      amount,
+      bucket,
+      note: rule.note ?? undefined,
+      rawText,
+      confidence: 1,
+      categoryId: rule.categoryId ?? undefined,
+    });
+    const categoryName = rule.categoryId
+      ? ((await deps.categoryRepository.findById(rule.categoryId))?.name ??
+        null)
+      : null;
+    const where = categoryName ? ` · ${sanitizeMd(categoryName)}` : "";
+    summary = `${formatMoney(amount)} → ${BUCKET_META[bucket].label}${where}${rule.note ? ` (${sanitizeMd(rule.note)})` : ""}`;
+  }
+
+  // Mark posted before any notify — a duplicate post is worse than a missed DM.
+  await deps.recurringRuleRepository.markPosted(rule.id, monthKey);
+  return summary;
+}

--- a/src/application/use-cases/processors/IncomeProcessor.spec.ts
+++ b/src/application/use-cases/processors/IncomeProcessor.spec.ts
@@ -64,7 +64,8 @@ describe("IncomeProcessor", () => {
     );
     const body = messageService.sendMessage.mock.calls[0][0].body;
     expect(body).toContain("Income ₹5,000");
-    expect(body).toContain("This month: ₹55,000");
+    expect(body).toContain("Income this cycle: ₹55,000");
+    expect(body).toContain("Budget on ₹55,000");
     expect(body).toContain("Needs ₹27,500"); // 55000 * 50%
     expect(body).toContain("Wants ₹16,500"); // 55000 * 30%
     expect(body).toContain("Savings ₹11,000"); // 55000 * 20%

--- a/src/application/use-cases/processors/IncomeProcessor.ts
+++ b/src/application/use-cases/processors/IncomeProcessor.ts
@@ -71,7 +71,8 @@ export class IncomeProcessor implements MessageProcessor {
 
     const label = parsed.note ? ` (${sanitizeMd(parsed.note)})` : "";
     const response = `✅ Income ${formatMoney(amount)}${label}
-This month: ${formatMoney(effective)} → ${BUCKET_META.NEEDS.emoji} Needs ${formatMoney(bucketBudget(effective, config, "NEEDS"))} · ${BUCKET_META.WANTS.emoji} Wants ${formatMoney(bucketBudget(effective, config, "WANTS"))} · ${BUCKET_META.SAVINGS.emoji} Savings ${formatMoney(bucketBudget(effective, config, "SAVINGS"))}`;
+💵 Income this cycle: ${formatMoney(monthIncome)}
+Budget on ${formatMoney(effective)} → ${BUCKET_META.NEEDS.emoji} Needs ${formatMoney(bucketBudget(effective, config, "NEEDS"))} · ${BUCKET_META.WANTS.emoji} Wants ${formatMoney(bucketBudget(effective, config, "WANTS"))} · ${BUCKET_META.SAVINGS.emoji} Savings ${formatMoney(bucketBudget(effective, config, "SAVINGS"))}`;
 
     await this.messageService.sendMessage({
       to: platformUserId,

--- a/src/application/use-cases/processors/RecurringConfirmProcessor.spec.ts
+++ b/src/application/use-cases/processors/RecurringConfirmProcessor.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RecurringConfirmProcessor } from "./RecurringConfirmProcessor";
+
+const expenseRule = {
+  id: "rr1",
+  userId: "u1",
+  kind: "EXPENSE",
+  amount: 8000,
+  dayOfMonth: 1,
+  bucket: "NEEDS",
+  categoryId: "c1",
+  note: "rent",
+};
+
+describe("RecurringConfirmProcessor", () => {
+  let recurringRuleRepository: any;
+  let expenseRepository: any;
+  let incomeRepository: any;
+  let categoryRepository: any;
+  let messageService: any;
+  let processor: RecurringConfirmProcessor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recurringRuleRepository = {
+      findById: vi.fn().mockResolvedValue(expenseRule),
+      markPosted: vi.fn().mockResolvedValue(undefined),
+    };
+    expenseRepository = { create: vi.fn().mockResolvedValue({ id: "e1" }) };
+    incomeRepository = { create: vi.fn().mockResolvedValue({ id: "i1" }) };
+    categoryRepository = {
+      findById: vi.fn().mockResolvedValue({ id: "c1", name: "Rent" }),
+    };
+    messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    processor = new RecurringConfirmProcessor(
+      recurringRuleRepository,
+      expenseRepository,
+      incomeRepository,
+      categoryRepository,
+      messageService,
+    );
+  });
+
+  it("matches only rec: callbacks", () => {
+    expect(processor.canHandle({ textMessage: "rec:rr1:yes" } as any)).toBe(
+      true,
+    );
+    expect(processor.canHandle({ textMessage: "lunch 30" } as any)).toBe(false);
+  });
+
+  it("yes → posts the rule for this month and marks it posted", async () => {
+    await processor.process({
+      platformUserId: "123",
+      textMessage: "rec:rr1:yes",
+    } as any);
+
+    expect(expenseRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u1", amount: 8000, bucket: "NEEDS" }),
+    );
+    expect(recurringRuleRepository.markPosted).toHaveBeenCalledWith(
+      "rr1",
+      expect.any(String),
+    );
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "Added for this month",
+    );
+  });
+
+  it("no → marks posted without creating anything", async () => {
+    await processor.process({
+      platformUserId: "123",
+      textMessage: "rec:rr1:no",
+    } as any);
+
+    expect(expenseRepository.create).not.toHaveBeenCalled();
+    expect(incomeRepository.create).not.toHaveBeenCalled();
+    expect(recurringRuleRepository.markPosted).toHaveBeenCalledWith(
+      "rr1",
+      expect.any(String),
+    );
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "next month",
+    );
+  });
+
+  it("handles an expired/missing rule gracefully", async () => {
+    recurringRuleRepository.findById.mockResolvedValue(null);
+    await processor.process({
+      platformUserId: "123",
+      textMessage: "rec:gone:yes",
+    } as any);
+
+    expect(expenseRepository.create).not.toHaveBeenCalled();
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "no longer set up",
+    );
+  });
+});

--- a/src/application/use-cases/processors/RecurringConfirmProcessor.ts
+++ b/src/application/use-cases/processors/RecurringConfirmProcessor.ts
@@ -1,0 +1,76 @@
+import {
+  MessageProcessor,
+  ProcessContext,
+  ProcessOutput,
+} from "./MessageProcessor";
+import { IRecurringRuleRepository } from "../../../domain/repositories/IRecurringRuleRepository";
+import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
+import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
+import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
+import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
+import { postRecurringRule } from "../postRecurringRule";
+
+// Handles the "add this recurring item for the current month?" button
+// (callback "rec:<ruleId>:yes|no") shown by RecurringSetupProcessor when the
+// rule's day already passed. Runs before AI parsing.
+export class RecurringConfirmProcessor implements MessageProcessor {
+  constructor(
+    private readonly recurringRuleRepository: IRecurringRuleRepository,
+    private readonly expenseRepository: IExpenseRepository,
+    private readonly incomeRepository: IIncomeRepository,
+    private readonly categoryRepository: ICategoryRepository,
+    private readonly messageService: IMessagingPlatform,
+  ) {}
+
+  canHandle(context: ProcessContext): boolean {
+    return context.textMessage.startsWith("rec:");
+  }
+
+  async process(context: ProcessContext): Promise<ProcessOutput> {
+    const { platformUserId } = context;
+    const [, ruleId, choice] = context.textMessage.split(":");
+
+    const rule = ruleId
+      ? await this.recurringRuleRepository.findById(ruleId)
+      : null;
+    if (!rule) {
+      return this.reply(
+        platformUserId,
+        "That recurring item is no longer set up.",
+      );
+    }
+
+    const now = new Date();
+    const monthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+
+    if (choice === "yes") {
+      const summary = await postRecurringRule(
+        {
+          recurringRuleRepository: this.recurringRuleRepository,
+          expenseRepository: this.expenseRepository,
+          incomeRepository: this.incomeRepository,
+          categoryRepository: this.categoryRepository,
+        },
+        rule,
+        monthKey,
+      );
+      return this.reply(platformUserId, `✅ Added for this month: ${summary}.`);
+    }
+
+    // "No": mark posted for this month so the daily cron doesn't add it anyway;
+    // it resumes normally next month.
+    await this.recurringRuleRepository.markPosted(rule.id, monthKey);
+    return this.reply(
+      platformUserId,
+      "👍 Got it — it'll start from next month.",
+    );
+  }
+
+  private async reply(
+    platformUserId: string,
+    body: string,
+  ): Promise<ProcessOutput> {
+    await this.messageService.sendMessage({ to: platformUserId, body });
+    return { response: body, parsed: { intent: "UNKNOWN", confidence: 1 } };
+  }
+}

--- a/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { RecurringSetupProcessor } from "./RecurringSetupProcessor";
 
 const user = { id: "u1", telegramId: "123" };
@@ -11,6 +11,9 @@ describe("RecurringSetupProcessor", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Fix "today" to the 15th so day 1 is in the past and day 25 is in the future.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 15));
     recurringRuleRepository = {
       create: vi.fn().mockResolvedValue({ id: "rr1" }),
     };
@@ -20,12 +23,19 @@ describe("RecurringSetupProcessor", () => {
         .fn()
         .mockResolvedValue({ id: "c1", name: "Rent", bucket: "NEEDS" }),
     };
-    messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    messageService = {
+      sendMessage: vi.fn().mockResolvedValue("m1"),
+      sendInteractiveMessage: vi.fn().mockResolvedValue("m2"),
+    };
     processor = new RecurringSetupProcessor(
       recurringRuleRepository,
       categoryRepository,
       messageService,
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("handles only the RECURRING intent", () => {
@@ -41,7 +51,7 @@ describe("RecurringSetupProcessor", () => {
     ).toBe(false);
   });
 
-  it("creates a recurring expense with resolved category + bucket", async () => {
+  it("creates a recurring expense and prompts for the current month when the day passed", async () => {
     await processor.process({
       user,
       platformUserId: "123",
@@ -50,7 +60,7 @@ describe("RecurringSetupProcessor", () => {
         intent: "RECURRING",
         recurringKind: "EXPENSE",
         amount: 8000,
-        dayOfMonth: 1,
+        dayOfMonth: 1, // already passed (today = 15th)
         category: "Rent",
         bucket: "NEEDS",
         note: "rent",
@@ -68,12 +78,17 @@ describe("RecurringSetupProcessor", () => {
         categoryId: "c1",
       }),
     );
-    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
-      "Recurring set",
-    );
+    const [, body, buttons] =
+      messageService.sendInteractiveMessage.mock.calls[0];
+    expect(body).toContain("Recurring set");
+    expect(body).toContain("add it for this month");
+    expect(buttons.map((b: any) => b.id)).toEqual([
+      "rec:rr1:yes",
+      "rec:rr1:no",
+    ]);
   });
 
-  it("creates a recurring income", async () => {
+  it("creates a recurring income with no prompt when the day is still ahead", async () => {
     await processor.process({
       user,
       platformUserId: "123",
@@ -82,7 +97,7 @@ describe("RecurringSetupProcessor", () => {
         intent: "RECURRING",
         recurringKind: "INCOME",
         amount: 50000,
-        dayOfMonth: 25,
+        dayOfMonth: 25, // still ahead (today = 15th)
         note: "salary",
         confidence: 0.9,
       },
@@ -95,6 +110,7 @@ describe("RecurringSetupProcessor", () => {
         dayOfMonth: 25,
       }),
     );
+    expect(messageService.sendInteractiveMessage).not.toHaveBeenCalled();
     expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
       "Recurring income",
     );

--- a/src/application/use-cases/processors/RecurringSetupProcessor.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.ts
@@ -47,15 +47,17 @@ export class RecurringSetupProcessor implements MessageProcessor {
     const kind = parsed.recurringKind ?? "EXPENSE";
 
     if (kind === "INCOME") {
-      await this.recurringRuleRepository.create({
+      const rule = await this.recurringRuleRepository.create({
         userId: user.id,
         kind: "INCOME",
         amount,
         dayOfMonth: day,
         note: parsed.note,
       });
-      return this.reply(
+      return this.finish(
         platformUserId,
+        rule.id,
+        day,
         `🔁 Recurring income set: ${formatMoney(amount)}${parsed.note ? ` (${sanitizeMd(parsed.note)})` : ""} on day ${day} — I'll auto-log it each month.`,
       );
     }
@@ -80,7 +82,7 @@ export class RecurringSetupProcessor implements MessageProcessor {
       categoryName = created.name;
     }
 
-    await this.recurringRuleRepository.create({
+    const rule = await this.recurringRuleRepository.create({
       userId: user.id,
       kind: "EXPENSE",
       amount,
@@ -91,10 +93,42 @@ export class RecurringSetupProcessor implements MessageProcessor {
     });
 
     const where = categoryName ? ` · ${sanitizeMd(categoryName)}` : "";
-    return this.reply(
+    return this.finish(
       platformUserId,
+      rule.id,
+      day,
       `🔁 Recurring set: ${formatMoney(amount)} → ${BUCKET_META[bucket].label}${where} on day ${day} — I'll auto-log it each month.`,
     );
+  }
+
+  // If the rule's day already passed this calendar month, the daily cron would
+  // post it on its next run — so ask the user whether to add it for this month
+  // now (Yes), or skip to next month (No, which marks it posted). Future day →
+  // just confirm; the cron posts it on the day.
+  private async finish(
+    platformUserId: string,
+    ruleId: string,
+    dayOfMonth: number,
+    baseMsg: string,
+  ): Promise<ProcessOutput> {
+    const now = new Date();
+    const daysInMonth = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+    ).getDate();
+    const dueDay = Math.min(dayOfMonth, daysInMonth);
+
+    if (now.getDate() >= dueDay) {
+      const body = `${baseMsg}\n\nDay ${dayOfMonth} already passed this month — add it for this month now too?`;
+      await this.messageService.sendInteractiveMessage(platformUserId, body, [
+        { id: `rec:${ruleId}:yes`, title: "✅ Add this month" },
+        { id: `rec:${ruleId}:no`, title: "No, next month" },
+      ]);
+      return { response: body, parsed: { intent: "RECURRING", confidence: 1 } };
+    }
+
+    return this.reply(platformUserId, baseMsg);
   }
 
   private async reply(

--- a/src/application/use-cases/processors/ReportProcessor.spec.ts
+++ b/src/application/use-cases/processors/ReportProcessor.spec.ts
@@ -63,7 +63,8 @@ describe("ReportProcessor", () => {
 
     const body = messageService.sendMessage.mock.calls[0][0].body;
     expect(body).toContain("summary");
-    expect(body).toContain("Income ₹50,000");
+    expect(body).toContain("Income logged ₹0");
+    expect(body).toContain("budget on ₹50,000");
     expect(body).toContain("₹23,400 / ₹25,000");
     expect(body).toContain("under by ₹1,600");
     expect(body).toContain("₹16,200 / ₹15,000");

--- a/src/application/use-cases/processors/ReportProcessor.ts
+++ b/src/application/use-cases/processors/ReportProcessor.ts
@@ -47,9 +47,14 @@ export class ReportProcessor implements MessageProcessor {
       (await this.budgetConfigRepository.findByUserId(user.id)) ??
       DEFAULT_SPLIT;
     const { start, end } = currentBudgetPeriod(user.payday);
+    const loggedIncome = await this.incomeRepository.sumForMonth(
+      user.id,
+      start,
+      end,
+    );
     const monthlyIncome = effectiveMonthlyIncome(
       Number(user.monthlyIncome ?? 0),
-      await this.incomeRepository.sumForMonth(user.id, start, end),
+      loggedIncome,
     );
     const monthName = new Intl.DateTimeFormat("en-IN", {
       month: "long",
@@ -67,7 +72,7 @@ export class ReportProcessor implements MessageProcessor {
       lines.push(this.bucketLine(bucket, spent, budget));
     }
 
-    let body = `📅 ${monthName} summary\n\nIncome ${formatMoney(monthlyIncome)}\n${lines.join("\n")}`;
+    let body = `📅 ${monthName} summary\n\nIncome logged ${formatMoney(loggedIncome)} (budget on ${formatMoney(monthlyIncome)})\n${lines.join("\n")}`;
 
     const leaks = await this.expenseRepository.topCategoriesForMonth(
       user.id,

--- a/src/application/use-cases/processors/StatusProcessor.ts
+++ b/src/application/use-cases/processors/StatusProcessor.ts
@@ -49,9 +49,14 @@ export class StatusProcessor implements MessageProcessor {
       DEFAULT_SPLIT;
     const { start, end } = currentBudgetPeriod(user.payday);
     const { day, daysInPeriod, remainingDays } = periodDayInfo(user.payday);
+    const loggedIncome = await this.incomeRepository.sumForMonth(
+      user.id,
+      start,
+      end,
+    );
     const monthlyIncome = effectiveMonthlyIncome(
       Number(user.monthlyIncome ?? 0),
-      await this.incomeRepository.sumForMonth(user.id, start, end),
+      loggedIncome,
     );
 
     const lines: string[] = [];
@@ -89,7 +94,7 @@ export class StatusProcessor implements MessageProcessor {
       }
     }
 
-    let body = `📊 This cycle — Day ${day} of ${daysInPeriod}\n\n${lines.join("\n")}`;
+    let body = `📊 This cycle — Day ${day} of ${daysInPeriod}\n💵 Income: ${formatMoney(loggedIncome)} (budget on ${formatMoney(monthlyIncome)})\n\n${lines.join("\n")}`;
     if (dailyParts.length > 0) {
       body += `\n\nSafe daily spend left:  ${dailyParts.join(" · ")}`;
     }

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -54,17 +54,15 @@ async function OverviewSection({
             {/* Headline stats */}
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                 <Stat>
-                    <StatLabel>Budget Income</StatLabel>
+                    <StatLabel>Income This Cycle</StatLabel>
                     <StatValue>
-                        <AnimatedNumber value={monthlyIncome} format={currencyFormat} />
+                        <AnimatedNumber value={incomeThisMonth} format={currencyFormat} />
                     </StatValue>
                     <StatDescription>
-                        {incomeThisMonth > 0
-                            ? `${formatMoney(incomeThisMonth, currency)} logged this month` +
-                              (monthlyIncome > incomeThisMonth
-                                  ? ` · ${formatMoney(expectedIncome, currency)} expected`
-                                  : "")
-                            : "Your expected monthly baseline"}
+                        Logged this cycle · budget on {formatMoney(monthlyIncome, currency)}
+                        {monthlyIncome > incomeThisMonth
+                            ? ` (expected ${formatMoney(expectedIncome, currency)})`
+                            : ""}
                     </StatDescription>
                     <StatIndicator color="success">
                         <Wallet className="h-4 w-4" />


### PR DESCRIPTION
Fixes two reported issues. (1) Income logged via Telegram looked like it vanished — recorded fine but budget=max(expected,actual) hid sub-salary amounts and no surface showed the logged total. Now logged income is visible in the bot income reply, /status, /report, and the web overview (first stat = Income This Cycle); budget math unchanged. (2) Recurring set up after its day passed now asks 'Day N already passed — add for this month now?' (Yes/No); yes posts now + marks, no marks only so the cron won't re-add. Shared postRecurringRule() helper. Verified: backend build + 65 tests, web build, root+web lint 0, schema drift in sync.