### PR TITLE
feat(analytics): surface income vs spending and net

### DIFF
--- a/web/src/app/dashboard/_components/income-expense-trend-chart.tsx
+++ b/web/src/app/dashboard/_components/income-expense-trend-chart.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, Legend } from "recharts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+interface IncomeExpenseTrendChartProps {
+  data: {
+    month: string;
+    income: number;
+    spend: number;
+    net: number;
+  }[];
+}
+
+const chartConfig = {
+  income: { label: "Income", color: "hsl(var(--chart-3))" },
+  spend: { label: "Spending", color: "hsl(var(--chart-2))" },
+} satisfies ChartConfig;
+
+export function IncomeExpenseTrendChart({ data }: IncomeExpenseTrendChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Income vs Spending</CardTitle>
+        <CardDescription>
+          Monthly money in vs money out across all categories
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="h-[300px] w-full">
+          <BarChart accessibilityLayer data={data}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="month"
+              tickLine={false}
+              tickMargin={10}
+              axisLine={false}
+            />
+            <ChartTooltip content={<ChartTooltipContent indicator="dashed" />} />
+            <Legend />
+            <Bar dataKey="income" name="Income" fill="#a3b18a" radius={4} />
+            <Bar dataKey="spend" name="Spending" fill="#dba19b" radius={4} />
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/app/dashboard/analytics/page.tsx
+++ b/web/src/app/dashboard/analytics/page.tsx
@@ -9,13 +9,19 @@ import {
 } from "@/components/ui/card";
 import { RoundedPieChart } from "@/components/ui/rounded-pie-chart";
 import { BucketTrendChart } from "../_components/income-expense-chart";
+import { IncomeExpenseTrendChart } from "../_components/income-expense-trend-chart";
 import { formatMoney } from "@/lib/budget";
 
 export default async function Page() {
-    const { monthlyTrend, categoryBreakdown, topCategories } =
-        await getAnalyticsData(6);
-
-    const totalThisMonth = categoryBreakdown.reduce((s, c) => s + c.value, 0);
+    const {
+        monthlyTrend,
+        incomeExpenseTrend,
+        categoryBreakdown,
+        topCategories,
+        incomeThisMonth,
+        spentThisMonth,
+        netThisMonth,
+    } = await getAnalyticsData(6);
 
     return (
         <ContentLayout title="Analytics">
@@ -24,40 +30,46 @@ export default async function Page() {
                 <div className="grid gap-4 md:grid-cols-3">
                     <Card>
                         <CardHeader className="pb-2">
+                            <CardTitle className="text-sm font-medium">Income This Month</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold text-green-600">
+                                {formatMoney(incomeThisMonth)}
+                            </div>
+                            <p className="text-xs text-muted-foreground">money in this month</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="pb-2">
                             <CardTitle className="text-sm font-medium">Spent This Month</CardTitle>
                         </CardHeader>
                         <CardContent>
-                            <div className="text-2xl font-bold">{formatMoney(totalThisMonth)}</div>
+                            <div className="text-2xl font-bold">{formatMoney(spentThisMonth)}</div>
                             <p className="text-xs text-muted-foreground">across all categories</p>
                         </CardContent>
                     </Card>
 
                     <Card>
                         <CardHeader className="pb-2">
-                            <CardTitle className="text-sm font-medium">Categories Used</CardTitle>
+                            <CardTitle className="text-sm font-medium">Net This Month</CardTitle>
                         </CardHeader>
                         <CardContent>
-                            <div className="text-2xl font-bold">{categoryBreakdown.length}</div>
-                            <p className="text-xs text-muted-foreground">with spend this month</p>
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardHeader className="pb-2">
-                            <CardTitle className="text-sm font-medium">Top Category</CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <div className="text-2xl font-bold">
-                                {topCategories[0]?.name ?? "—"}
+                            <div
+                                className={`text-2xl font-bold ${netThisMonth >= 0 ? "text-green-600" : "text-red-600"}`}
+                            >
+                                {netThisMonth >= 0 ? "+" : "−"}
+                                {formatMoney(Math.abs(netThisMonth))}
                             </div>
                             <p className="text-xs text-muted-foreground">
-                                {topCategories[0]
-                                    ? formatMoney(topCategories[0].value)
-                                    : "No spend yet"}
+                                {netThisMonth >= 0 ? "saved this month" : "over budget this month"}
                             </p>
                         </CardContent>
                     </Card>
                 </div>
+
+                {/* Income vs spending trend */}
+                <IncomeExpenseTrendChart data={incomeExpenseTrend} />
 
                 {/* Monthly bucket trend */}
                 <BucketTrendChart data={monthlyTrend} />

--- a/web/src/lib/actions/analytics.ts
+++ b/web/src/lib/actions/analytics.ts
@@ -16,11 +16,17 @@ export async function getAnalyticsData(months: number = 6) {
   const now = new Date();
   const startDate = new Date(now.getFullYear(), now.getMonth() - months + 1, 1);
 
-  // Per-bucket spend per month over the window.
-  const expenses = await prisma.expense.findMany({
-    where: { userId, isDeleted: false, date: { gte: startDate } },
-    select: { date: true, amount: true, bucket: true },
-  });
+  // Per-bucket spend + income per month over the window.
+  const [expenses, incomes] = await Promise.all([
+    prisma.expense.findMany({
+      where: { userId, isDeleted: false, date: { gte: startDate } },
+      select: { date: true, amount: true, bucket: true },
+    }),
+    prisma.income.findMany({
+      where: { userId, isDeleted: false, date: { gte: startDate } },
+      select: { date: true, amount: true },
+    }),
+  ]);
 
   type MonthEntry = {
     month: string;
@@ -29,6 +35,7 @@ export async function getAnalyticsData(months: number = 6) {
     SAVINGS: number;
   };
   const monthMap = new Map<string, MonthEntry>();
+  const incomeMap = new Map<string, number>(); // monthKey → income total
 
   for (let i = 0; i < months; i++) {
     const d = new Date(now.getFullYear(), now.getMonth() - (months - 1) + i, 1);
@@ -38,6 +45,7 @@ export async function getAnalyticsData(months: number = 6) {
       year: "2-digit",
     });
     monthMap.set(key, { month: label, NEEDS: 0, WANTS: 0, SAVINGS: 0 });
+    incomeMap.set(key, 0);
   }
 
   for (const e of expenses) {
@@ -47,7 +55,20 @@ export async function getAnalyticsData(months: number = 6) {
     entry[e.bucket as Bucket] += Number(e.amount);
   }
 
+  for (const i of incomes) {
+    const key = `${i.date.getFullYear()}-${String(i.date.getMonth() + 1).padStart(2, "0")}`;
+    if (incomeMap.has(key))
+      incomeMap.set(key, incomeMap.get(key)! + Number(i.amount));
+  }
+
   const monthlyTrend = Array.from(monthMap.values());
+
+  // Income vs spending per month (net = income − spend).
+  const incomeExpenseTrend = Array.from(monthMap.entries()).map(([key, m]) => {
+    const spend = m.NEEDS + m.WANTS + m.SAVINGS;
+    const income = incomeMap.get(key) ?? 0;
+    return { month: m.month, income, spend, net: income - spend };
+  });
 
   // Category breakdown (current month).
   const { start, end } = currentMonthRange(now);
@@ -80,10 +101,23 @@ export async function getAnalyticsData(months: number = 6) {
 
   const topCategories = categoryBreakdown.slice(0, 5);
 
+  // Current-month income + net (income − spend).
+  const incomeAgg = await prisma.income.aggregate({
+    _sum: { amount: true },
+    where: { userId, isDeleted: false, date: { gte: start, lt: end } },
+  });
+  const incomeThisMonth = Number(incomeAgg._sum.amount ?? 0);
+  const spentThisMonth = categoryBreakdown.reduce((s, c) => s + c.value, 0);
+  const netThisMonth = incomeThisMonth - spentThisMonth;
+
   return {
     monthlyTrend,
+    incomeExpenseTrend,
     buckets: BUCKETS,
     categoryBreakdown,
     topCategories,
+    incomeThisMonth,
+    spentThisMonth,
+    netThisMonth,
   };
 }


### PR DESCRIPTION
## What

Analytics page (`/dashboard/analytics`) was expense-only. Surfaces income so it answers "am I net-positive?".

- **Income vs Spending** monthly trend chart (grouped bars over the 6-month window)
- **Income This Month** and **Net This Month** summary stat cards (net green ≥0 / red negative)
- `getAnalyticsData` now queries income over the window → `incomeExpenseTrend` + current-month `incomeThisMonth` / `spentThisMonth` / `netThisMonth`

## Notes

- Pure web change. Calendar-month basis (matches existing analytics trend). No schema/backend/migration.
- Soft-deletes excluded (`isDeleted:false`), consistent with the rest of the app.

## Verify

- `pnpm build` ✓ · `pnpm lint` ✓ (0 errors)
- Analytics: income total + net (signed/colored) + income-vs-spend bars render; existing bucket trend + category pie unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)