### PR TITLE
feat(bot): detailed /help command

### DIFF
--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -23,6 +23,7 @@ import { ConfirmBucketProcessor } from "./processors/ConfirmBucketProcessor";
 import { RecurringConfirmProcessor } from "./processors/RecurringConfirmProcessor";
 import { OnboardingProcessor } from "./processors/OnboardingProcessor";
 import { SettingsProcessor } from "./processors/SettingsProcessor";
+import { HelpProcessor } from "./processors/HelpProcessor";
 import { StatusProcessor } from "./processors/StatusProcessor";
 import { ReportProcessor } from "./processors/ReportProcessor";
 import { UndoProcessor } from "./processors/UndoProcessor";
@@ -89,6 +90,7 @@ export class ProcessIncomingMessageUseCase {
         messageService,
       ),
       new SettingsProcessor(userRepository, messageService),
+      new HelpProcessor(messageService),
       new StatusProcessor(
         expenseRepository,
         budgetConfigRepository,

--- a/src/application/use-cases/processors/FallbackProcessor.ts
+++ b/src/application/use-cases/processors/FallbackProcessor.ts
@@ -21,7 +21,7 @@ export class FallbackProcessor implements MessageProcessor {
     };
     const body =
       parsed.conversational_response ??
-      'I didn\'t catch that. Try logging a spend like "chai 30" or "auto 80 office".';
+      'I didn\'t catch that. Try logging a spend like "chai 30" or "auto 80 office" — or type /help.';
     await this.messageService.sendMessage({
       to: context.platformUserId,
       body,

--- a/src/application/use-cases/processors/HelpProcessor.spec.ts
+++ b/src/application/use-cases/processors/HelpProcessor.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HelpProcessor } from "./HelpProcessor";
+
+describe("HelpProcessor", () => {
+  let messageService: any;
+  let processor: HelpProcessor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    processor = new HelpProcessor(messageService);
+  });
+
+  it("matches 'help' and '/help' only", () => {
+    expect(processor.canHandle({ textMessage: "help" } as any)).toBe(true);
+    expect(processor.canHandle({ textMessage: "  /HELP " } as any)).toBe(true);
+    expect(processor.canHandle({ textMessage: "chai 30" } as any)).toBe(false);
+  });
+
+  it("sends a detailed guide covering commands, voice, and questions", async () => {
+    await processor.process({
+      platformUserId: "123",
+      textMessage: "/help",
+    } as any);
+
+    const body = messageService.sendMessage.mock.calls[0][0].body;
+    expect(body).toContain("/status");
+    expect(body).toContain("/settings");
+    expect(body).toContain("voice");
+    expect(body).toContain("can I afford");
+  });
+});

--- a/src/application/use-cases/processors/HelpProcessor.ts
+++ b/src/application/use-cases/processors/HelpProcessor.ts
@@ -1,0 +1,53 @@
+import {
+  MessageProcessor,
+  ProcessContext,
+  ProcessOutput,
+} from "./MessageProcessor";
+import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
+
+const HELP_BODY = `🧭 *How to use Blipko*
+
+*Log a spend* — just say what you spent, in English, Hindi, Manglish, or Malayalam:
+• \`chai 30\`
+• \`auto 80 office\`
+• \`petrol 500 koduthu\`
+Or send a *voice note* — I'll transcribe and log it.
+
+*Ask me anything* about your money:
+• "how much did I spend on food this month?"
+• "can I afford a 5000 phone?"
+• "what's my biggest expense?"
+
+*Commands*
+• /status — budget health & safe daily spend
+• /report — this month's summary + top leaks
+• /recurring — repeating income/expenses (rent, salary…)
+• /settings — reminder style (off / gentle / aggressive)
+• /start — set up or redo your budget
+• \`undo\` — remove the last entry
+
+*Fine-tune anything* on the web dashboard — categories, per-category limits, income split, and reminders: blipko.lol`;
+
+// Replies to "help"/"/help" with a detailed guide. Pre-parse (no AI needed).
+export class HelpProcessor implements MessageProcessor {
+  constructor(private readonly messageService: IMessagingPlatform) {}
+
+  canHandle(context: ProcessContext): boolean {
+    const normalized = context.textMessage
+      .trim()
+      .toLowerCase()
+      .replace(/^\//, "");
+    return normalized === "help";
+  }
+
+  async process(context: ProcessContext): Promise<ProcessOutput> {
+    await this.messageService.sendMessage({
+      to: context.platformUserId,
+      body: HELP_BODY,
+    });
+    return {
+      response: HELP_BODY,
+      parsed: { intent: "UNKNOWN", confidence: 1 },
+    };
+  }
+}


### PR DESCRIPTION
`/help` was registered as a bot command but had **no handler** — it fell through to the generic "I didn't catch that" fallback, so it was actively misleading.

Adds a pre-parse `HelpProcessor` that replies with a skimmable guide:
- **Log a spend** — text in English/Hindi/Manglish/Malayalam (`chai 30`, `auto 80 office`, `petrol 500 koduthu`) + voice notes
- **Ask me anything** — the QUERY agent ("how much on food this month?", "can I afford a 5000 phone?")
- **Commands** — `/status`, `/report`, `/recurring`, `/settings`, `/start`, `undo`
- **Fine-tune on the web** — categories, per-category limits, split, reminders

Also points the fallback line at `/help` for discoverability.

`pnpm build`/`lint`/`test:unit` ✓ (84 passing, incl. a HelpProcessor spec). Pure backend, single processor, no schema/web change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)