### PR TITLE
feat(onboarding): web UI — taxonomy, per-category budgets, reminder dosage (PR C)

### DIFF
--- a/web/src/app/dashboard/account/account-settings.tsx
+++ b/web/src/app/dashboard/account/account-settings.tsx
@@ -58,6 +58,8 @@ export function AppearanceCard() {
     );
 }
 
+export type NotificationDosage = "OFF" | "GENTLE" | "AGGRESSIVE" | "RELENTLESS";
+
 export type BudgetSettings = {
     monthlyIncome: number;
     payday: number;
@@ -66,6 +68,7 @@ export type BudgetSettings = {
     needsPct: number;
     wantsPct: number;
     savingsPct: number;
+    notificationDosage: NotificationDosage;
 };
 
 const CURRENCIES = [
@@ -75,6 +78,13 @@ const CURRENCIES = [
     { value: "GBP", label: "GBP (£)", locale: "en-GB" },
 ];
 
+const DOSAGES: { value: NotificationDosage; label: string }[] = [
+    { value: "OFF", label: "Off — no reminders" },
+    { value: "GENTLE", label: "Gentle — 1–2 a day" },
+    { value: "AGGRESSIVE", label: "Aggressive — + daily check-in" },
+    { value: "RELENTLESS", label: "Relentless — daily + repeats" },
+];
+
 export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
     const [income, setIncome] = useState(String(initial.monthlyIncome));
     const [payday, setPayday] = useState(String(initial.payday));
@@ -82,6 +92,9 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
     const [needs, setNeeds] = useState(initial.needsPct);
     const [wants, setWants] = useState(initial.wantsPct);
     const [savings, setSavings] = useState(initial.savingsPct);
+    const [dosage, setDosage] = useState<NotificationDosage>(
+        initial.notificationDosage,
+    );
     const [isPending, startTransition] = useTransition();
 
     const sum = needs + wants + savings;
@@ -109,6 +122,7 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
                 needsPct: needs,
                 wantsPct: wants,
                 savingsPct: savings,
+                notificationDosage: dosage,
             });
             if (res.success) {
                 toast.success("Budget settings saved");
@@ -194,6 +208,28 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
                             onChange={setSavings}
                         />
                     </div>
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="dosage">Telegram reminders</Label>
+                    <Select
+                        value={dosage}
+                        onValueChange={(v) => setDosage(v as NotificationDosage)}
+                    >
+                        <SelectTrigger id="dosage">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {DOSAGES.map((d) => (
+                                <SelectItem key={d.value} value={d.value}>
+                                    {d.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                        How often the bot nudges you when a bucket runs hot.
+                    </p>
                 </div>
 
                 <Button

--- a/web/src/app/dashboard/categories/page.tsx
+++ b/web/src/app/dashboard/categories/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { ContentLayout } from "@/components/admin-panel/content-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -32,6 +32,7 @@ import {
   createCategory,
   renameCategory,
   setCategoryBucket,
+  setCategoryBudget,
   deleteCategory,
   type CategoryStat,
 } from "@/lib/actions/categories";
@@ -52,6 +53,7 @@ export default function CategoriesPage() {
   const [editing, setEditing] = useState<CategoryStat | null>(null);
   const [editName, setEditName] = useState("");
   const [editBucket, setEditBucket] = useState<Bucket>("NEEDS");
+  const [editBudget, setEditBudget] = useState("");
   const [editError, setEditError] = useState("");
 
   const load = () =>
@@ -62,6 +64,13 @@ export default function CategoriesPage() {
   useEffect(() => {
     load();
   }, []);
+
+  // Group rows are organizational only — used to label children, not listed.
+  const groupNameById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of categories) if (c.isGroup) m.set(c.id, c.name);
+    return m;
+  }, [categories]);
 
   const handleAdd = () =>
     startTransition(async () => {
@@ -79,6 +88,7 @@ export default function CategoriesPage() {
     setEditing(cat);
     setEditName(cat.name);
     setEditBucket(cat.bucket);
+    setEditBudget(cat.monthlyBudget == null ? "" : String(cat.monthlyBudget));
     setEditError("");
   };
 
@@ -99,6 +109,15 @@ export default function CategoriesPage() {
           return;
         }
       }
+      const trimmed = editBudget.trim();
+      const nextBudget = trimmed === "" ? null : Number(trimmed);
+      if (nextBudget !== editing.monthlyBudget) {
+        const r = await setCategoryBudget(editing.id, nextBudget);
+        if (!r.success) {
+          setEditError(r.message ?? "Failed to set budget");
+          return;
+        }
+      }
       setEditing(null);
       load();
     });
@@ -113,8 +132,8 @@ export default function CategoriesPage() {
     <ContentLayout title="Categories">
       <div className="space-y-6">
         <p className="text-sm text-muted-foreground">
-          System categories come with Blipko. Add your own and assign each to a
-          50/30/20 bucket.
+          Your categories, grouped into 50/30/20 buckets. Set a monthly limit on
+          any of them — the bot warns you as you approach it.
         </p>
 
         {/* Add a custom category */}
@@ -134,7 +153,9 @@ export default function CategoriesPage() {
                     setNewName(e.target.value);
                     setAddError("");
                   }}
-                  onKeyDown={(e) => e.key === "Enter" && newName.trim() && handleAdd()}
+                  onKeyDown={(e) =>
+                    e.key === "Enter" && newName.trim() && handleAdd()
+                  }
                 />
               </div>
               <div className="space-y-1">
@@ -166,9 +187,11 @@ export default function CategoriesPage() {
           </CardContent>
         </Card>
 
-        {/* Grouped by bucket */}
+        {/* Grouped by bucket (leaf categories only) */}
         {BUCKETS.map((bucket) => {
-          const inBucket = categories.filter((c) => c.bucket === bucket);
+          const inBucket = categories.filter(
+            (c) => c.bucket === bucket && !c.isGroup,
+          );
           return (
             <Card key={bucket}>
               <CardHeader>
@@ -181,46 +204,62 @@ export default function CategoriesPage() {
                   <p className="text-sm text-muted-foreground">No categories.</p>
                 ) : (
                   <div className="divide-y">
-                    {inBucket.map((cat) => (
-                      <div
-                        key={cat.id}
-                        className="flex items-center justify-between py-2"
-                      >
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium">{cat.name}</span>
-                          {cat.isSystem && (
-                            <Badge variant="secondary" className="text-xs">
-                              System
-                            </Badge>
-                          )}
+                    {inBucket.map((cat) => {
+                      const group = cat.parentId
+                        ? groupNameById.get(cat.parentId)
+                        : null;
+                      return (
+                        <div
+                          key={cat.id}
+                          className="flex items-center justify-between py-2"
+                        >
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">{cat.name}</span>
+                            {group && (
+                              <span className="text-xs text-muted-foreground">
+                                {group}
+                              </span>
+                            )}
+                            {cat.isSystem && (
+                              <Badge variant="secondary" className="text-xs">
+                                System
+                              </Badge>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-3">
+                            <span className="text-sm tabular-nums text-muted-foreground">
+                              {fmt(cat.spend)}
+                              {cat.monthlyBudget != null && (
+                                <span className="text-muted-foreground/70">
+                                  {" "}
+                                  / {formatMoney(cat.monthlyBudget)}
+                                </span>
+                              )}
+                            </span>
+                            {!cat.isSystem && (
+                              <>
+                                <Button
+                                  size="icon"
+                                  variant="ghost"
+                                  className="h-7 w-7"
+                                  onClick={() => openEdit(cat)}
+                                >
+                                  <Pencil className="h-3.5 w-3.5" />
+                                </Button>
+                                <Button
+                                  size="icon"
+                                  variant="ghost"
+                                  className="h-7 w-7 text-destructive"
+                                  onClick={() => handleDelete(cat)}
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </Button>
+                              </>
+                            )}
+                          </div>
                         </div>
-                        <div className="flex items-center gap-3">
-                          <span className="text-sm text-muted-foreground">
-                            {fmt(cat.spend)}
-                          </span>
-                          {!cat.isSystem && (
-                            <>
-                              <Button
-                                size="icon"
-                                variant="ghost"
-                                className="h-7 w-7"
-                                onClick={() => openEdit(cat)}
-                              >
-                                <Pencil className="h-3.5 w-3.5" />
-                              </Button>
-                              <Button
-                                size="icon"
-                                variant="ghost"
-                                className="h-7 w-7 text-destructive"
-                                onClick={() => handleDelete(cat)}
-                              >
-                                <Trash2 className="h-3.5 w-3.5" />
-                              </Button>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </CardContent>
@@ -263,6 +302,19 @@ export default function CategoriesPage() {
                   ))}
                 </SelectContent>
               </Select>
+            </div>
+            <div className="space-y-1">
+              <Label>Monthly limit (optional)</Label>
+              <Input
+                type="number"
+                min={0}
+                value={editBudget}
+                placeholder="No limit"
+                onChange={(e) => {
+                  setEditBudget(e.target.value);
+                  setEditError("");
+                }}
+              />
             </div>
             {editError && <p className="text-sm text-destructive">{editError}</p>}
             <div className="flex gap-2">

--- a/web/src/lib/actions/budget.ts
+++ b/web/src/lib/actions/budget.ts
@@ -172,6 +172,7 @@ export async function getBudgetSettings() {
         payday: true,
         currency: true,
         locale: true,
+        notificationDosage: true,
       },
     }),
     prisma.budgetConfig.findUnique({ where: { userId } }),
@@ -185,6 +186,7 @@ export async function getBudgetSettings() {
     needsPct: config?.needsPct ?? DEFAULT_SPLIT.needsPct,
     wantsPct: config?.wantsPct ?? DEFAULT_SPLIT.wantsPct,
     savingsPct: config?.savingsPct ?? DEFAULT_SPLIT.savingsPct,
+    notificationDosage: user?.notificationDosage ?? "OFF",
   };
 }
 
@@ -197,6 +199,9 @@ const settingsSchema = z
     needsPct: z.number().int().min(0).max(100).optional(),
     wantsPct: z.number().int().min(0).max(100).optional(),
     savingsPct: z.number().int().min(0).max(100).optional(),
+    notificationDosage: z
+      .enum(["OFF", "GENTLE", "AGGRESSIVE", "RELENTLESS"])
+      .optional(),
   })
   .refine(
     (d) => {
@@ -220,6 +225,7 @@ export async function updateBudgetSettings(input: {
   needsPct?: number;
   wantsPct?: number;
   savingsPct?: number;
+  notificationDosage?: "OFF" | "GENTLE" | "AGGRESSIVE" | "RELENTLESS";
 }): Promise<{ success: boolean; message?: string }> {
   const session = await auth();
   if (!session?.user?.id) return { success: false, message: "Unauthorized" };
@@ -239,11 +245,14 @@ export async function updateBudgetSettings(input: {
     payday?: number;
     currency?: string;
     locale?: string;
+    notificationDosage?: "OFF" | "GENTLE" | "AGGRESSIVE" | "RELENTLESS";
   } = {};
   if (d.monthlyIncome !== undefined) userData.monthlyIncome = d.monthlyIncome;
   if (d.payday !== undefined) userData.payday = d.payday;
   if (d.currency !== undefined) userData.currency = d.currency;
   if (d.locale !== undefined) userData.locale = d.locale;
+  if (d.notificationDosage !== undefined)
+    userData.notificationDosage = d.notificationDosage;
 
   if (Object.keys(userData).length > 0) {
     await prisma.user.update({ where: { id: userId }, data: userData });

--- a/web/src/lib/actions/categories.ts
+++ b/web/src/lib/actions/categories.ts
@@ -12,6 +12,9 @@ export type CategoryStat = {
   name: string;
   bucket: Bucket;
   isSystem: boolean;
+  isGroup: boolean;
+  parentId: string | null;
+  monthlyBudget: number | null;
   spend: number;
 };
 
@@ -50,6 +53,9 @@ export async function getCategories(): Promise<CategoryStat[]> {
     name: c.name,
     bucket: c.bucket,
     isSystem: c.userId === null,
+    isGroup: c.isGroup,
+    parentId: c.parentId,
+    monthlyBudget: c.monthlyBudget === null ? null : Number(c.monthlyBudget),
     spend: spendById.get(c.id) ?? 0,
   }));
 }
@@ -57,6 +63,7 @@ export async function getCategories(): Promise<CategoryStat[]> {
 export async function createCategory(
   name: string,
   bucket: Bucket,
+  opts?: { parentId?: string | null; monthlyBudget?: number | null },
 ): Promise<{ success: boolean; message?: string }> {
   const session = await auth();
   if (!session?.user?.id) return { success: false, message: "Unauthorized" };
@@ -72,12 +79,49 @@ export async function createCategory(
   if (existing)
     return { success: false, message: "A category with that name exists" };
 
+  // A parent, if given, must be one of the user's own group categories.
+  let parentId: string | null = null;
+  if (opts?.parentId) {
+    const parent = await ownedCategory(opts.parentId, session.user.id);
+    if (!parent?.isGroup)
+      return { success: false, message: "Invalid parent group" };
+    parentId = parent.id;
+  }
+
   await prisma.category.create({
     data: {
       name: parsedName.data,
       bucket: parsedBucket.data,
       userId: session.user.id,
+      parentId,
+      monthlyBudget: opts?.monthlyBudget ?? null,
     },
+  });
+
+  revalidatePath("/dashboard/categories");
+  return { success: true };
+}
+
+export async function setCategoryBudget(
+  id: string,
+  monthlyBudget: number | null,
+): Promise<{ success: boolean; message?: string }> {
+  const session = await auth();
+  if (!session?.user?.id) return { success: false, message: "Unauthorized" };
+
+  if (
+    monthlyBudget !== null &&
+    (!Number.isFinite(monthlyBudget) || monthlyBudget < 0)
+  )
+    return { success: false, message: "Invalid amount" };
+
+  const cat = await ownedCategory(id, session.user.id);
+  if (!cat)
+    return { success: false, message: "Category not found or not editable" };
+
+  await prisma.category.update({
+    where: { id },
+    data: { monthlyBudget },
   });
 
   revalidatePath("/dashboard/categories");


### PR DESCRIPTION
Final PR of the onboarding redesign (after #30, #31). Surfaces the new model on the web dashboard.

## Categories page
- Leaf categories grouped by bucket, each tagged with its **parent group** label.
- Per-category **monthly limit** shown as `spend / limit` and editable in the edit dialog.
- Group rows are organizational (used for labels), not listed as spendable.

## Actions
- `getCategories` returns `parentId` / `isGroup` / `monthlyBudget`.
- `createCategory` accepts `parentId` + `monthlyBudget`; new `setCategoryBudget`.
- `getBudgetSettings` / `updateBudgetSettings` carry `notificationDosage`.

## Account settings
- A **Telegram reminders** selector: Off / Gentle / Aggressive / Relentless — the same dosage the bot's `/settings` sets.

`web build` ✓ · `lint` ✓ (0 errors).

## After merge
I'll run the system-taxonomy seed against prod once (idempotent) so the grouped categories are consistent for the web view — deferred until now so the live categories list didn't change before this UI shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)