### PR TITLE
feat(web): animated text-roll labels on action buttons

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       resend:
         specifier: ^6.5.2
         version: 6.5.2
+      slot-text:
+        specifier: ^0.2.2
+        version: 0.2.2(react@19.2.0)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -4289,6 +4292,17 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  slot-text@0.2.2:
+    resolution: {integrity: sha512-/XJR7fQKDxZQ0aA/s9kMHSz571GtiRIt0wZloHZ4yTMfIBFSwO/yGYcKZ+6YjchWEEjQ9x49s/xqTBuY+F+Vyw==}
+    peerDependencies:
+      react: '>=18 <20'
+      vue: '>=3.4 <4'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      vue:
+        optional: true
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -8977,6 +8991,10 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  slot-text@0.2.2(react@19.2.0):
+    optionalDependencies:
+      react: 19.2.0
 
   sonner@2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -61,6 +61,7 @@
     "react-hook-form": "^7.67.0",
     "recharts": "^2.15.4",
     "resend": "^6.5.2",
+    "slot-text": "^0.2.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "vaul": "^1.1.2",

--- a/web/src/app/dashboard/account/account-settings.tsx
+++ b/web/src/app/dashboard/account/account-settings.tsx
@@ -10,6 +10,8 @@ import {
     CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { SlotLabel } from "@/components/ui/slot-label";
+import { useTransientFlag } from "@/hooks/use-transient-flag";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -83,6 +85,7 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
     const [wants, setWants] = useState(initial.wantsPct);
     const [savings, setSavings] = useState(initial.savingsPct);
     const [isPending, startTransition] = useTransition();
+    const [saved, flashSaved] = useTransientFlag();
 
     const sum = needs + wants + savings;
     const splitValid = sum === 100;
@@ -111,6 +114,7 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
                 savingsPct: savings,
             });
             if (res.success) {
+                flashSaved();
                 toast.success("Budget settings saved");
             } else {
                 toast.error(res.message ?? "Failed to save");
@@ -200,7 +204,9 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
                     onClick={handleSave}
                     disabled={isPending || !splitValid || !paydayValid}
                 >
-                    Save changes
+                    <SlotLabel
+                        text={isPending ? "Saving…" : saved ? "Saved" : "Save changes"}
+                    />
                 </Button>
             </CardContent>
         </Card>

--- a/web/src/app/dashboard/categories/page.tsx
+++ b/web/src/app/dashboard/categories/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useTransition } from "react";
 import { ContentLayout } from "@/components/admin-panel/content-layout";
 import { Button } from "@/components/ui/button";
+import { SlotLabel } from "@/components/ui/slot-label";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -157,7 +158,7 @@ export default function CategoriesPage() {
               </div>
               <Button onClick={handleAdd} disabled={isPending || !newName.trim()}>
                 <Plus className="mr-2 h-4 w-4" />
-                Add
+                <SlotLabel text={isPending ? "Adding…" : "Add"} />
               </Button>
             </div>
             {addError && (

--- a/web/src/app/dashboard/expenses/_components/expense-table-toolbar.tsx
+++ b/web/src/app/dashboard/expenses/_components/expense-table-toolbar.tsx
@@ -10,6 +10,8 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { X, Download } from "lucide-react";
 import { toast } from "sonner";
+import { SlotLabel } from "@/components/ui/slot-label";
+import { useTransientFlag } from "@/hooks/use-transient-flag";
 import {
     exportExpensesCsv,
     type ExpenseFilters,
@@ -29,6 +31,7 @@ export function ExpenseTableToolbar<TData>({
 }: ExpenseTableToolbarProps<TData>) {
     const isFiltered = table.getState().columnFilters.length > 0;
     const [isExporting, startExport] = React.useTransition();
+    const [exported, flashExported] = useTransientFlag();
 
     const handleExport = () =>
         startExport(async () => {
@@ -44,6 +47,7 @@ export function ExpenseTableToolbar<TData>({
             a.download = `expenses-${new Date().toISOString().split("T")[0]}.csv`;
             a.click();
             URL.revokeObjectURL(url);
+            flashExported();
         });
 
     return (
@@ -95,7 +99,9 @@ export function ExpenseTableToolbar<TData>({
                 disabled={isExporting}
             >
                 <Download className="mr-2 h-4 w-4" />
-                Export CSV
+                <SlotLabel
+                    text={isExporting ? "Exporting…" : exported ? "Exported" : "Export CSV"}
+                />
             </Button>
         </DataTableAdvancedToolbar>
     );

--- a/web/src/app/dashboard/income/_components/income-table-toolbar.tsx
+++ b/web/src/app/dashboard/income/_components/income-table-toolbar.tsx
@@ -9,6 +9,8 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { X, Download } from "lucide-react";
 import { toast } from "sonner";
+import { SlotLabel } from "@/components/ui/slot-label";
+import { useTransientFlag } from "@/hooks/use-transient-flag";
 import { exportIncomeCsv, type IncomeFilters } from "@/lib/actions/income";
 
 interface IncomeTableToolbarProps<TData> {
@@ -22,6 +24,7 @@ export function IncomeTableToolbar<TData>({
 }: IncomeTableToolbarProps<TData>) {
   const isFiltered = table.getState().columnFilters.length > 0;
   const [isExporting, startExport] = React.useTransition();
+  const [exported, flashExported] = useTransientFlag();
 
   const handleExport = () =>
     startExport(async () => {
@@ -37,6 +40,7 @@ export function IncomeTableToolbar<TData>({
       a.download = `income-${new Date().toISOString().split("T")[0]}.csv`;
       a.click();
       URL.revokeObjectURL(url);
+      flashExported();
     });
 
   return (
@@ -68,7 +72,9 @@ export function IncomeTableToolbar<TData>({
         disabled={isExporting}
       >
         <Download className="mr-2 h-4 w-4" />
-        Export CSV
+        <SlotLabel
+          text={isExporting ? "Exporting…" : exported ? "Exported" : "Export CSV"}
+        />
       </Button>
     </DataTableAdvancedToolbar>
   );

--- a/web/src/app/dashboard/recurring/page.tsx
+++ b/web/src/app/dashboard/recurring/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useTransition } from "react";
 import { ContentLayout } from "@/components/admin-panel/content-layout";
 import { Button } from "@/components/ui/button";
+import { SlotLabel } from "@/components/ui/slot-label";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -156,7 +157,8 @@ export default function RecurringPage() {
             </div>
             {error && <p className="text-sm text-destructive">{error}</p>}
             <Button onClick={add} disabled={pending}>
-              <Plus className="mr-2 size-4" /> Add recurring
+              <Plus className="mr-2 size-4" />{" "}
+              <SlotLabel text={pending ? "Adding…" : "Add recurring"} />
             </Button>
           </CardContent>
         </Card>

--- a/web/src/components/telegram-card.tsx
+++ b/web/src/components/telegram-card.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { SlotLabel } from "@/components/ui/slot-label";
 import { generateTelegramLinkToken, getTelegramConnectionStatus } from "@/lib/actions/user";
 
 export function TelegramCard() {
@@ -57,7 +58,7 @@ export function TelegramCard() {
                 ) : (
                     <Button onClick={handleConnect} disabled={loading} variant="outline">
                         <SendIcon className="mr-2 size-4" />
-                        {loading ? "Opening…" : "Connect Telegram"}
+                        <SlotLabel text={loading ? "Opening…" : "Connect Telegram"} />
                     </Button>
                 )}
             </CardContent>

--- a/web/src/components/ui/slot-label.tsx
+++ b/web/src/components/ui/slot-label.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import "slot-text/style.css";
+import { useEffect, useState } from "react";
+import { SlotText } from "slot-text/react";
+
+/**
+ * Text-roll (slot-machine) label for short, tactile button text.
+ *
+ * slot-text is browser-only DOM, so render plain text on the server / before
+ * mount to avoid a hydration mismatch + SSR document access, then let SlotText
+ * take over once mounted. `skipUnchanged: false` makes equal-length word swaps
+ * (e.g. "Save changes" → "Saved") still roll.
+ */
+export function SlotLabel({ text }: { text: string }) {
+  const [mounted, setMounted] = useState(false);
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return <span>{text}</span>;
+
+  return (
+    <SlotText text={text} options={{ skipUnchanged: false, direction: "down" }} />
+  );
+}

--- a/web/src/hooks/use-transient-flag.ts
+++ b/web/src/hooks/use-transient-flag.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * A boolean that flips true on `trigger()` and auto-resets to false after `ms`.
+ * Used for brief "Saved" / "Exported" success labels on action buttons.
+ */
+export function useTransientFlag(ms = 1500): [boolean, () => void] {
+  const [on, setOn] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const trigger = useCallback(() => {
+    clearTimeout(timer.current);
+    setOn(true);
+    timer.current = setTimeout(() => setOn(false), ms);
+  }, [ms]);
+
+  useEffect(() => () => clearTimeout(timer.current), []);
+
+  return [on, trigger];
+}


### PR DESCRIPTION
## What

Action buttons had a pending state but no textual feedback — `Export CSV` stayed "Export CSV" (only `disabled` toggled), `Save changes` stayed "Save changes", `Add` stayed "Add". Adds `slot-text` roll animation for **idle → pending → done** label feedback.

- **new** `SlotLabel` wrapper (`slot-text/react`) — mount guard renders plain text on SSR/before-hydration, then the roll takes over
- **new** `useTransientFlag` hook — brief success label, auto-resets
- Save changes → Saving… → **Saved**
- Export CSV → Exporting… → **Exported** (income + expenses toolbars)
- Connect Telegram → Opening… (animates the existing flip)
- Add / Add recurring → Adding…

## Out of scope (deliberate)

Money stat cards (`Income/Spent/Savings This Cycle`, analytics summary) already animate via `@number-flow/react` — left untouched to avoid double-animating. Counters (selection count, pagination, split %) left for a later pass.

## Notes

- Pure `web/` change. New dep `slot-text@0.2.2` (dependency-free, CSS transforms). No schema/backend/bot change.
- `pnpm build` ✓ · `pnpm lint` ✓ (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)