### PR TITLE
feat(web): redesign marketing landing page

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       framer-motion:
         specifier: ^12.23.25
         version: 12.23.25(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      geist:
+        specifier: ^1.7.2
+        version: 1.7.2(next@16.0.10(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       gsap:
         specifier: ^3.13.0
         version: 3.13.0
@@ -3124,6 +3127,11 @@ packages:
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
+
+  geist@1.7.2:
+    resolution: {integrity: sha512-Gu5lDFa3pLRyoBlBPf0QIFHVdWAnpco7fS1bJm41jyLPFoguBgiubseUN2oLXMgqZ7uxAxDoXcHMhCY/fOTTgg==}
+    peerDependencies:
+      next: '>=13.2.0'
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -7735,6 +7743,10 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  geist@1.7.2(next@16.0.10(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)):
+    dependencies:
+      next: 16.0.10(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   generator-function@2.0.1: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
     "date-fns": "^4.1.0",
     "dicons": "^1.1.7",
     "framer-motion": "^12.23.25",
+    "geist": "^1.7.2",
     "gsap": "^3.13.0",
     "immer": "^11.0.1",
     "lucide-react": "^0.555.0",

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -6,8 +6,11 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-brand: var(--brand);
+  --color-brand-foreground: var(--brand-foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --font-display: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -72,6 +75,8 @@
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
+  --brand: oklch(0.62 0.13 155);
+  --brand-foreground: oklch(0.985 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
@@ -106,6 +111,8 @@
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
+  --brand: oklch(0.72 0.14 158);
+  --brand-foreground: oklch(0.145 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
@@ -140,6 +147,9 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+  }
+  html {
+    scroll-behavior: smooth;
   }
   body {
     @apply bg-background text-foreground;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
   generateWebsiteSchema,
 } from "@/lib/seo";
 import { Analytics } from "@vercel/analytics/next";
+import { GeistMono } from "geist/font/mono";
 import { DM_Sans } from "next/font/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "./globals.css";
@@ -83,7 +84,7 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://res.cloudinary.com" />
       </head>
       <body
-        className={`${dmSans.variable} antialiased`}
+        className={`${dmSans.variable} ${GeistMono.variable} antialiased`}
       >
         <ThemeProvider
           attribute="class"

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -31,7 +31,7 @@ export const Header = () => {
               aria-label="home"
               className="flex gap-2 items-center"
             >
-              <p className="font-semibold text-xl tracking-tighter italic">
+              <p className="font-display font-semibold text-xl tracking-tight">
                 Blipko
               </p>
             </Link>

--- a/web/src/components/chat-capture-demo.tsx
+++ b/web/src/components/chat-capture-demo.tsx
@@ -7,7 +7,7 @@ export function ChatCaptureDemo() {
     return (
         <section className="w-full max-w-2xl mx-auto px-6 py-12">
             <div className="text-center mb-8">
-                <h2 className="text-2xl md:text-3xl font-bold mb-2">
+                <h2 className="font-display tracking-tight text-2xl md:text-3xl font-bold mb-2">
                     Just type what you spent
                 </h2>
                 <p className="text-muted-foreground">
@@ -38,8 +38,8 @@ export function ChatCaptureDemo() {
                     className="flex justify-start"
                 >
                     <div className="rounded-2xl rounded-bl-sm bg-muted px-4 py-3 text-sm space-y-1 max-w-[80%]">
-                        <div className="font-medium">✅ ₹220 → Wants · Food</div>
-                        <div className="text-muted-foreground">
+                        <div className="font-medium tabular-nums">✅ ₹220 → Wants · Food</div>
+                        <div className="text-muted-foreground tabular-nums">
                             Wants left this month: ₹14,780 / ₹15,000
                         </div>
                     </div>

--- a/web/src/components/faqs-section.tsx
+++ b/web/src/components/faqs-section.tsx
@@ -13,8 +13,8 @@ export function FaqsSection() {
 	return (
 		<div className="mx-auto w-full max-w-3xl space-y-7 px-4 pt-16">
 			<div className="space-y-2">
-				<h2 className="font-semibold text-3xl md:text-4xl">
-					Frequently Asked Questions
+				<h2 className="font-display tracking-tight font-semibold text-3xl md:text-4xl">
+					Frequently asked questions
 				</h2>
 				<p className="max-w-2xl text-muted-foreground">
 					Got questions? Here are answers about how Blipko works for Kerala users.
@@ -79,7 +79,7 @@ const questions = [
 		id: "item-5",
 		title: "Is there a web app?",
 		content:
-			"Yes — sign in at blipko.app for a full dashboard: budget health, expense history with filters and CSV export, monthly trends, and category breakdowns. Edit your income and budget split right there. Works on any browser.",
+			"Yes — sign in at blipko.lol for a full dashboard: budget health, expense history with filters and CSV export, monthly trends, and category breakdowns. Edit your income and budget split right there. Works on any browser.",
 	},
 	{
 		id: "item-6",

--- a/web/src/components/features-4.tsx
+++ b/web/src/components/features-4.tsx
@@ -4,32 +4,32 @@ import { motion } from 'motion/react'
 const features = [
     {
         icon: MessageCircle,
-        title: "Chat in Your Language",
+        title: "Chat in your language",
         body: "Type \"lunch 220\" or \"auto 60\" in Malayalam, Manglish, or English. Blipko reads it and logs the spend.",
     },
     {
         icon: Mic,
-        title: "Voice Notes Too",
+        title: "Voice notes too",
         body: "Send a voice note on the go. It's transcribed instantly and added to your budget — no typing needed.",
     },
     {
         icon: PieChart,
-        title: "Auto 50/30/20 Sorting",
+        title: "Auto 50/30/20 sorting",
         body: "Every spend is auto-categorized into Needs, Wants, or Savings. No manual tagging, ever.",
     },
     {
         icon: Activity,
-        title: "Instant Budget Health",
+        title: "Instant budget health",
         body: "Send /status anytime to see how much is left in each bucket and your safe daily spend.",
     },
     {
         icon: Bell,
-        title: "Heads-up Before You Overspend",
+        title: "Heads-up before you overspend",
         body: "Blipko nudges you when a bucket hits 80% — so the month doesn't end with a surprise.",
     },
     {
         icon: LayoutDashboard,
-        title: "Monthly Report + Web Dashboard",
+        title: "Monthly report + web dashboard",
         body: "Get a /report each month, and dive into trends, categories, and history on the web — no app install.",
     },
 ];
@@ -45,11 +45,11 @@ export default function Features() {
                     transition={{ duration: 0.6 }}
                     className="relative z-10 mx-auto max-w-xl text-center"
                 >
-                    <h2 className="text-3xl md:text-4xl font-bold mb-3">Everything you need</h2>
+                    <h2 className="font-display tracking-tight text-3xl md:text-4xl font-bold mb-3">Everything you need</h2>
                     <p className="text-muted-foreground text-lg">Budgeting that fits in a chat. Built for Kerala.</p>
                 </motion.div>
 
-                <div className="relative mx-auto grid max-w-5xl overflow-hidden rounded-xl border bg-card/60 backdrop-blur-sm sm:grid-cols-2 lg:grid-cols-3">
+                <div className="relative mx-auto grid max-w-4xl gap-4 sm:grid-cols-2">
                     {features.map((f, i) => {
                         const Icon = f.icon;
                         return (
@@ -59,11 +59,11 @@ export default function Features() {
                                 whileInView={{ opacity: 1, y: 0 }}
                                 viewport={{ once: true }}
                                 transition={{ delay: i * 0.08 }}
-                                className="group relative border-b border-r p-8 last:border-b-0 sm:last:border-r-0 lg:last:border-r lg:[&:nth-child(3n)]:border-r-0 lg:[&:nth-last-child(-n+3)]:border-b-0 hover:bg-muted/50 transition-colors"
+                                className="group relative rounded-xl border bg-card/60 p-6 md:p-8 backdrop-blur-sm transition duration-200 hover:-translate-y-0.5 hover:border-brand/40 hover:shadow-lg hover:shadow-brand/10"
                             >
                                 <div className="space-y-3 relative z-10">
                                     <div className="flex items-center gap-3 mb-4">
-                                        <div className="flex h-10 w-10 items-center justify-center rounded-lg border bg-background">
+                                        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-brand/10 text-brand">
                                             <Icon className="h-5 w-5" />
                                         </div>
                                         <h3 className="text-base font-semibold">{f.title}</h3>

--- a/web/src/components/home-content.tsx
+++ b/web/src/components/home-content.tsx
@@ -27,11 +27,19 @@ interface HomeContentProps {
 
 export const HomeContent = ({ session }: HomeContentProps) => {
     return (
-        <main className="relative min-h-screen overflow-hidden flex flex-col items-center">
-            <div className="fixed inset-0 pointer-events-none -z-10">
-                <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] bg-green-500/10 blur-[120px] rounded-full animate-pulse" />
-                <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] bg-purple-500/5 blur-[120px] rounded-full" />
+        <main className="relative min-h-dvh overflow-hidden flex flex-col items-center">
+            <div aria-hidden className="fixed inset-0 pointer-events-none -z-10">
+                <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] bg-brand/15 blur-[120px] rounded-full animate-pulse" />
+                <div className="absolute bottom-[-10%] right-[-10%] w-[45%] h-[45%] bg-brand/5 blur-[140px] rounded-full" />
             </div>
+            <div
+                aria-hidden
+                className="fixed inset-0 pointer-events-none -z-10 opacity-[0.04]"
+                style={{
+                    backgroundImage:
+                        "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
+                }}
+            />
 
             {/* Hero Section */}
             <motion.div
@@ -51,7 +59,7 @@ export const HomeContent = ({ session }: HomeContentProps) => {
                 <motion.p
                     variants={{ hidden: { y: 20, opacity: 0 }, visible: { y: 0, opacity: 1 } }}
                     transition={{ duration: 0.8 }}
-                    className="text-lg md:text-xl text-muted-foreground font-medium"
+                    className="text-lg md:text-xl text-brand font-medium"
                     lang="ml"
                 >
                     ശമ്പളം എവിടെ പോകുന്നു?
@@ -61,7 +69,7 @@ export const HomeContent = ({ session }: HomeContentProps) => {
                     variants={{ hidden: { y: 20, opacity: 0 }, visible: { y: 0, opacity: 1 } }}
                     transition={{ duration: 0.8 }}
                 >
-                    <LineShadowText className="italic text-7xl md:text-9xl font-bold">
+                    <LineShadowText className="font-display tracking-tight text-7xl md:text-9xl font-bold">
                         Blipko
                     </LineShadowText>
                 </motion.div>
@@ -70,10 +78,10 @@ export const HomeContent = ({ session }: HomeContentProps) => {
                     variants={{ hidden: { y: 20, opacity: 0 }, visible: { y: 0, opacity: 1 } }}
                     transition={{ duration: 0.8 }}
                 >
-                    <TextAnimate className="text-lg md:text-2xl text-gray-400 max-w-2xl mb-4 font-medium">
+                    <TextAnimate className="text-lg md:text-2xl text-muted-foreground max-w-2xl mb-4 font-medium text-balance">
                         Know where your salary goes. Just chat.
                     </TextAnimate>
-                    <p className="text-sm md:text-base text-muted-foreground max-w-xl mx-auto mb-10">
+                    <p className="text-sm md:text-base text-muted-foreground max-w-[60ch] mx-auto mb-10 text-pretty">
                         Log any spend in plain Malayalam, Manglish, or English — by text or voice.
                         Blipko sorts it into a 50/30/20 budget and tells you what&apos;s left, instantly.
                     </p>
@@ -93,7 +101,7 @@ export const HomeContent = ({ session }: HomeContentProps) => {
                                     href={TELEGRAM_URL}
                                     target="_blank"
                                     rel="noreferrer"
-                                    className="group relative flex h-12 w-[220px] items-center justify-between rounded-full border-2 border-[#229ED9] bg-[#229ED9] font-medium text-white hover:opacity-90 transition-opacity"
+                                    className="group relative flex h-12 w-[220px] items-center justify-between rounded-full border-2 border-[#229ED9] bg-[#229ED9] font-medium text-white transition hover:opacity-90 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#229ED9] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                                 >
                                     <span className="pl-5 flex items-center gap-2">
                                         <Send className="h-4 w-4" />
@@ -102,7 +110,7 @@ export const HomeContent = ({ session }: HomeContentProps) => {
                                 </Link>
                                 <Link
                                     href="/dashboard"
-                                    className="group relative flex h-12 w-[220px] items-center justify-between rounded-full border-2 border-[#394481] bg-primary font-medium text-accent hover:opacity-90 transition-opacity"
+                                    className="group relative flex h-12 w-[220px] items-center justify-between rounded-full border-2 border-primary bg-primary font-medium text-primary-foreground transition hover:opacity-90 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                                 >
                                     <span className="pl-5">Open Dashboard</span>
                                     <div className="relative mr-1 h-9 w-9 overflow-hidden rounded-full bg-black dark:bg-white">

--- a/web/src/components/split-visual.tsx
+++ b/web/src/components/split-visual.tsx
@@ -14,7 +14,7 @@ export function SplitVisual() {
     return (
         <section className="w-full max-w-3xl mx-auto px-6 py-12">
             <div className="text-center mb-8">
-                <h2 className="text-2xl md:text-3xl font-bold mb-2">
+                <h2 className="font-display tracking-tight text-2xl md:text-3xl font-bold mb-2">
                     Every rupee, auto-sorted
                 </h2>
                 <p className="text-muted-foreground">
@@ -31,7 +31,7 @@ export function SplitVisual() {
                                 <span>
                                     {meta.emoji} {meta.label}
                                 </span>
-                                <span className="text-muted-foreground">{pct}%</span>
+                                <span className="text-muted-foreground tabular-nums">{pct}%</span>
                             </div>
                             <div className="h-3 w-full rounded-full bg-muted overflow-hidden">
                                 <motion.div


### PR DESCRIPTION
## What

Audit-driven redesign of the public landing page (`/`). Commits to **one emerald brand accent** and **Geist Mono** as the display face. Landing-only — the dashboard and its neutral `--primary` system are untouched.

### Fixes from the design audit
- **Color:** dropped the green+**purple** "AI gradient" blobs for a single brand-emerald ambient glow; added a `--brand` token (desaturated emerald, chroma <0.15) so color is no longer ad-hoc. Telegram blue kept only on the literal "Open in Telegram" button.
- **Type:** Geist Mono for the wordmark + section H2s (DM Sans stays for body); `tabular-nums` on ₹/% figures; sentence-case headings + feature titles; `text-balance`/`text-pretty`.
- **Surface:** subtle grain overlay for texture; brand-tinted icon tiles + hover lift on feature cards.
- **Layout:** broke the textbook 3-equal-column features grid into a 2-col card layout; `min-h-screen` → `min-h-dvh` (iOS viewport); `scroll-behavior: smooth` for anchor nav.
- **A11y:** real `focus-visible` rings + `active:scale` on the custom CTA pills; dropped a random `#394481` border and a low-contrast `text-accent`.
- **Content:** FAQ "sign in at **blipko.app**" → **blipko.lol** (was a dead reference).

## Notes
- Pure `web/` change. New dep `geist` (Vercel, font-only). No schema/backend/bot/migration.
- `pnpm build` ✓ · `pnpm lint` ✓ (0 errors). Verified `bg-brand` / `font-display` utilities compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)