### PR TITLE
feat(onboarding): wizard + dosage-aware reminders (PR B)

### DIFF
--- a/src/application/interfaces/IMessagingPlatform.ts
+++ b/src/application/interfaces/IMessagingPlatform.ts
@@ -8,14 +8,26 @@ export interface InlineButton {
   title: string; // display text
 }
 
+// Inline buttons are laid out as rows: InlineButton[][] (each inner array is one
+// row). A single-row keyboard is just [[...]].
+export type InlineButtonRows = InlineButton[][];
+
 export interface IMessagingPlatform {
   sendMessage(payload: SendMessagePayload): Promise<string>;
   sendTypingIndicator(platformUserId: string): Promise<void>;
   sendInteractiveMessage(
     to: string,
     body: string,
-    buttons: InlineButton[],
+    rows: InlineButtonRows,
   ): Promise<string>;
+  // Edit an existing message's text + keyboard in place (for multi-select
+  // toggles). No-op if the platform can't edit.
+  editInteractiveMessage?(
+    to: string,
+    messageId: string,
+    body: string,
+    rows: InlineButtonRows,
+  ): Promise<void>;
   // Optional: ack a button press (Telegram: answerCallbackQuery)
   acknowledgeInteraction?(interactionId: string): Promise<void>;
 }

--- a/src/application/use-cases/ProcessIncomingMessage.spec.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.spec.ts
@@ -52,6 +52,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
     };
     categoryRepository = {
       findAllForUser: vi.fn().mockResolvedValue([]),
+      cloneGroupsForUser: vi.fn().mockResolvedValue(5),
       findByNameForUser: vi.fn().mockResolvedValue(null),
       findById: vi
         .fn()
@@ -92,6 +93,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
     messageService = {
       sendMessage: vi.fn().mockResolvedValue("msg-id-123"),
       sendInteractiveMessage: vi.fn().mockResolvedValue("msg-id-456"),
+      editInteractiveMessage: vi.fn().mockResolvedValue(undefined),
       sendTypingIndicator: vi.fn(),
     };
     queryAgent = { answer: vi.fn().mockResolvedValue("agent answer") };
@@ -111,24 +113,27 @@ describe("ProcessIncomingMessage (budget flow)", () => {
     );
   });
 
-  it("onboards a new user from their income number and shows the 50/30/20 split", async () => {
+  it("captures income, shows the split, and moves to category selection", async () => {
     userRepository.findByTelegramId.mockResolvedValue(newUser);
+    budgetConfigRepository.findByUserId.mockResolvedValue(null);
 
     await useCase.execute({ platformUserId: "123", textMessage: "50000" });
 
-    expect(userRepository.update).toHaveBeenCalledWith("u1", {
-      monthlyIncome: 50000,
-      hasOnboarded: true,
-    });
+    expect(userRepository.update).toHaveBeenCalledWith(
+      "u1",
+      expect.objectContaining({
+        monthlyIncome: 50000,
+        onboardingStep: "PICK_GROUPS",
+      }),
+    );
     expect(budgetConfigRepository.create).toHaveBeenCalledWith({
       userId: "u1",
     });
     expect(aiParser.parseText).not.toHaveBeenCalled();
-    const body = messageService.sendMessage.mock.calls[0][0].body;
-    expect(body).toContain("monthly plan");
+    const [, body, rows] = messageService.sendInteractiveMessage.mock.calls[0];
     expect(body).toContain("25,000"); // Needs
     expect(body).toContain("15,000"); // Wants
-    expect(body).toContain("10,000"); // Savings
+    expect(rows.flat().some((b: any) => b.id === "ob:done")).toBe(true);
   });
 
   it("records a confident expense and shows remaining bucket budget", async () => {
@@ -178,10 +183,9 @@ describe("ProcessIncomingMessage (budget flow)", () => {
 
     expect(parseLogRepository.create).toHaveBeenCalled();
     expect(expenseRepository.create).not.toHaveBeenCalled();
-    const [, body, buttons] =
-      messageService.sendInteractiveMessage.mock.calls[0];
+    const [, body, rows] = messageService.sendInteractiveMessage.mock.calls[0];
     expect(body).toContain("which bucket");
-    expect(buttons.map((b: any) => b.id)).toEqual([
+    expect(rows.flat().map((b: any) => b.id)).toEqual([
       "bkt:plog1:NEEDS",
       "bkt:plog1:WANTS",
       "bkt:plog1:SAVINGS",

--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -22,6 +22,7 @@ import {
 import { ConfirmBucketProcessor } from "./processors/ConfirmBucketProcessor";
 import { RecurringConfirmProcessor } from "./processors/RecurringConfirmProcessor";
 import { OnboardingProcessor } from "./processors/OnboardingProcessor";
+import { SettingsProcessor } from "./processors/SettingsProcessor";
 import { StatusProcessor } from "./processors/StatusProcessor";
 import { ReportProcessor } from "./processors/ReportProcessor";
 import { UndoProcessor } from "./processors/UndoProcessor";
@@ -36,6 +37,9 @@ export interface ProcessIncomingMessageInput {
   textMessage: string;
   platformUsername?: string | undefined;
   replyToMessageId?: string | undefined;
+  // The message_id of the inline-keyboard message, when this is a button press —
+  // lets processors edit that message in place (e.g. multi-select toggles).
+  callbackMessageId?: string | undefined;
 }
 
 export interface ProcessIncomingMessageOutput {
@@ -81,8 +85,10 @@ export class ProcessIncomingMessageUseCase {
       new OnboardingProcessor(
         userRepository,
         budgetConfigRepository,
+        categoryRepository,
         messageService,
       ),
+      new SettingsProcessor(userRepository, messageService),
       new StatusProcessor(
         expenseRepository,
         budgetConfigRepository,
@@ -168,6 +174,7 @@ export class ProcessIncomingMessageUseCase {
       platformUserId: payload.platformUserId,
       textMessage: payload.textMessage,
       replyToMessageId: payload.replyToMessageId,
+      callbackMessageId: payload.callbackMessageId,
       conversationHistory: history,
     };
 

--- a/src/application/use-cases/SendBudgetNudges.spec.ts
+++ b/src/application/use-cases/SendBudgetNudges.spec.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SendBudgetNudgesUseCase } from "./SendBudgetNudges";
 
-const user = { id: "u1", telegramId: "123", monthlyIncome: 50000 };
+const user = {
+  id: "u1",
+  telegramId: "123",
+  monthlyIncome: 50000,
+  payday: 1,
+  notificationDosage: "GENTLE",
+};
 
 describe("SendBudgetNudges", () => {
   let userRepository: any;
@@ -94,5 +100,33 @@ describe("SendBudgetNudges", () => {
 
     expect(nudgeRepository.recordSentIfNew).not.toHaveBeenCalled();
     expect(messageService.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing when the user's dosage is OFF", async () => {
+    userRepository.findOnboardedWithTelegram.mockResolvedValue([
+      { ...user, notificationDosage: "OFF" },
+    ]);
+    setSpend({ WANTS: 16200 });
+
+    const { sent } = await useCase.execute();
+
+    expect(sent).toBe(0);
+    expect(messageService.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("adds a daily check-in summary for RELENTLESS on top of alerts", async () => {
+    userRepository.findOnboardedWithTelegram.mockResolvedValue([
+      { ...user, notificationDosage: "RELENTLESS" },
+    ]);
+    setSpend({ WANTS: 16200 }); // over → OVER alert + daily CHECKIN
+
+    const { sent } = await useCase.execute();
+
+    expect(sent).toBe(2);
+    const kinds = nudgeRepository.recordSentIfNew.mock.calls.map(
+      (c: any) => c[2],
+    );
+    expect(kinds).toContain("OVER");
+    expect(kinds).toContain("CHECKIN");
   });
 });

--- a/src/application/use-cases/SendBudgetNudges.ts
+++ b/src/application/use-cases/SendBudgetNudges.ts
@@ -1,4 +1,4 @@
-import { Bucket } from "@prisma/client";
+import { Bucket, NotificationDosage } from "@prisma/client";
 import { IUserRepository } from "../../domain/repositories/IUserRepository";
 import { IExpenseRepository } from "../../domain/repositories/IExpenseRepository";
 import { IBudgetConfigRepository } from "../../domain/repositories/IBudgetConfigRepository";
@@ -19,15 +19,23 @@ import {
 const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
 // Savings overspend is good, not a leak — only nudge the spending buckets.
 const WATCHED: Bucket[] = ["NEEDS", "WANTS"];
-const WARN_THRESHOLD = 0.8;
+
+// Today as "YYYY-MM-DD" — the idempotency key for daily kinds (CHECKIN, and the
+// repeated OVER for RELENTLESS) so they fire once per day, not on every run.
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 export interface SendBudgetNudgesResult {
   sent: number;
 }
 
-// Proactively warns users before they blow a bucket (80%) and once they go over.
-// Each nudge is sent at most once per bucket per month (idempotency via
-// INudgeRepository), so a daily run does not spam. Build-brief step 9.
+// Proactive reminders, gated by each user's notificationDosage:
+//   OFF        → nothing.
+//   GENTLE     → WARN_80 + OVER, once per bucket per cycle (the original behavior).
+//   AGGRESSIVE → adds WARN_50 + a once-a-day CHECKIN summary.
+//   RELENTLESS → as AGGRESSIVE, and OVER repeats daily until they're back under.
+// Idempotency via INudgeRepository keeps a single daily run from spamming.
 export class SendBudgetNudgesUseCase {
   constructor(
     private readonly userRepository: IUserRepository,
@@ -58,12 +66,17 @@ export class SendBudgetNudgesUseCase {
     telegramId: string | null;
     monthlyIncome: unknown;
     payday: number;
+    notificationDosage: NotificationDosage;
   }): Promise<number> {
-    if (!user.telegramId) return 0;
+    const dosage = user.notificationDosage;
+    if (!user.telegramId || dosage === "OFF") return 0;
+
+    const loud = dosage === "AGGRESSIVE" || dosage === "RELENTLESS";
 
     // Per-user payday cycle.
     const { start, end } = currentBudgetPeriod(user.payday);
     const cycleKey = periodKey(user.payday);
+    const dayKey = todayKey();
     const { day, daysInPeriod } = periodDayInfo(user.payday);
     const daysLeft = daysInPeriod - day;
 
@@ -78,6 +91,7 @@ export class SendBudgetNudgesUseCase {
       DEFAULT_SPLIT;
 
     let sent = 0;
+    const summary: string[] = [];
     for (const bucket of WATCHED) {
       const budget = bucketBudget(income, config, bucket);
       if (budget <= 0) continue;
@@ -89,35 +103,73 @@ export class SendBudgetNudgesUseCase {
         end,
       );
       const meta = BUCKET_META[bucket];
+      summary.push(`${meta.emoji} ${meta.label} ${pctSpent(spent, budget)}%`);
 
       if (spent > budget) {
-        const isNew = await this.nudgeRepository.recordSentIfNew(
-          user.id,
-          bucket,
-          "OVER",
-          cycleKey,
-        );
-        if (isNew) {
+        // RELENTLESS repeats the over-budget alert daily; others once per cycle.
+        const overKey = dosage === "RELENTLESS" ? dayKey : cycleKey;
+        if (
+          await this.nudgeRepository.recordSentIfNew(
+            user.id,
+            bucket,
+            "OVER",
+            overKey,
+          )
+        ) {
           await this.send(
             user.telegramId,
-            `🔴 You've gone over ${meta.label} by ${formatMoney(spent - budget)} this month.`,
+            `🔴 You've gone over ${meta.label} by ${formatMoney(spent - budget)} this cycle.`,
           );
           sent++;
         }
-      } else if (spent / budget >= WARN_THRESHOLD) {
-        const isNew = await this.nudgeRepository.recordSentIfNew(
-          user.id,
-          bucket,
-          "WARN_80",
-          cycleKey,
-        );
-        if (isNew) {
+      } else if (spent / budget >= 0.8) {
+        if (
+          await this.nudgeRepository.recordSentIfNew(
+            user.id,
+            bucket,
+            "WARN_80",
+            cycleKey,
+          )
+        ) {
           await this.send(
             user.telegramId,
             `⚠️ Heads up — ${meta.label} at ${pctSpent(spent, budget)}% (${formatMoney(spent)} of ${formatMoney(budget)}) with ${daysLeft} days left.`,
           );
           sent++;
         }
+      } else if (loud && spent / budget >= 0.5) {
+        if (
+          await this.nudgeRepository.recordSentIfNew(
+            user.id,
+            bucket,
+            "WARN_50",
+            cycleKey,
+          )
+        ) {
+          await this.send(
+            user.telegramId,
+            `👀 ${meta.label} is halfway — ${pctSpent(spent, budget)}% used with ${daysLeft} days left.`,
+          );
+          sent++;
+        }
+      }
+    }
+
+    // Aggressive/Relentless also get a once-a-day check-in summary.
+    if (loud && summary.length > 0) {
+      if (
+        await this.nudgeRepository.recordSentIfNew(
+          user.id,
+          "NEEDS",
+          "CHECKIN",
+          dayKey,
+        )
+      ) {
+        await this.send(
+          user.telegramId,
+          `📊 Daily check-in — ${summary.join(" · ")} · ${daysLeft} days left.`,
+        );
+        sent++;
       }
     }
     return sent;

--- a/src/application/use-cases/processors/ExpenseProcessor.ts
+++ b/src/application/use-cases/processors/ExpenseProcessor.ts
@@ -103,9 +103,11 @@ export class ExpenseProcessor implements MessageProcessor {
       context.platformUserId,
       body,
       [
-        { id: `bkt:${log.id}:NEEDS`, title: "🏠 Need" },
-        { id: `bkt:${log.id}:WANTS`, title: "🎯 Want" },
-        { id: `bkt:${log.id}:SAVINGS`, title: "💰 Savings" },
+        [
+          { id: `bkt:${log.id}:NEEDS`, title: "🏠 Need" },
+          { id: `bkt:${log.id}:WANTS`, title: "🎯 Want" },
+          { id: `bkt:${log.id}:SAVINGS`, title: "💰 Savings" },
+        ],
       ],
     );
     return { response: body, parsed };

--- a/src/application/use-cases/processors/MessageProcessor.ts
+++ b/src/application/use-cases/processors/MessageProcessor.ts
@@ -8,6 +8,7 @@ export interface ProcessContext {
   textMessage: string;
   parsed?: ParsedData | undefined;
   replyToMessageId?: string | undefined;
+  callbackMessageId?: string | undefined;
   conversationHistory?: ConversationTurn[] | undefined;
 }
 

--- a/src/application/use-cases/processors/OnboardingProcessor.spec.ts
+++ b/src/application/use-cases/processors/OnboardingProcessor.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { OnboardingProcessor } from "./OnboardingProcessor";
+
+describe("OnboardingProcessor (wizard)", () => {
+  let userRepository: any;
+  let budgetConfigRepository: any;
+  let categoryRepository: any;
+  let messageService: any;
+  let processor: OnboardingProcessor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userRepository = { update: vi.fn().mockResolvedValue({}) };
+    budgetConfigRepository = {
+      findByUserId: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({}),
+    };
+    categoryRepository = { cloneGroupsForUser: vi.fn().mockResolvedValue(12) };
+    messageService = {
+      sendMessage: vi.fn().mockResolvedValue("m1"),
+      sendInteractiveMessage: vi.fn().mockResolvedValue("m2"),
+      editInteractiveMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    processor = new OnboardingProcessor(
+      userRepository,
+      budgetConfigRepository,
+      categoryRepository,
+      messageService,
+    );
+  });
+
+  const ctx = (over: any) => ({
+    user: { id: "u1", hasOnboarded: false, monthlyIncome: null, ...over.user },
+    platformUserId: "123",
+    textMessage: over.textMessage,
+    callbackMessageId: over.callbackMessageId,
+  });
+
+  it("handles /start, un-onboarded users, and ob: callbacks", () => {
+    expect(processor.canHandle(ctx({ textMessage: "/start", user: {} }))).toBe(
+      true,
+    );
+    expect(processor.canHandle(ctx({ textMessage: "ob:done", user: {} }))).toBe(
+      true,
+    );
+    expect(
+      processor.canHandle(
+        ctx({ textMessage: "anything", user: { hasOnboarded: true } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("captures income, creates the config, and shows the group keyboard", async () => {
+    await processor.process(ctx({ textMessage: "50000", user: {} }));
+
+    expect(userRepository.update).toHaveBeenCalledWith(
+      "u1",
+      expect.objectContaining({
+        monthlyIncome: 50000,
+        onboardingStep: "PICK_GROUPS",
+      }),
+    );
+    expect(budgetConfigRepository.create).toHaveBeenCalled();
+    const rows = messageService.sendInteractiveMessage.mock.calls[0][2];
+    expect(rows.flat().some((b: any) => b.id === "ob:done")).toBe(true);
+  });
+
+  it("toggles a group selection and edits the keyboard in place", async () => {
+    await processor.process(
+      ctx({
+        textMessage: "ob:grp:food",
+        callbackMessageId: "55",
+        user: {
+          onboardingStep: "PICK_GROUPS",
+          onboardingDraft: { income: 50000, groups: ["ess"] },
+        },
+      }),
+    );
+
+    expect(userRepository.update).toHaveBeenCalledWith("u1", {
+      onboardingDraft: { income: 50000, groups: ["ess", "food"] },
+    });
+    expect(messageService.editInteractiveMessage).toHaveBeenCalled();
+  });
+
+  it("on Done clones the selected groups and advances to dosage", async () => {
+    await processor.process(
+      ctx({
+        textMessage: "ob:done",
+        callbackMessageId: "55",
+        user: {
+          onboardingStep: "PICK_GROUPS",
+          onboardingDraft: { income: 50000, groups: ["ess", "save"] },
+        },
+      }),
+    );
+
+    expect(categoryRepository.cloneGroupsForUser).toHaveBeenCalledWith(
+      "u1",
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Essentials" }),
+        expect.objectContaining({ name: "Savings" }),
+      ]),
+    );
+    expect(userRepository.update).toHaveBeenCalledWith("u1", {
+      onboardingStep: "PICK_DOSAGE",
+    });
+    const editRows = messageService.editInteractiveMessage.mock.calls[0][3];
+    expect(editRows.flat().some((b: any) => b.id === "ob:dose:GENTLE")).toBe(
+      true,
+    );
+  });
+
+  it("finishes onboarding when a dosage is chosen", async () => {
+    await processor.process(
+      ctx({
+        textMessage: "ob:dose:AGGRESSIVE",
+        callbackMessageId: "55",
+        user: { onboardingStep: "PICK_DOSAGE" },
+      }),
+    );
+
+    expect(userRepository.update).toHaveBeenCalledWith("u1", {
+      hasOnboarded: true,
+      onboardingStep: null,
+      onboardingDraft: null,
+      notificationDosage: "AGGRESSIVE",
+    });
+  });
+});

--- a/src/application/use-cases/processors/OnboardingProcessor.ts
+++ b/src/application/use-cases/processors/OnboardingProcessor.ts
@@ -1,3 +1,4 @@
+import { NotificationDosage } from "@prisma/client";
 import {
   MessageProcessor,
   ProcessContext,
@@ -5,34 +6,68 @@ import {
 } from "./MessageProcessor";
 import { IUserRepository } from "../../../domain/repositories/IUserRepository";
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
-import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
-import { bucketBudget, formatMoney } from "../budgetMath";
+import {
+  CloneGroupInput,
+  ICategoryRepository,
+} from "../../../domain/repositories/ICategoryRepository";
+import {
+  IMessagingPlatform,
+  InlineButtonRows,
+} from "../../interfaces/IMessagingPlatform";
+import {
+  bucketBudget,
+  formatMoney,
+  suggestCategoryBudgets,
+  SelectedLeaf,
+} from "../budgetMath";
+import {
+  CATEGORY_TEMPLATE,
+  groupByKey,
+  GroupTemplate,
+} from "../../../domain/categoryTemplate";
 
 const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
 const MAX_INCOME = 100_000_000;
-
-// Matches a pure number (optionally ₹-prefixed, with grouping commas/decimals).
 const PURE_NUMBER_RE = /^\s*₹?\s*([\d,]+(?:\.\d+)?)\s*$/;
 
-// Drives first-run onboarding: greet → capture monthly income → create
-// BudgetConfig → show the 50/30/20 split. Runs before AI parsing.
+type Draft = { income?: number; groups?: string[] };
+
+const DOSAGE_LABEL: Record<NotificationDosage, string> = {
+  OFF: "No reminders",
+  GENTLE: "Gentle (1–2 a day)",
+  AGGRESSIVE: "Aggressive",
+  RELENTLESS: "Relentless",
+};
+
+// Multi-step onboarding wizard: greet → capture income → multi-select category
+// groups (auto-creating their children with suggested budgets) → pick a reminder
+// dosage. State lives in user.onboardingStep + user.onboardingDraft so it
+// survives across messages. Runs before AI parsing; also owns the "ob:" button
+// callbacks.
 export class OnboardingProcessor implements MessageProcessor {
   constructor(
     private readonly userRepository: IUserRepository,
     private readonly budgetConfigRepository: IBudgetConfigRepository,
+    private readonly categoryRepository: ICategoryRepository,
     private readonly messageService: IMessagingPlatform,
   ) {}
 
   canHandle(context: ProcessContext): boolean {
+    if (context.textMessage.startsWith("ob:")) return true;
     const normalized = context.textMessage.trim().toLowerCase();
-    const isStart = normalized === "start" || normalized === "/start";
-    return isStart || !context.user.hasOnboarded;
+    if (normalized === "start" || normalized === "/start") return true;
+    return !context.user.hasOnboarded;
   }
 
   async process(context: ProcessContext): Promise<ProcessOutput> {
     const { user, platformUserId, textMessage } = context;
+    const draft = ((user.onboardingDraft as Draft | null) ?? {}) as Draft;
 
-    // Already onboarded and just typed /start → friendly welcome-back.
+    if (textMessage.startsWith("ob:")) {
+      return this.handleCallback(context, draft);
+    }
+
+    // Already onboarded and typed /start → friendly welcome-back.
     if (user.hasOnboarded) {
       return this.reply(
         platformUserId,
@@ -40,46 +75,217 @@ export class OnboardingProcessor implements MessageProcessor {
       );
     }
 
-    // Awaiting income: a pure number captures it.
-    const match = textMessage.match(PURE_NUMBER_RE);
-    if (match && match[1]) {
-      const income = Number(match[1].replace(/,/g, ""));
+    const step = user.onboardingStep ?? "ASK_INCOME";
+
+    if (step === "ASK_INCOME") {
+      const match = textMessage.match(PURE_NUMBER_RE);
+      const income = match?.[1] ? Number(match[1].replace(/,/g, "")) : NaN;
       if (income > 0 && income <= MAX_INCOME) {
-        return this.onboard(user.id, platformUserId, income);
+        return this.captureIncome(user.id, platformUserId, income);
       }
+      await this.userRepository.update(user.id, {
+        onboardingStep: "ASK_INCOME",
+      });
+      return this.reply(
+        platformUserId,
+        `👋 Welcome! I help you track spending and stay on budget — just by chatting.\n\nFirst, what's your *monthly take-home income* (post-tax)? Send the number, e.g. 50000.`,
+      );
     }
 
-    // No income yet (start command, or a non-numeric first message) → ask.
-    return this.reply(
-      platformUserId,
-      `👋 Welcome! I help you track spending and stay on budget.\n\nWhat's your monthly income? (just send the number, e.g. 50000)`,
-    );
+    // Mid-wizard but the user typed instead of tapping → re-show the keyboard.
+    if (step === "PICK_GROUPS") {
+      await this.messageService.sendInteractiveMessage(
+        platformUserId,
+        groupPrompt(),
+        groupKeyboard(draft.groups ?? []),
+      );
+      return this.ack("PICK_GROUPS");
+    }
+    if (step === "PICK_DOSAGE") {
+      await this.messageService.sendInteractiveMessage(
+        platformUserId,
+        dosagePrompt(),
+        dosageKeyboard(),
+      );
+      return this.ack("PICK_DOSAGE");
+    }
+
+    return this.reply(platformUserId, `Send /start to set up your budget.`);
   }
 
-  private async onboard(
+  private async captureIncome(
     userId: string,
     platformUserId: string,
     income: number,
   ): Promise<ProcessOutput> {
+    const existingConfig =
+      await this.budgetConfigRepository.findByUserId(userId);
+    if (!existingConfig) await this.budgetConfigRepository.create({ userId });
+
+    const defaults = CATEGORY_TEMPLATE.filter((g) => g.defaultSelected).map(
+      (g) => g.key,
+    );
     await this.userRepository.update(userId, {
       monthlyIncome: income,
-      hasOnboarded: true,
+      onboardingStep: "PICK_GROUPS",
+      onboardingDraft: { income, groups: defaults },
     });
-    await this.budgetConfigRepository.create({ userId });
 
     const needs = bucketBudget(income, DEFAULT_SPLIT, "NEEDS");
     const wants = bucketBudget(income, DEFAULT_SPLIT, "WANTS");
     const savings = bucketBudget(income, DEFAULT_SPLIT, "SAVINGS");
+    const body = `Nice — on ${formatMoney(income)}/mo your 50/30/20 plan is:
+🏠 Needs ${formatMoney(needs)} · 🎯 Wants ${formatMoney(wants)} · 💰 Savings ${formatMoney(savings)}
 
-    const body = `Got it. Here's your monthly plan (50/30/20):
-🏠 Needs    ${formatMoney(needs)}
-🎯 Wants    ${formatMoney(wants)}
-💰 Savings  ${formatMoney(savings)}
+${groupPrompt()}`;
 
-Just text me what you spend — like "chai 30" or "auto 80".
-You can also send a voice note. Type /help anytime.`;
+    await this.messageService.sendInteractiveMessage(
+      platformUserId,
+      body,
+      groupKeyboard(defaults),
+    );
+    return this.ack("PICK_GROUPS");
+  }
 
-    return this.reply(platformUserId, body);
+  private async handleCallback(
+    context: ProcessContext,
+    draft: Draft,
+  ): Promise<ProcessOutput> {
+    const { user, platformUserId, textMessage, callbackMessageId } = context;
+    const [, action, value] = textMessage.split(":");
+
+    if (action === "grp" && value) {
+      const selected = new Set(draft.groups ?? []);
+      if (selected.has(value)) selected.delete(value);
+      else selected.add(value);
+      const groups = [...selected];
+      await this.userRepository.update(user.id, {
+        onboardingDraft: { ...draft, groups },
+      });
+      await this.edit(
+        platformUserId,
+        callbackMessageId,
+        groupPrompt(),
+        groupKeyboard(groups),
+      );
+      return this.ack("PICK_GROUPS");
+    }
+
+    if (action === "done") {
+      return this.finalizeGroups(context, draft);
+    }
+
+    if (action === "dose" && value) {
+      return this.finishOnboarding(context, value as NotificationDosage);
+    }
+
+    return this.reply(
+      platformUserId,
+      "Tap one of the buttons above to continue.",
+    );
+  }
+
+  private async finalizeGroups(
+    context: ProcessContext,
+    draft: Draft,
+  ): Promise<ProcessOutput> {
+    const { user, platformUserId, callbackMessageId } = context;
+    const income = draft.income ?? Number(user.monthlyIncome ?? 0);
+    const keys = draft.groups ?? [];
+    const groups = keys
+      .map(groupByKey)
+      .filter((g): g is GroupTemplate => Boolean(g));
+
+    if (groups.length === 0) {
+      await this.edit(
+        platformUserId,
+        callbackMessageId,
+        "Pick at least one group so I know what to track.",
+        groupKeyboard([]),
+      );
+      return this.ack("PICK_GROUPS");
+    }
+
+    const leaves: SelectedLeaf[] = groups.flatMap((g) =>
+      g.children.map((c) => ({
+        name: c.name,
+        bucket: c.bucket,
+        weight: c.weight,
+      })),
+    );
+    const budgets = suggestCategoryBudgets(income, DEFAULT_SPLIT, leaves);
+
+    const cloneInput: CloneGroupInput[] = groups.map((g) => ({
+      name: g.name,
+      bucket: g.bucket,
+      children: g.children.map((c) => ({
+        name: c.name,
+        bucket: c.bucket,
+        monthlyBudget: budgets.get(c.name),
+      })),
+    }));
+    const leafCount = await this.categoryRepository.cloneGroupsForUser(
+      user.id,
+      cloneInput,
+    );
+
+    await this.userRepository.update(user.id, {
+      onboardingStep: "PICK_DOSAGE",
+    });
+
+    const body = `✅ Set up ${leafCount} categories with suggested limits — tweak any of them later on the web.\n\n${dosagePrompt()}`;
+    await this.edit(platformUserId, callbackMessageId, body, dosageKeyboard());
+    return this.ack("PICK_DOSAGE");
+  }
+
+  private async finishOnboarding(
+    context: ProcessContext,
+    dosage: NotificationDosage,
+  ): Promise<ProcessOutput> {
+    const { user, platformUserId, callbackMessageId } = context;
+    const safeDosage: NotificationDosage = (
+      ["OFF", "GENTLE", "AGGRESSIVE", "RELENTLESS"] as NotificationDosage[]
+    ).includes(dosage)
+      ? dosage
+      : "OFF";
+
+    await this.userRepository.update(user.id, {
+      hasOnboarded: true,
+      onboardingStep: null,
+      onboardingDraft: null,
+      notificationDosage: safeDosage,
+    });
+
+    const body = `🎉 You're all set — reminders: *${DOSAGE_LABEL[safeDosage]}*.
+
+Just text me what you spend, like "chai 30" or "auto 80". Send a voice note too.
+• /status — how your budget's doing
+• /settings — change reminders
+Everything's editable on the web dashboard anytime.`;
+    await this.edit(platformUserId, callbackMessageId, body, []);
+    return { response: body, parsed: { intent: "UNKNOWN", confidence: 1 } };
+  }
+
+  private async edit(
+    to: string,
+    messageId: string | undefined,
+    body: string,
+    rows: InlineButtonRows,
+  ): Promise<void> {
+    if (messageId && this.messageService.editInteractiveMessage) {
+      await this.messageService.editInteractiveMessage(
+        to,
+        messageId,
+        body,
+        rows,
+      );
+      return;
+    }
+    if (rows.length > 0) {
+      await this.messageService.sendInteractiveMessage(to, body, rows);
+    } else {
+      await this.messageService.sendMessage({ to, body });
+    }
   }
 
   private async reply(
@@ -92,4 +298,49 @@ You can also send a voice note. Type /help anytime.`;
       parsed: { intent: "UNKNOWN", confidence: 1 },
     };
   }
+
+  // The reply text isn't user-facing here (the message was already sent/edited);
+  // it's bookkeeping for the use-case's conversation log.
+  private ack(step: string): ProcessOutput {
+    return {
+      response: `[onboarding:${step}]`,
+      parsed: { intent: "UNKNOWN", confidence: 1 },
+    };
+  }
+}
+
+function groupPrompt(): string {
+  return `Now tap the things you spend on (common ones are already ticked), then press *Done*:`;
+}
+
+function groupKeyboard(selectedKeys: string[]): InlineButtonRows {
+  const selected = new Set(selectedKeys);
+  const rows: InlineButtonRows = [];
+  for (let i = 0; i < CATEGORY_TEMPLATE.length; i += 2) {
+    rows.push(
+      CATEGORY_TEMPLATE.slice(i, i + 2).map((g) => ({
+        id: `ob:grp:${g.key}`,
+        title: `${selected.has(g.key) ? "✅" : "▫️"} ${g.name}`,
+      })),
+    );
+  }
+  rows.push([{ id: "ob:done", title: "Done ✅" }]);
+  return rows;
+}
+
+function dosagePrompt(): string {
+  return `Last thing — how should I keep you on track? (Change anytime with /settings.)`;
+}
+
+function dosageKeyboard(): InlineButtonRows {
+  return [
+    [
+      { id: "ob:dose:OFF", title: "😴 No reminders" },
+      { id: "ob:dose:GENTLE", title: "🔔 Gentle" },
+    ],
+    [
+      { id: "ob:dose:AGGRESSIVE", title: "⚡ Aggressive" },
+      { id: "ob:dose:RELENTLESS", title: "🔥 Relentless" },
+    ],
+  ];
 }

--- a/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
@@ -78,11 +78,10 @@ describe("RecurringSetupProcessor", () => {
         categoryId: "c1",
       }),
     );
-    const [, body, buttons] =
-      messageService.sendInteractiveMessage.mock.calls[0];
+    const [, body, rows] = messageService.sendInteractiveMessage.mock.calls[0];
     expect(body).toContain("Recurring set");
     expect(body).toContain("add it for this month");
-    expect(buttons.map((b: any) => b.id)).toEqual([
+    expect(rows.flat().map((b: any) => b.id)).toEqual([
       "rec:rr1:yes",
       "rec:rr1:no",
     ]);

--- a/src/application/use-cases/processors/RecurringSetupProcessor.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.ts
@@ -122,8 +122,10 @@ export class RecurringSetupProcessor implements MessageProcessor {
     if (now.getDate() >= dueDay) {
       const body = `${baseMsg}\n\nDay ${dayOfMonth} already passed this month — add it for this month now too?`;
       await this.messageService.sendInteractiveMessage(platformUserId, body, [
-        { id: `rec:${ruleId}:yes`, title: "✅ Add this month" },
-        { id: `rec:${ruleId}:no`, title: "No, next month" },
+        [
+          { id: `rec:${ruleId}:yes`, title: "✅ Add this month" },
+          { id: `rec:${ruleId}:no`, title: "No, next month" },
+        ],
       ]);
       return { response: body, parsed: { intent: "RECURRING", confidence: 1 } };
     }

--- a/src/application/use-cases/processors/SettingsProcessor.ts
+++ b/src/application/use-cases/processors/SettingsProcessor.ts
@@ -1,0 +1,100 @@
+import { NotificationDosage } from "@prisma/client";
+import {
+  MessageProcessor,
+  ProcessContext,
+  ProcessOutput,
+} from "./MessageProcessor";
+import { IUserRepository } from "../../../domain/repositories/IUserRepository";
+import {
+  IMessagingPlatform,
+  InlineButtonRows,
+} from "../../interfaces/IMessagingPlatform";
+import { formatMoney } from "../budgetMath";
+
+const DOSAGE_LABEL: Record<NotificationDosage, string> = {
+  OFF: "No reminders",
+  GENTLE: "Gentle (1–2 a day)",
+  AGGRESSIVE: "Aggressive",
+  RELENTLESS: "Relentless",
+};
+
+const VALID: NotificationDosage[] = [
+  "OFF",
+  "GENTLE",
+  "AGGRESSIVE",
+  "RELENTLESS",
+];
+
+// `/settings`: shows current income + reminder dosage and lets the user change
+// the dosage via buttons (`set:dose:<LEVEL>`). Deeper edits (categories, budgets)
+// live on the web dashboard. Runs before AI parsing.
+export class SettingsProcessor implements MessageProcessor {
+  constructor(
+    private readonly userRepository: IUserRepository,
+    private readonly messageService: IMessagingPlatform,
+  ) {}
+
+  canHandle(context: ProcessContext): boolean {
+    if (context.textMessage.startsWith("set:")) return true;
+    const normalized = context.textMessage
+      .trim()
+      .toLowerCase()
+      .replace(/^\//, "");
+    return normalized === "settings";
+  }
+
+  async process(context: ProcessContext): Promise<ProcessOutput> {
+    const { user, platformUserId, textMessage, callbackMessageId } = context;
+
+    if (textMessage.startsWith("set:dose:")) {
+      const level = textMessage.split(":")[2] as NotificationDosage;
+      const dosage = VALID.includes(level) ? level : "OFF";
+      await this.userRepository.update(user.id, {
+        notificationDosage: dosage,
+      });
+      const body = `✅ Reminders set to *${DOSAGE_LABEL[dosage]}*.`;
+      if (callbackMessageId && this.messageService.editInteractiveMessage) {
+        await this.messageService.editInteractiveMessage(
+          platformUserId,
+          callbackMessageId,
+          body,
+          [],
+        );
+      } else {
+        await this.messageService.sendMessage({ to: platformUserId, body });
+      }
+      return { response: body, parsed: { intent: "UNKNOWN", confidence: 1 } };
+    }
+
+    const current = user.notificationDosage;
+    const body = `⚙️ *Your settings*
+Income: ${formatMoney(Number(user.monthlyIncome ?? 0))}/mo
+Reminders: ${DOSAGE_LABEL[current]}
+
+Pick a reminder level (edit categories & budgets on the web):`;
+    await this.messageService.sendInteractiveMessage(
+      platformUserId,
+      body,
+      dosageKeyboard(current),
+    );
+    return { response: body, parsed: { intent: "UNKNOWN", confidence: 1 } };
+  }
+}
+
+function dosageKeyboard(current: NotificationDosage): InlineButtonRows {
+  const mark = (d: NotificationDosage, label: string) =>
+    `${current === d ? "✅ " : ""}${label}`;
+  return [
+    [
+      { id: "set:dose:OFF", title: mark("OFF", "😴 Off") },
+      { id: "set:dose:GENTLE", title: mark("GENTLE", "🔔 Gentle") },
+    ],
+    [
+      { id: "set:dose:AGGRESSIVE", title: mark("AGGRESSIVE", "⚡ Aggressive") },
+      {
+        id: "set:dose:RELENTLESS",
+        title: mark("RELENTLESS", "🔥 Relentless"),
+      },
+    ],
+  ];
+}

--- a/src/data/messaging/TelegramMessageService.ts
+++ b/src/data/messaging/TelegramMessageService.ts
@@ -1,7 +1,7 @@
 import {
   IMessagingPlatform,
   SendMessagePayload,
-  InlineButton,
+  InlineButtonRows,
 } from "../../application/interfaces/IMessagingPlatform";
 import { env } from "../../config/env";
 
@@ -41,11 +41,11 @@ export class TelegramMessageService implements IMessagingPlatform {
   async sendInteractiveMessage(
     to: string,
     body: string,
-    buttons: InlineButton[],
+    rows: InlineButtonRows,
   ): Promise<string> {
-    const inline_keyboard = [
-      buttons.map((b) => ({ text: b.title, callback_data: b.id })),
-    ];
+    const inline_keyboard = rows.map((row) =>
+      row.map((b) => ({ text: b.title, callback_data: b.id })),
+    );
     const res = await fetch(`${this.base}/sendMessage`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -64,6 +64,33 @@ export class TelegramMessageService implements IMessagingPlatform {
     }
     const data = (await res.json()) as { result?: { message_id?: number } };
     return String(data.result?.message_id ?? "");
+  }
+
+  async editInteractiveMessage(
+    to: string,
+    messageId: string,
+    body: string,
+    rows: InlineButtonRows,
+  ): Promise<void> {
+    const inline_keyboard = rows.map((row) =>
+      row.map((b) => ({ text: b.title, callback_data: b.id })),
+    );
+    const res = await fetch(`${this.base}/editMessageText`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: to,
+        message_id: Number(messageId),
+        text: body,
+        parse_mode: "Markdown",
+        reply_markup: { inline_keyboard },
+      }),
+    });
+    // Telegram returns 400 "message is not modified" on a no-op edit — ignore.
+    if (!res.ok) {
+      const err = await res.text().catch(() => "");
+      console.warn(`Telegram editMessageText ${res.status}: ${err}`);
+    }
   }
 
   async acknowledgeInteraction(callbackQueryId: string): Promise<void> {

--- a/src/data/repositories/PrismaUserRepository.ts
+++ b/src/data/repositories/PrismaUserRepository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, User } from "@prisma/client";
+import { Prisma, PrismaClient, User } from "@prisma/client";
 import {
   IUserRepository,
   CreateUserDTO,
@@ -30,6 +30,18 @@ export class PrismaUserRepository implements IUserRepository {
         }),
         ...(data.hasOnboarded !== undefined && {
           hasOnboarded: data.hasOnboarded,
+        }),
+        ...(data.onboardingStep !== undefined && {
+          onboardingStep: data.onboardingStep,
+        }),
+        ...(data.onboardingDraft !== undefined && {
+          onboardingDraft:
+            data.onboardingDraft === null
+              ? Prisma.JsonNull
+              : data.onboardingDraft,
+        }),
+        ...(data.notificationDosage !== undefined && {
+          notificationDosage: data.notificationDosage,
         }),
       },
     });

--- a/src/domain/repositories/IUserRepository.ts
+++ b/src/domain/repositories/IUserRepository.ts
@@ -1,4 +1,4 @@
-import { User } from "@prisma/client";
+import { NotificationDosage, Prisma, User } from "@prisma/client";
 
 export interface CreateUserDTO {
   telegramId?: string;
@@ -11,6 +11,9 @@ export interface UpdateUserDTO {
   name?: string;
   monthlyIncome?: number;
   hasOnboarded?: boolean;
+  onboardingStep?: string | null;
+  onboardingDraft?: Prisma.InputJsonValue | null;
+  notificationDosage?: NotificationDosage;
 }
 
 export interface IUserRepository {

--- a/src/presentation/controllers/TelegramWebhookController.ts
+++ b/src/presentation/controllers/TelegramWebhookController.ts
@@ -129,6 +129,7 @@ export class TelegramWebhookController {
                 command: "recurring",
                 description: "Manage repeating income/expenses",
               },
+              { command: "settings", description: "Reminders & preferences" },
               { command: "help", description: "How to use the bot" },
             ],
           }),
@@ -185,6 +186,9 @@ export class TelegramWebhookController {
           platformUserId,
           platformUsername: cq.from.username ?? cq.from.first_name,
           textMessage: cq.data ?? "",
+          callbackMessageId: cq.message?.message_id
+            ? String(cq.message.message_id)
+            : undefined,
         });
 
         res


### PR DESCRIPTION
PR B of the onboarding redesign (builds on #30). Replaces the one-step onboarding with a guided wizard and makes reminders opt-in by dosage.

## Onboarding wizard
State machine on `onboardingStep` + `onboardingDraft`:
1. greet → ask post-tax monthly income
2. show the 50/30/20 split → **multi-select category groups** (common ones pre-ticked); toggles edit the message in place
3. Done → clone the picked groups + their children into the user's categories with **income-based per-category budget suggestions** (`suggestCategoryBudgets`)
4. pick a **reminder dosage** (Off default) → done

## Reminders by dosage (`SendBudgetNudges`)
- **OFF** → nothing · **GENTLE** → WARN_80 + OVER once/cycle (original behaviour) · **AGGRESSIVE** → adds WARN_50 + a once-a-day check-in · **RELENTLESS** → check-in daily + OVER repeats daily. Daily kinds keyed per-day for idempotency.

## Supporting
- Multi-row inline buttons: `sendInteractiveMessage` takes rows; new `editInteractiveMessage` (edit-in-place); `callbackMessageId` threaded from the webhook.
- New `SettingsProcessor` (`/settings`): view income + change dosage by buttons; `/settings` registered as a bot command.
- `UpdateUserDTO` carries the new fields.

## Tests
Wizard transitions (income→groups→done→dosage), dosage gating (OFF silent, RELENTLESS daily check-in), plus existing specs updated for the rows signature. `pnpm build`/`lint`/`test:unit` ✓ (**82 passing**).

## Notes
- Existing flat categories + already-onboarded users are unaffected (wizard only runs for new/`/start`). Web category/dosage UI + prod template seeding come in PR C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)