### PR TITLE
feat(bot): conversational Q&A via read-only tool-calling agent

### DIFF
--- a/src/application/use-cases/ProcessIncomingMessage.spec.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.spec.ts
@@ -29,6 +29,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
   let conversationRepository: any;
   let aiParser: any;
   let messageService: any;
+  let queryAgent: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -93,6 +94,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       sendInteractiveMessage: vi.fn().mockResolvedValue("msg-id-456"),
       sendTypingIndicator: vi.fn(),
     };
+    queryAgent = { answer: vi.fn().mockResolvedValue("agent answer") };
 
     useCase = new ProcessIncomingMessageUseCase(
       aiParser,
@@ -105,6 +107,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       recurringRuleRepository,
       conversationRepository,
       messageService,
+      queryAgent,
     );
   });
 

--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -12,6 +12,7 @@ import { IParseLogRepository } from "../../domain/repositories/IParseLogReposito
 import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
 import { IRecurringRuleRepository } from "../../domain/repositories/IRecurringRuleRepository";
 import { IConversationRepository } from "../../domain/repositories/IConversationRepository";
+import { IFinancialQueryAgent } from "../../domain/services/IFinancialQueryAgent";
 import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import { ParsedData, ParsedBucket } from "../../domain/entities/ParsedData";
 import {
@@ -27,6 +28,7 @@ import { UndoProcessor } from "./processors/UndoProcessor";
 import { ExpenseProcessor } from "./processors/ExpenseProcessor";
 import { IncomeProcessor } from "./processors/IncomeProcessor";
 import { RecurringSetupProcessor } from "./processors/RecurringSetupProcessor";
+import { QueryProcessor } from "./processors/QueryProcessor";
 import { FallbackProcessor } from "./processors/FallbackProcessor";
 
 export interface ProcessIncomingMessageInput {
@@ -58,6 +60,7 @@ export class ProcessIncomingMessageUseCase {
     private readonly recurringRuleRepository: IRecurringRuleRepository,
     private readonly conversationRepository: IConversationRepository,
     private readonly messageService: IMessagingPlatform,
+    private readonly queryAgent: IFinancialQueryAgent,
   ) {
     this.preParseProcessors = [
       new ConfirmBucketProcessor(
@@ -132,6 +135,7 @@ export class ProcessIncomingMessageUseCase {
         categoryRepository,
         messageService,
       ),
+      new QueryProcessor(queryAgent, messageService),
       new FallbackProcessor(messageService),
     ];
   }

--- a/src/application/use-cases/processors/QueryProcessor.spec.ts
+++ b/src/application/use-cases/processors/QueryProcessor.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryProcessor } from "./QueryProcessor";
+
+const user = {
+  id: "u1",
+  telegramId: "123",
+  monthlyIncome: 50000,
+  payday: 1,
+  currency: "INR",
+  locale: "en-IN",
+};
+
+describe("QueryProcessor", () => {
+  let queryAgent: any;
+  let messageService: any;
+  let processor: QueryProcessor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryAgent = { answer: vi.fn() };
+    messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    processor = new QueryProcessor(queryAgent, messageService);
+  });
+
+  it("handles only the QUERY intent", () => {
+    expect(
+      processor.canHandle({
+        textMessage: "how much on food?",
+        parsed: { intent: "QUERY", confidence: 0.9 },
+      } as any),
+    ).toBe(true);
+    expect(
+      processor.canHandle({
+        textMessage: "chai 30",
+        parsed: { intent: "EXPENSE", confidence: 0.9 },
+      } as any),
+    ).toBe(false);
+  });
+
+  it("delegates to the agent and sends its answer", async () => {
+    queryAgent.answer.mockResolvedValue("You spent ₹1,200 on food this cycle.");
+
+    const out = await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "how much on food?",
+      parsed: { intent: "QUERY", confidence: 0.9 },
+      conversationHistory: [],
+    } as any);
+
+    expect(queryAgent.answer).toHaveBeenCalledWith(
+      "how much on food?",
+      expect.objectContaining({ userId: "u1", currency: "INR", payday: 1 }),
+    );
+    expect(messageService.sendMessage).toHaveBeenCalledWith({
+      to: "123",
+      body: "You spent ₹1,200 on food this cycle.",
+    });
+    expect(out.response).toBe("You spent ₹1,200 on food this cycle.");
+    expect(out.parsed.intent).toBe("QUERY");
+  });
+
+  it("degrades to a friendly fallback when the agent throws", async () => {
+    queryAgent.answer.mockRejectedValue(new Error("provider down"));
+
+    const out = await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "can I afford a 5000 phone?",
+      parsed: { intent: "QUERY", confidence: 0.9 },
+    } as any);
+
+    expect(out.response).toContain("/status");
+    expect(messageService.sendMessage).toHaveBeenCalledWith({
+      to: "123",
+      body: out.response,
+    });
+  });
+});

--- a/src/application/use-cases/processors/QueryProcessor.ts
+++ b/src/application/use-cases/processors/QueryProcessor.ts
@@ -1,0 +1,62 @@
+import {
+  MessageProcessor,
+  ProcessContext,
+  ProcessOutput,
+} from "./MessageProcessor";
+import { IFinancialQueryAgent } from "../../../domain/services/IFinancialQueryAgent";
+import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
+import { currentBudgetPeriod, periodDayInfo } from "../budgetMath";
+
+const FALLBACK =
+  "I couldn't work that out right now — try /status, or rephrase your question.";
+
+// Handles the QUERY intent: free-form questions about the user's spending,
+// income, or budget. Delegates to a read-only tool-calling agent that fetches
+// real figures and composes the answer. On any agent failure it degrades to a
+// friendly nudge rather than crashing the webhook.
+export class QueryProcessor implements MessageProcessor {
+  constructor(
+    private readonly queryAgent: IFinancialQueryAgent,
+    private readonly messageService: IMessagingPlatform,
+  ) {}
+
+  canHandle(context: ProcessContext): boolean {
+    return context.parsed?.intent === "QUERY";
+  }
+
+  async process(context: ProcessContext): Promise<ProcessOutput> {
+    const { user, platformUserId, textMessage } = context;
+    const now = new Date();
+    const { start, end } = currentBudgetPeriod(user.payday, now);
+    const { day, daysInPeriod, remainingDays } = periodDayInfo(
+      user.payday,
+      now,
+    );
+
+    let body: string;
+    try {
+      body = await this.queryAgent.answer(textMessage, {
+        userId: user.id,
+        currency: user.currency,
+        locale: user.locale,
+        payday: user.payday,
+        monthlyIncome: Number(user.monthlyIncome ?? 0),
+        now,
+        period: {
+          start: start.toISOString(),
+          end: end.toISOString(),
+          day,
+          daysInPeriod,
+          remainingDays,
+        },
+        history: context.conversationHistory,
+      });
+    } catch (error) {
+      console.error("QueryProcessor: agent failed.", error);
+      body = FALLBACK;
+    }
+
+    await this.messageService.sendMessage({ to: platformUserId, body });
+    return { response: body, parsed: { intent: "QUERY", confidence: 1 } };
+  }
+}

--- a/src/application/use-cases/query/FinancialDataTools.spec.ts
+++ b/src/application/use-cases/query/FinancialDataTools.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { FinancialDataTools } from "./FinancialDataTools";
+
+const user = {
+  id: "u1",
+  monthlyIncome: 50000,
+  payday: 1,
+  currency: "INR",
+  locale: "en-IN",
+};
+
+describe("FinancialDataTools", () => {
+  let userRepository: any;
+  let expenseRepository: any;
+  let incomeRepository: any;
+  let budgetConfigRepository: any;
+  let recurringRuleRepository: any;
+  let categoryRepository: any;
+  let tools: FinancialDataTools;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userRepository = { findById: vi.fn().mockResolvedValue(user) };
+    expenseRepository = {
+      sumByBucketForMonth: vi.fn((_u, bucket) =>
+        Promise.resolve(
+          (
+            { NEEDS: 10000, WANTS: 6000, SAVINGS: 2000 } as Record<
+              string,
+              number
+            >
+          )[bucket] ?? 0,
+        ),
+      ),
+      categoryTotals: vi
+        .fn()
+        .mockResolvedValue([{ name: "Food", total: 1200 }]),
+      findRecent: vi.fn().mockResolvedValue([
+        {
+          date: new Date("2026-06-10T00:00:00Z"),
+          amount: 220,
+          bucket: "WANTS",
+          categoryName: "Food",
+          note: "lunch",
+        },
+      ]),
+    };
+    incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(50000) };
+    budgetConfigRepository = {
+      findByUserId: vi
+        .fn()
+        .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
+    };
+    recurringRuleRepository = { findByUserId: vi.fn().mockResolvedValue([]) };
+    categoryRepository = { findById: vi.fn().mockResolvedValue(null) };
+
+    tools = new FinancialDataTools(
+      userRepository,
+      expenseRepository,
+      incomeRepository,
+      budgetConfigRepository,
+      recurringRuleRepository,
+      categoryRepository,
+    );
+  });
+
+  it("computes per-bucket budget/spent/remaining from the 50/30/20 split", async () => {
+    const status = await tools.getPeriodStatus("u1");
+    const needs = status.buckets.find((b) => b.bucket === "NEEDS")!;
+    expect(needs.budget).toBe(25000); // 50% of 50000
+    expect(needs.spent).toBe(10000);
+    expect(needs.remaining).toBe(15000);
+    expect(needs.pct).toBe(40);
+    expect(status.currency).toBe("INR");
+  });
+
+  it("returns all buckets when none specified, one when scoped", async () => {
+    const all = await tools.getSpendByBucket("u1", {});
+    expect(all).toHaveLength(3);
+    const wants = await tools.getSpendByBucket("u1", {}, "WANTS");
+    expect(wants).toEqual([{ bucket: "WANTS", total: 6000 }]);
+  });
+
+  it("passes a bucket filter and limit to categoryTotals", async () => {
+    const cats = await tools.getSpendByCategory("u1", {}, "WANTS", 3);
+    expect(cats).toEqual([{ name: "Food", total: 1200 }]);
+    const call = expenseRepository.categoryTotals.mock.calls[0];
+    expect(call[3]).toBe("WANTS"); // bucket
+    expect(call[4]).toBe(3); // limit
+  });
+
+  it("maps recent expenses to ISO dates", async () => {
+    const recent = await tools.getRecentExpenses("u1", { limit: 5 });
+    expect(recent[0]).toMatchObject({
+      amount: 220,
+      bucket: "WANTS",
+      category: "Food",
+      note: "lunch",
+    });
+    expect(recent[0].date).toBe("2026-06-10T00:00:00.000Z");
+  });
+});

--- a/src/application/use-cases/query/FinancialDataTools.ts
+++ b/src/application/use-cases/query/FinancialDataTools.ts
@@ -1,0 +1,208 @@
+import { Bucket } from "@prisma/client";
+import {
+  DateRange,
+  IFinancialDataTools,
+  PeriodStatus,
+  CategoryTotal,
+  RecentExpense,
+  RecurringRuleSummary,
+} from "../../../domain/services/IFinancialDataTools";
+import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
+import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
+import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
+import { IRecurringRuleRepository } from "../../../domain/repositories/IRecurringRuleRepository";
+import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
+import { IUserRepository } from "../../../domain/repositories/IUserRepository";
+import {
+  bucketBudget,
+  currentBudgetPeriod,
+  effectiveMonthlyIncome,
+  pctSpent,
+  periodDayInfo,
+} from "../budgetMath";
+
+const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
+const ORDER: Bucket[] = ["NEEDS", "WANTS", "SAVINGS"];
+
+// Read-only data tools for the conversational query agent. Reuses the same
+// repositories + budgetMath as the deterministic processors, so answers match
+// what /status and /report would show. No method ever writes.
+export class FinancialDataTools implements IFinancialDataTools {
+  constructor(
+    private readonly userRepository: IUserRepository,
+    private readonly expenseRepository: IExpenseRepository,
+    private readonly incomeRepository: IIncomeRepository,
+    private readonly budgetConfigRepository: IBudgetConfigRepository,
+    private readonly recurringRuleRepository: IRecurringRuleRepository,
+    private readonly categoryRepository: ICategoryRepository,
+  ) {}
+
+  async getPeriodStatus(userId: string): Promise<PeriodStatus> {
+    const user = await this.requireUser(userId);
+    const config =
+      (await this.budgetConfigRepository.findByUserId(userId)) ?? DEFAULT_SPLIT;
+    const { start, end } = currentBudgetPeriod(user.payday);
+    const { day, daysInPeriod, remainingDays } = periodDayInfo(user.payday);
+    const incomeLogged = await this.incomeRepository.sumForMonth(
+      userId,
+      start,
+      end,
+    );
+    const monthlyIncome = effectiveMonthlyIncome(
+      Number(user.monthlyIncome ?? 0),
+      incomeLogged,
+    );
+
+    const buckets = await Promise.all(
+      ORDER.map(async (bucket) => {
+        const budget = bucketBudget(monthlyIncome, config, bucket);
+        const spent = await this.expenseRepository.sumByBucketForMonth(
+          userId,
+          bucket,
+          start,
+          end,
+        );
+        return {
+          bucket,
+          budget,
+          spent,
+          remaining: budget - spent,
+          pct: pctSpent(spent, budget),
+        };
+      }),
+    );
+
+    return {
+      currency: user.currency,
+      periodStart: start.toISOString(),
+      periodEnd: end.toISOString(),
+      day,
+      daysInPeriod,
+      remainingDays,
+      monthlyIncome,
+      incomeLogged,
+      buckets,
+    };
+  }
+
+  async getSpendByBucket(
+    userId: string,
+    range: DateRange,
+    bucket?: Bucket,
+  ): Promise<Array<{ bucket: Bucket; total: number }>> {
+    const { from, to } = await this.resolveRange(userId, range);
+    const buckets = bucket ? [bucket] : ORDER;
+    return Promise.all(
+      buckets.map(async (b) => ({
+        bucket: b,
+        total: await this.expenseRepository.sumByBucketForMonth(
+          userId,
+          b,
+          from,
+          to,
+        ),
+      })),
+    );
+  }
+
+  async getSpendByCategory(
+    userId: string,
+    range: DateRange,
+    bucket?: Bucket,
+    limit = 5,
+  ): Promise<CategoryTotal[]> {
+    const { from, to } = await this.resolveRange(userId, range);
+    return this.expenseRepository.categoryTotals(
+      userId,
+      from,
+      to,
+      bucket ?? null,
+      clamp(limit, 1, 20),
+    );
+  }
+
+  async getIncome(
+    userId: string,
+    range: DateRange,
+  ): Promise<{ total: number }> {
+    const { from, to } = await this.resolveRange(userId, range);
+    const total = await this.incomeRepository.sumForMonth(userId, from, to);
+    return { total };
+  }
+
+  async getRecentExpenses(
+    userId: string,
+    opts: {
+      limit?: number | undefined;
+      category?: string | undefined;
+      range?: DateRange | undefined;
+    },
+  ): Promise<RecentExpense[]> {
+    // No default range here — "recent" spans all time unless the user narrows it.
+    const range = opts.range
+      ? await this.resolveRange(userId, opts.range)
+      : undefined;
+    const rows = await this.expenseRepository.findRecent(userId, {
+      limit: clamp(opts.limit ?? 10, 1, 50),
+      categoryName: opts.category,
+      from: range?.from,
+      to: range?.to,
+    });
+    return rows.map((r) => ({
+      date: r.date.toISOString(),
+      amount: r.amount,
+      bucket: r.bucket,
+      category: r.categoryName,
+      note: r.note,
+    }));
+  }
+
+  async getRecurringRules(userId: string): Promise<RecurringRuleSummary[]> {
+    const rules = await this.recurringRuleRepository.findByUserId(userId);
+    return Promise.all(
+      rules.map(async (r) => {
+        let category: string | null = null;
+        if (r.categoryId) {
+          const c = await this.categoryRepository.findById(r.categoryId);
+          category = c?.name ?? null;
+        }
+        return {
+          kind: r.kind,
+          amount: Number(r.amount),
+          dayOfMonth: r.dayOfMonth,
+          bucket: r.bucket ?? null,
+          category,
+          note: r.note ?? null,
+        };
+      }),
+    );
+  }
+
+  private async requireUser(userId: string) {
+    const user = await this.userRepository.findById(userId);
+    if (!user) throw new Error(`FinancialDataTools: user ${userId} not found`);
+    return user;
+  }
+
+  // Resolve an ISO range to concrete Dates, defaulting to the current cycle.
+  private async resolveRange(
+    userId: string,
+    range: DateRange,
+  ): Promise<{ from: Date; to: Date }> {
+    const user = await this.requireUser(userId);
+    const period = currentBudgetPeriod(user.payday);
+    const from = parseDate(range.from) ?? period.start;
+    const to = parseDate(range.to) ?? period.end;
+    return { from, to };
+  }
+}
+
+function parseDate(iso?: string): Date | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(Math.max(Math.floor(n) || min, min), max);
+}

--- a/src/data/ai/GeminiParser.ts
+++ b/src/data/ai/GeminiParser.ts
@@ -10,9 +10,17 @@ const budgetSchema: Schema = {
   properties: {
     intent: {
       type: Type.STRING,
-      enum: ["EXPENSE", "INCOME", "UNDO", "STATUS", "RECURRING", "UNKNOWN"],
+      enum: [
+        "EXPENSE",
+        "INCOME",
+        "UNDO",
+        "STATUS",
+        "RECURRING",
+        "QUERY",
+        "UNKNOWN",
+      ],
       description:
-        'EXPENSE if the user spent money. INCOME if they received money/declared salary. STATUS for budget-health questions. UNDO to remove the last entry. RECURRING to set up a repeating monthly income/expense ("every month", "monthly", "on the Nth"). UNKNOWN for social/non-financial messages.',
+        'EXPENSE if the user spent money. INCOME if they received money/declared salary. STATUS for a plain overall budget-health check ("status", "how much is left"). UNDO to remove the last entry. RECURRING to set up a repeating monthly income/expense ("every month", "monthly", "on the Nth"). QUERY when the user ASKS a data-backed question about their spending/income/budget ("how much did I spend on food?", "biggest expense?", "can I afford X?", trends/comparisons) — a question, never a statement that logs money. UNKNOWN for social/non-financial messages.',
     },
     amount: {
       type: Type.NUMBER,

--- a/src/data/ai/OpenAiQueryAgent.ts
+++ b/src/data/ai/OpenAiQueryAgent.ts
@@ -1,0 +1,251 @@
+import OpenAI from "openai";
+import { Bucket } from "@prisma/client";
+import {
+  IFinancialQueryAgent,
+  QueryAgentContext,
+} from "../../domain/services/IFinancialQueryAgent";
+import {
+  DateRange,
+  IFinancialDataTools,
+} from "../../domain/services/IFinancialDataTools";
+import { env } from "../../config/env";
+
+const BUCKETS = ["NEEDS", "WANTS", "SAVINGS"] as const;
+const MAX_ROUNDS = 5;
+
+// Read-only conversational agent. Given a question, it plans tool calls over the
+// user's real data (IFinancialDataTools) and composes a grounded answer. It can
+// only read — there are no write tools.
+export class OpenAiQueryAgent implements IFinancialQueryAgent {
+  private client: OpenAI;
+
+  constructor(
+    private readonly tools: IFinancialDataTools,
+    apiKey: string = env.OPENAI_API_KEY,
+    private readonly model: string = "gpt-4o-mini",
+  ) {
+    if (!apiKey) throw new Error("OpenAiQueryAgent: API Key is missing.");
+    this.client = new OpenAI({ apiKey });
+  }
+
+  async answer(question: string, ctx: QueryAgentContext): Promise<string> {
+    const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
+      { role: "system", content: this.systemPrompt(ctx) },
+      ...(ctx.history ?? []).map((h) => ({
+        role: (h.role === "model" ? "assistant" : "user") as
+          | "assistant"
+          | "user",
+        content: h.content,
+      })),
+      { role: "user", content: question },
+    ];
+
+    for (let round = 0; round < MAX_ROUNDS; round++) {
+      const completion = await this.client.chat.completions.create({
+        model: this.model,
+        messages,
+        tools: TOOL_SCHEMAS,
+        tool_choice: "auto",
+        temperature: 0.2,
+      });
+
+      const msg = completion.choices[0]?.message;
+      if (!msg) throw new Error("OpenAiQueryAgent: empty completion.");
+
+      if (msg.tool_calls && msg.tool_calls.length > 0) {
+        messages.push(msg);
+        for (const call of msg.tool_calls) {
+          if (call.type !== "function") continue;
+          const result = await this.runTool(
+            call.function.name,
+            call.function.arguments,
+            ctx.userId,
+          );
+          messages.push({
+            role: "tool",
+            tool_call_id: call.id,
+            content: JSON.stringify(result),
+          });
+        }
+        continue;
+      }
+
+      const text = msg.content?.trim();
+      if (text) return text;
+      throw new Error("OpenAiQueryAgent: model returned no answer.");
+    }
+
+    throw new Error("OpenAiQueryAgent: exceeded tool-call rounds.");
+  }
+
+  private systemPrompt(ctx: QueryAgentContext): string {
+    const today = ctx.now.toISOString().split("T")[0];
+    return `You are Blipko's budgeting assistant. The user follows a 50/30/20 budget (NEEDS 50%, WANTS 30%, SAVINGS 20%) on a payday-based cycle. Answer the user's question about THEIR money using the tools — never invent numbers.
+
+User context:
+- Currency: ${ctx.currency} (format amounts with ₹)
+- Today: ${today}
+- Current budget cycle: ${ctx.period.start.split("T")[0]} to ${ctx.period.end.split("T")[0]} (day ${ctx.period.day} of ${ctx.period.daysInPeriod}, ${ctx.period.remainingDays} left)
+- Payday: day ${ctx.payday} of the month
+- Expected monthly income: ${ctx.monthlyIncome}
+
+Rules:
+- ALWAYS call tools to get real figures before stating any number. If a tool returns nothing, say there's no data for that — don't guess.
+- Resolve relative dates ("last week", "this month", "yesterday") to explicit ISO from/to using today's date, and pass them to the tools. Omit the range to use the current cycle.
+- For "can I afford X?" use get_period_status: compare the amount to the remaining budget in the relevant bucket and the days left, then give a clear yes/no with the numbers.
+- Keep replies short and skimmable for Telegram. Use Markdown sparingly (*bold* for key numbers). Use ₹ for money. No preamble.
+- Only answer questions about the user's budget/spending/income. Politely decline anything else.`;
+  }
+
+  private async runTool(
+    name: string,
+    rawArgs: string,
+    userId: string,
+  ): Promise<unknown> {
+    let args: Record<string, unknown> = {};
+    try {
+      args = rawArgs ? JSON.parse(rawArgs) : {};
+    } catch {
+      return { error: "invalid tool arguments" };
+    }
+    const range: DateRange = {
+      from: asString(args.from),
+      to: asString(args.to),
+    };
+    const bucket = asBucket(args.bucket);
+
+    switch (name) {
+      case "get_period_status":
+        return this.tools.getPeriodStatus(userId);
+      case "get_spend_by_bucket":
+        return this.tools.getSpendByBucket(userId, range, bucket);
+      case "get_spend_by_category":
+        return this.tools.getSpendByCategory(
+          userId,
+          range,
+          bucket,
+          asNumber(args.limit),
+        );
+      case "get_income":
+        return this.tools.getIncome(userId, range);
+      case "get_recent_expenses":
+        return this.tools.getRecentExpenses(userId, {
+          limit: asNumber(args.limit),
+          category: asString(args.category),
+          range: args.from || args.to ? range : undefined,
+        });
+      case "get_recurring_rules":
+        return this.tools.getRecurringRules(userId);
+      default:
+        return { error: `unknown tool: ${name}` };
+    }
+  }
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+function asNumber(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+function asBucket(v: unknown): Bucket | undefined {
+  return typeof v === "string" && (BUCKETS as readonly string[]).includes(v)
+    ? (v as Bucket)
+    : undefined;
+}
+
+const RANGE_PROPS = {
+  from: {
+    type: "string",
+    description: "ISO start date (inclusive). Omit for the current cycle.",
+  },
+  to: {
+    type: "string",
+    description: "ISO end date (exclusive). Omit for the current cycle.",
+  },
+} as const;
+
+const BUCKET_PROP = {
+  bucket: {
+    type: "string",
+    enum: ["NEEDS", "WANTS", "SAVINGS"],
+    description: "Optional 50/30/20 bucket filter.",
+  },
+} as const;
+
+const TOOL_SCHEMAS: OpenAI.Chat.Completions.ChatCompletionTool[] = [
+  {
+    type: "function",
+    function: {
+      name: "get_period_status",
+      description:
+        "Current-cycle budget health: per-bucket budget/spent/remaining/percent, days left, and effective income. Use for overall status and affordability checks.",
+      parameters: { type: "object", properties: {} },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_spend_by_bucket",
+      description:
+        "Total spend per bucket over a date range (defaults to the current cycle). Pass a bucket to scope to one.",
+      parameters: {
+        type: "object",
+        properties: { ...RANGE_PROPS, ...BUCKET_PROP },
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_spend_by_category",
+      description:
+        "Top spending categories over a date range (defaults to the current cycle), highest first. Optional bucket filter and limit.",
+      parameters: {
+        type: "object",
+        properties: {
+          ...RANGE_PROPS,
+          ...BUCKET_PROP,
+          limit: { type: "number", description: "Max categories (default 5)." },
+        },
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_income",
+      description:
+        "Total income logged over a date range (defaults to the current cycle).",
+      parameters: { type: "object", properties: { ...RANGE_PROPS } },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_recent_expenses",
+      description:
+        "Most recent expenses, newest first. Optional category name and date range. Use for 'last few spends' or 'when did I last spend on X'.",
+      parameters: {
+        type: "object",
+        properties: {
+          ...RANGE_PROPS,
+          category: {
+            type: "string",
+            description: "Optional category name to filter by.",
+          },
+          limit: { type: "number", description: "Max rows (default 10)." },
+        },
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_recurring_rules",
+      description:
+        "The user's active recurring income/expense rules (amount, day of month, bucket, category).",
+      parameters: { type: "object", properties: {} },
+    },
+  },
+];

--- a/src/data/ai/budgetParserPrompt.ts
+++ b/src/data/ai/budgetParserPrompt.ts
@@ -21,7 +21,7 @@ ${categoryList}
 
 ### OUTPUT (strict JSON, no prose):
 {
-  "intent": "EXPENSE | INCOME | UNDO | STATUS | RECURRING | UNKNOWN",
+  "intent": "EXPENSE | INCOME | UNDO | STATUS | RECURRING | QUERY | UNKNOWN",
   "amount": <number>,            // the spend/income amount; omit if none
   "currency": "INR",
   "category": "<best category>", // prefer one from the list above; else propose a short new one
@@ -57,7 +57,13 @@ ${categoryList}
    - "netflix 199 every month on 5th" → { "intent":"RECURRING", "recurringKind":"EXPENSE", "amount":199, "dayOfMonth":5, "category":"Subscriptions", "bucket":"WANTS", "note":"netflix", "confidence":0.9 }
    - "salary 50000 on 25th monthly" → { "intent":"RECURRING", "recurringKind":"INCOME", "amount":50000, "dayOfMonth":25, "note":"salary", "confidence":0.9 }
    - Cap dayOfMonth at 28. Use EXPENSE intent (not RECURRING) for a one-off spend with no "every month".
-6. UNKNOWN — social/non-financial or unintelligible.
+6. QUERY — user ASKS a question about their own spending/income/budget that needs their data to answer. This is a question, NOT a statement of spending.
+   - Spending questions: "how much did I spend on food last week?", "what's my biggest expense this month?", "evide poyi ee maasathe panam?" ("where did this month's money go?").
+   - Comparisons/trends: "am I spending more than last month?", "how's my wants vs last month?".
+   - Affordability: "can I afford a 5000 phone?", "should I buy this?".
+   - { "intent":"QUERY", "confidence":0.9 }
+   - Boundary: a plain overall health check ("status", "how much is left") is STATUS, handled instantly. A statement that logs money ("chai 30", "paid 500") is EXPENSE — never QUERY. Only route a genuine information-seeking question to QUERY.
+7. UNKNOWN — social/non-financial or unintelligible.
    - "hi", "thanks", "what can you do".
    - { "intent":"UNKNOWN", "confidence":0.9, "conversational_response":"Hi! Text me a spend like \\"chai 30\\" and I'll track it." }
 

--- a/src/data/repositories/PrismaExpenseRepository.ts
+++ b/src/data/repositories/PrismaExpenseRepository.ts
@@ -1,7 +1,9 @@
-import { Bucket, Expense, PrismaClient } from "@prisma/client";
+import { Bucket, Expense, Prisma, PrismaClient } from "@prisma/client";
 import {
   CreateExpenseDTO,
   IExpenseRepository,
+  RecentExpenseFilter,
+  RecentExpenseRow,
 } from "../../domain/repositories/IExpenseRepository";
 
 export class PrismaExpenseRepository implements IExpenseRepository {
@@ -104,6 +106,83 @@ export class PrismaExpenseRepository implements IExpenseRepository {
         ? (nameById.get(g.categoryId) ?? "Other")
         : "Uncategorized",
       total: Number(g._sum.amount ?? 0),
+    }));
+  }
+
+  async categoryTotals(
+    userId: string,
+    from: Date,
+    to: Date,
+    bucket: Bucket | null,
+    limit: number,
+  ): Promise<Array<{ name: string; total: number }>> {
+    const groups = await this.prisma.expense.groupBy({
+      by: ["categoryId"],
+      where: {
+        userId,
+        isDeleted: false,
+        date: { gte: from, lt: to },
+        ...(bucket ? { bucket } : {}),
+      },
+      _sum: { amount: true },
+      orderBy: { _sum: { amount: "desc" } },
+      take: limit,
+    });
+
+    const ids = groups
+      .map((g) => g.categoryId)
+      .filter((id): id is string => id !== null);
+    const categories = await this.prisma.category.findMany({
+      where: { id: { in: ids } },
+    });
+    const nameById = new Map(categories.map((c) => [c.id, c.name]));
+
+    return groups.map((g) => ({
+      name: g.categoryId
+        ? (nameById.get(g.categoryId) ?? "Other")
+        : "Uncategorized",
+      total: Number(g._sum.amount ?? 0),
+    }));
+  }
+
+  async findRecent(
+    userId: string,
+    opts: RecentExpenseFilter,
+  ): Promise<RecentExpenseRow[]> {
+    const where: Prisma.ExpenseWhereInput = { userId, isDeleted: false };
+
+    if (opts.categoryName) {
+      const category = await this.prisma.category.findFirst({
+        where: {
+          name: { equals: opts.categoryName, mode: "insensitive" },
+          OR: [{ userId: null }, { userId }],
+        },
+      });
+      // Unknown category → no matches rather than ignoring the filter.
+      if (!category) return [];
+      where.categoryId = category.id;
+    }
+
+    if (opts.from || opts.to) {
+      where.date = {
+        ...(opts.from ? { gte: opts.from } : {}),
+        ...(opts.to ? { lt: opts.to } : {}),
+      };
+    }
+
+    const rows = await this.prisma.expense.findMany({
+      where,
+      orderBy: { date: "desc" },
+      take: opts.limit,
+      include: { category: true },
+    });
+
+    return rows.map((r) => ({
+      date: r.date,
+      amount: Number(r.amount),
+      bucket: r.bucket,
+      categoryName: r.category?.name ?? "Uncategorized",
+      note: r.note,
     }));
   }
 

--- a/src/domain/entities/ParsedData.ts
+++ b/src/domain/entities/ParsedData.ts
@@ -11,6 +11,7 @@ export const PARSED_INTENTS = [
   "UNDO",
   "STATUS",
   "RECURRING",
+  "QUERY",
   "UNKNOWN",
 ] as const;
 export type ParsedIntent = (typeof PARSED_INTENTS)[number];

--- a/src/domain/repositories/IExpenseRepository.ts
+++ b/src/domain/repositories/IExpenseRepository.ts
@@ -41,5 +41,35 @@ export interface IExpenseRepository {
     monthEnd: Date,
     limit: number,
   ): Promise<Array<{ name: string; total: number }>>;
+  // Top spending categories over an arbitrary [from, to) range, optionally
+  // scoped to one bucket. Generalizes topCategoriesForMonth for Q&A.
+  categoryTotals(
+    userId: string,
+    from: Date,
+    to: Date,
+    bucket: Bucket | null,
+    limit: number,
+  ): Promise<Array<{ name: string; total: number }>>;
+  // Recent non-deleted expenses, newest first, with optional category-name and
+  // date-range filters. For conversational Q&A ("last few spends on food").
+  findRecent(
+    userId: string,
+    opts: RecentExpenseFilter,
+  ): Promise<RecentExpenseRow[]>;
   softDelete(id: string): Promise<void>;
+}
+
+export interface RecentExpenseFilter {
+  limit: number;
+  categoryName?: string | undefined;
+  from?: Date | undefined;
+  to?: Date | undefined;
+}
+
+export interface RecentExpenseRow {
+  date: Date;
+  amount: number;
+  bucket: Bucket;
+  categoryName: string;
+  note: string | null;
 }

--- a/src/domain/services/IFinancialDataTools.ts
+++ b/src/domain/services/IFinancialDataTools.ts
@@ -1,0 +1,77 @@
+import { Bucket } from "@prisma/client";
+
+// Read-only data accessors the query agent calls as tools. Each is scoped to a
+// single user (userId is bound server-side, never supplied by the model). All
+// dates are ISO strings on the wire; ranges default to the current budget cycle.
+
+export interface DateRange {
+  from?: string | undefined; // ISO date; defaults to current period start
+  to?: string | undefined; // ISO date (exclusive); defaults to current period end
+}
+
+export interface BucketStatus {
+  bucket: Bucket;
+  budget: number;
+  spent: number;
+  remaining: number;
+  pct: number;
+}
+
+export interface PeriodStatus {
+  currency: string;
+  periodStart: string;
+  periodEnd: string;
+  day: number;
+  daysInPeriod: number;
+  remainingDays: number;
+  monthlyIncome: number; // effective income the budget is computed on
+  incomeLogged: number;
+  buckets: BucketStatus[];
+}
+
+export interface CategoryTotal {
+  name: string;
+  total: number;
+}
+
+export interface RecentExpense {
+  date: string;
+  amount: number;
+  bucket: Bucket;
+  category: string;
+  note: string | null;
+}
+
+export interface RecurringRuleSummary {
+  kind: string;
+  amount: number;
+  dayOfMonth: number;
+  bucket: string | null;
+  category: string | null;
+  note: string | null;
+}
+
+export interface IFinancialDataTools {
+  getPeriodStatus(userId: string): Promise<PeriodStatus>;
+  getSpendByBucket(
+    userId: string,
+    range: DateRange,
+    bucket?: Bucket,
+  ): Promise<Array<{ bucket: Bucket; total: number }>>;
+  getSpendByCategory(
+    userId: string,
+    range: DateRange,
+    bucket?: Bucket,
+    limit?: number,
+  ): Promise<CategoryTotal[]>;
+  getIncome(userId: string, range: DateRange): Promise<{ total: number }>;
+  getRecentExpenses(
+    userId: string,
+    opts: {
+      limit?: number | undefined;
+      category?: string | undefined;
+      range?: DateRange | undefined;
+    },
+  ): Promise<RecentExpense[]>;
+  getRecurringRules(userId: string): Promise<RecurringRuleSummary[]>;
+}

--- a/src/domain/services/IFinancialQueryAgent.ts
+++ b/src/domain/services/IFinancialQueryAgent.ts
@@ -1,0 +1,27 @@
+import { ConversationTurn } from "./IAiParser";
+
+// Context the query agent needs to ground its answer. The agent itself is
+// read-only: it calls IFinancialDataTools to fetch real numbers and composes a
+// natural-language reply. It never writes/edits/deletes.
+export interface QueryAgentContext {
+  userId: string;
+  currency: string;
+  locale: string;
+  payday: number;
+  monthlyIncome: number; // expected salary (a floor); actual income may exceed it
+  now: Date;
+  period: {
+    start: string; // ISO
+    end: string; // ISO (exclusive)
+    day: number;
+    daysInPeriod: number;
+    remainingDays: number;
+  };
+  history?: ConversationTurn[] | undefined;
+}
+
+export interface IFinancialQueryAgent {
+  // Returns a Telegram-Markdown answer. Throws on provider/loop failure so the
+  // caller can degrade to a friendly fallback.
+  answer(question: string, ctx: QueryAgentContext): Promise<string>;
+}

--- a/src/presentation/controllers/TelegramWebhookController.ts
+++ b/src/presentation/controllers/TelegramWebhookController.ts
@@ -8,6 +8,8 @@ import { TelegramMediaService } from "../../data/messaging/TelegramMediaService"
 import { GeminiParser } from "../../data/ai/GeminiParser";
 import { OpenAIParser } from "../../data/ai/OpenAIParser";
 import { FallbackAiParser } from "../../data/ai/FallbackAiParser";
+import { OpenAiQueryAgent } from "../../data/ai/OpenAiQueryAgent";
+import { FinancialDataTools } from "../../application/use-cases/query/FinancialDataTools";
 import { SarvamTranscriptionService } from "../../data/ai/SarvamTranscriptionService";
 import { PrismaUserRepository } from "../../data/repositories/PrismaUserRepository";
 import { PrismaExpenseRepository } from "../../data/repositories/PrismaExpenseRepository";
@@ -63,6 +65,18 @@ const nudgeRepository = new PrismaNudgeRepository(prisma);
 const processedMessageRepository = new PrismaProcessedMessageRepository(prisma);
 const conversationRepository = new PrismaConversationRepository();
 
+// Read-only conversational Q&A agent (QUERY intent). Reuses the repositories +
+// budget math; can only read, never writes.
+const financialDataTools = new FinancialDataTools(
+  userRepository,
+  expenseRepository,
+  incomeRepository,
+  budgetConfigRepository,
+  recurringRuleRepository,
+  categoryRepository,
+);
+const queryAgent = new OpenAiQueryAgent(financialDataTools);
+
 const processIncomingMessage = new ProcessIncomingMessageUseCase(
   aiParser,
   userRepository,
@@ -74,6 +88,7 @@ const processIncomingMessage = new ProcessIncomingMessageUseCase(
   recurringRuleRepository,
   conversationRepository,
   messageService,
+  queryAgent,
 );
 
 const processVoiceMessage = new ProcessVoiceMessageUseCase(


### PR DESCRIPTION
## Why

The bot was a fixed **6-intent classifier** — any real question ("how much did I spend on food?", "can I afford a ₹5000 phone?", "biggest expense?") fell to `UNKNOWN` → a canned reply with **no access to the user's data**. The data + math to answer already existed; they just weren't reachable conversationally.

## What (hybrid, read-only — as scoped)

Keep the cheap deterministic classifier for the hot write paths. Add **one `QUERY` intent** that routes information-seeking questions to a **read-only tool-calling agent** that fetches real figures and composes a grounded answer.

- `ParsedData` / shared prompt / Gemini schema: add `QUERY` (questions, never statements that log money; plain "status" stays the fast `STATUS` path)
- `IFinancialDataTools` + `FinancialDataTools`: read-only tools reusing the existing repos + `budgetMath` — period status, spend by bucket/category, income, recent expenses, recurring rules. `userId` is bound server-side, never from model args.
- 2 new expense repo reads: `categoryTotals` (arbitrary range + optional bucket), `findRecent` (category/date filters)
- `OpenAiQueryAgent`: `gpt-4o-mini` function-calling loop (cap 5 rounds), Telegram Markdown answers; "can I afford X" is composed from primitives (no bespoke tool)
- `QueryProcessor`: `QUERY` → agent, friendly fallback on any failure; registered **before** `FallbackProcessor`

## Scope discipline

- **Read-only**: no log/edit/delete tools — writes stay on the deterministic confidence-confirm path.
- Only `QUERY` messages hit the agent (cost/latency contained); EXPENSE/INCOME/STATUS/UNDO/RECURRING unchanged.
- No schema/migration (new read queries only). No web change.

## Tests

`pnpm build` ✓ · `pnpm lint` ✓ · `pnpm test:unit` ✓ (72 passing). New specs: `FinancialDataTools` (bucket/range/category math) and `QueryProcessor` (delegates on QUERY; error → fallback). Regression specs (chai 30 → EXPENSE, status → STATUS, hi → UNKNOWN) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)