### PR TITLE
Categories: fix confusions, group rework, smarter budgets, pinned limits

### DIFF
--- a/prisma/migrations/20260629164358_add_category_budget_lock/migration.sql
+++ b/prisma/migrations/20260629164358_add_category_budget_lock/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "budgetLocked" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,9 @@ model Category {
   // Per-leaf monthly budget suggestion (editable; null = uncapped).
   monthlyBudget Decimal? @db.Decimal(12, 2)
 
+  // User pinned a fixed monthlyBudget — Auto-balance must not overwrite it.
+  budgetLocked Boolean @default(false)
+
   // Relative share of its bucket, used to suggest budgets during onboarding.
   // Only meaningful on system leaf rows; 0 on groups and user-created rows.
   weight Int @default(0)

--- a/scripts/cleanup-group-data.mjs
+++ b/scripts/cleanup-group-data.mjs
@@ -1,0 +1,36 @@
+// One-time, idempotent cleanup: groups are organization-only and must never hold
+// spend or a budget. Detaches any expenses wrongly attached to a group row (they
+// become uncategorized → surface in Needs Review) and clears budgets set on group
+// rows. Safe to run more than once. Run against each environment's DB:
+//   node scripts/cleanup-group-data.mjs
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const groups = await prisma.category.findMany({
+    where: { isGroup: true },
+    select: { id: true },
+  });
+  const ids = groups.map((g) => g.id);
+
+  const detached = await prisma.expense.updateMany({
+    where: { categoryId: { in: ids } },
+    data: { categoryId: null },
+  });
+  const cleared = await prisma.category.updateMany({
+    where: { isGroup: true, monthlyBudget: { not: null } },
+    data: { monthlyBudget: null },
+  });
+
+  console.log(
+    `Detached ${detached.count} expense(s) from group rows; cleared ${cleared.count} group budget(s).`,
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/application/use-cases/expenseFlow.ts
+++ b/src/application/use-cases/expenseFlow.ts
@@ -47,6 +47,10 @@ export async function recordExpenseAndReply(
   const { user, amount, bucket } = args;
 
   // Resolve the category: use a known id, else find-or-create by name + bucket.
+  // Expenses only ever attach to leaf categories — never a group row. If the
+  // name resolves to a group, the expense stays uncategorized (it still lands in
+  // the right bucket and shows up in Needs Review). We can't create a same-name
+  // leaf either: (userId, name) is unique.
   let categoryId = args.categoryId;
   let categoryLabel = args.categoryName ?? "General";
   if (!categoryId && args.categoryName) {
@@ -54,10 +58,10 @@ export async function recordExpenseAndReply(
       user.id,
       args.categoryName,
     );
-    if (existing) {
+    if (existing && !existing.isGroup) {
       categoryId = existing.id;
       categoryLabel = existing.name;
-    } else {
+    } else if (!existing) {
       const created = await deps.categoryRepository.create({
         userId: user.id,
         name: args.categoryName,
@@ -66,6 +70,7 @@ export async function recordExpenseAndReply(
       categoryId = created.id;
       categoryLabel = created.name;
     }
+    // else: name matches a group → leave uncategorized.
   }
 
   const expense = await deps.expenseRepository.create({

--- a/src/application/use-cases/processors/ExpenseProcessor.ts
+++ b/src/application/use-cases/processors/ExpenseProcessor.ts
@@ -53,13 +53,16 @@ export class ExpenseProcessor implements MessageProcessor {
       return { response, parsed };
     }
 
-    // Resolve category; a known category's bucket is authoritative.
+    // Resolve category; a known category's bucket is authoritative. A group
+    // match still sets the bucket, but the expense never attaches to a group
+    // (only leaf categories hold spend) — expenseFlow leaves it uncategorized.
     const matched = parsed.category
       ? await this.categoryRepository.findByNameForUser(
           user.id,
           parsed.category,
         )
       : null;
+    const leaf = matched && !matched.isGroup ? matched : null;
     const bucket = matched?.bucket ?? parsed.bucket;
 
     const needsConfirm = parsed.confidence < CONFIDENCE_THRESHOLD || !bucket;
@@ -83,8 +86,8 @@ export class ExpenseProcessor implements MessageProcessor {
         rawText: textMessage,
         confidence: parsed.confidence,
         note: parsed.note,
-        categoryId: matched?.id,
-        categoryName: matched?.name ?? parsed.category,
+        categoryId: leaf?.id,
+        categoryName: leaf?.name ?? parsed.category,
       },
     );
     return { response, parsed };

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -133,6 +133,9 @@ model Category {
   // Per-leaf monthly budget suggestion (editable; null = uncapped).
   monthlyBudget Decimal? @db.Decimal(12, 2)
 
+  // User pinned a fixed monthlyBudget — Auto-balance must not overwrite it.
+  budgetLocked Boolean @default(false)
+
   // Relative share of its bucket, used to suggest budgets during onboarding.
   // Only meaningful on system leaf rows; 0 on groups and user-created rows.
   weight Int @default(0)

--- a/web/src/app/dashboard/_components/needs-review-inbox.tsx
+++ b/web/src/app/dashboard/_components/needs-review-inbox.tsx
@@ -54,7 +54,7 @@ export function NeedsReviewInbox({ expenses, categories, currency }: NeedsReview
           Needs Review ({items.length})
         </CardTitle>
         <CardDescription>
-          The bot wasn't totally sure about these transactions, or they fell into a generic bucket. Please assign them to a specific category.
+          The bot wasn&apos;t totally sure about these transactions, or they fell into a generic bucket. Please assign them to a specific category.
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/web/src/app/dashboard/categories/_components/add-category-form.tsx
+++ b/web/src/app/dashboard/categories/_components/add-category-form.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -35,17 +36,30 @@ export const AddCategoryForm = ({ onAdded }: AddCategoryFormProps) => {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [bucket, setBucket] = useState<Bucket>("NEEDS");
+  const [fixed, setFixed] = useState(false);
+  const [amount, setAmount] = useState("");
   const [error, setError] = useState("");
 
   const reset = () => {
     setName("");
     setBucket("NEEDS");
+    setFixed(false);
+    setAmount("");
     setError("");
   };
 
   const handleAdd = () =>
     startTransition(async () => {
-      const res = await createCategory(name, bucket);
+      const amt = Number(amount);
+      if (fixed && (!amount.trim() || !Number.isFinite(amt) || amt < 0)) {
+        setError("Enter a valid monthly amount");
+        return;
+      }
+      const res = await createCategory(
+        name,
+        bucket,
+        fixed ? { monthlyBudget: amt, locked: true } : undefined,
+      );
       if (!res.success) {
         toast.error(res.message ?? "Failed to add category");
         setError(res.message ?? "Failed to add");
@@ -112,6 +126,39 @@ export const AddCategoryForm = ({ onAdded }: AddCategoryFormProps) => {
               </SelectContent>
             </Select>
           </div>
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-0.5">
+              <Label htmlFor="fixed-toggle">Set a fixed monthly limit</Label>
+              <p className="text-xs text-muted-foreground">
+                Pin an amount Auto-balance won&apos;t change.
+              </p>
+            </div>
+            <Switch
+              id="fixed-toggle"
+              checked={fixed}
+              onCheckedChange={(v) => {
+                setFixed(v);
+                setError("");
+              }}
+            />
+          </div>
+          {fixed && (
+            <div className="space-y-1">
+              <Label htmlFor="fixed-amount">Monthly limit</Label>
+              <Input
+                id="fixed-amount"
+                type="number"
+                min={0}
+                inputMode="numeric"
+                placeholder="2000"
+                value={amount}
+                onChange={(e) => {
+                  setAmount(e.target.value);
+                  setError("");
+                }}
+              />
+            </div>
+          )}
           {error && <p className="text-sm text-destructive">{error}</p>}
         </div>
         <ResponsiveModalFooter>

--- a/web/src/app/dashboard/categories/_components/bucket-section.tsx
+++ b/web/src/app/dashboard/categories/_components/bucket-section.tsx
@@ -47,7 +47,9 @@ export const BucketSection = ({
 }: BucketSectionProps) => {
   const meta = BUCKET_META[bucket];
   const { budget, spent, remaining, pct } = overview;
-  const over = remaining < 0;
+  // Savings is a goal: spending past the target is good, so it's never "over".
+  const isSavings = bucket === "SAVINGS";
+  const over = !isSavings && remaining < 0;
   const allocated = categories.reduce(
     (s, c) => s + (c.monthlyBudget ?? 0),
     0,
@@ -74,12 +76,20 @@ export const BucketSection = ({
           <span
             className={cn(
               "text-sm font-medium tabular-nums",
-              over ? "text-red-600" : "text-muted-foreground",
+              over
+                ? "text-red-600"
+                : isSavings && remaining <= 0
+                  ? "text-emerald-600"
+                  : "text-muted-foreground",
             )}
           >
-            {over
-              ? `${money(Math.abs(remaining))} over`
-              : `${money(remaining)} left`}
+            {isSavings
+              ? remaining > 0
+                ? `${money(remaining)} to save`
+                : `${money(Math.abs(remaining))} beyond target`
+              : over
+                ? `${money(Math.abs(remaining))} over`
+                : `${money(remaining)} left`}
           </span>
         </div>
         <div className="h-2 w-full rounded-full bg-muted">
@@ -92,13 +102,17 @@ export const BucketSection = ({
           />
         </div>
         <p className="text-xs text-muted-foreground tabular-nums">
-          {money(spent)} spent of {money(budget)}
-          {budget > 0 && !over && (
-            <>
-              {" "}
-              · safe {money(Math.max(0, remaining) / remainingDays)}/day
-            </>
-          )}
+          {money(spent)} {isSavings ? "saved" : "spent"} of {money(budget)}
+          {budget > 0 &&
+            (isSavings ? (
+              remaining > 0 && (
+                <> · save {money(remaining / remainingDays)}/day to target</>
+              )
+            ) : (
+              !over && (
+                <> · safe {money(Math.max(0, remaining) / remainingDays)}/day</>
+              )
+            ))}
         </p>
       </div>
 

--- a/web/src/app/dashboard/categories/_components/bucket-section.tsx
+++ b/web/src/app/dashboard/categories/_components/bucket-section.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { cn } from "@/lib/utils";
-import { BUCKET_META, type CategoryPacing } from "@/lib/budget";
+import { BUCKET_META } from "@/lib/budget";
 import { CategoryRow } from "./category-row";
 import type { CategoryStat } from "@/lib/actions/categories";
 import type { Bucket } from "@prisma/client";
@@ -135,6 +135,7 @@ export const BucketSection = ({
             title={`Auto-balance ${meta.label}?`}
             description={`Distribute ${money(budget)} across ${meta.label} weighted by your recent spending. This replaces their current limits.`}
             confirmLabel="Auto-balance"
+            destructive={false}
             onConfirm={() => onAutoBalance(categories, budget)}
             trigger={
               <Button

--- a/web/src/app/dashboard/categories/_components/bucket-section.tsx
+++ b/web/src/app/dashboard/categories/_components/bucket-section.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useMemo } from "react";
 
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/confirm-dialog";
@@ -60,17 +59,6 @@ export const BucketSection = ({
   // system-category spend) — surfaced so the rows reconcile with the bucket total.
   const shownSpend = categories.reduce((s, c) => s + c.spend, 0);
   const uncategorized = Math.max(0, spent - shownSpend);
-
-  const groupedCategories = useMemo(() => {
-    const map = new Map<string | null, CategoryStat[]>();
-    for (const cat of categories) {
-      const parentName = cat.parentId ? (groupNameById.get(cat.parentId) ?? "Unknown Group") : null;
-      const groupKey = cat.isGroup ? null : parentName;
-      if (!map.has(groupKey)) map.set(groupKey, []);
-      map.get(groupKey)!.push(cat);
-    }
-    return map;
-  }, [categories, groupNameById]);
 
   return (
     <div>
@@ -151,33 +139,31 @@ export const BucketSection = ({
         </div>
       )}
 
-      {/* Category rows */}
+      {/* Flat list of the bucket's categories; the group is a subtle tag per row,
+          not a sub-header (groups can span buckets, which made headers confusing). */}
       {categories.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           No categories in this bucket yet.
         </p>
       ) : (
-        <div className="flex flex-col gap-2">
-          {Array.from(groupedCategories.entries()).map(([groupName, cats]) => (
-            <div key={groupName || "standalone"} className={cn(groupName ? "pl-2 border-l-2 border-muted" : "")}>
-              {groupName && <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1 mt-1 pl-1">{groupName}</div>}
-              <div className="divide-y">
-                {cats.map((cat) => (
-                  <CategoryRow
-                    key={cat.id}
-                    cat={cat}
-                    groupName={null} // We don't need the subtitle anymore since it's grouped
-                    money={money}
-                    day={day}
-                    daysInPeriod={daysInPeriod}
-                    remainingDays={remainingDays}
-                    isPending={isPending}
-                    onEdit={onEdit}
-                    onDelete={onDelete}
-                  />
-                ))}
-              </div>
-            </div>
+        <div className="divide-y">
+          {categories.map((cat) => (
+            <CategoryRow
+              key={cat.id}
+              cat={cat}
+              groupName={
+                cat.parentId
+                  ? (groupNameById.get(cat.parentId) ?? null)
+                  : null
+              }
+              money={money}
+              day={day}
+              daysInPeriod={daysInPeriod}
+              remainingDays={remainingDays}
+              isPending={isPending}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
           ))}
         </div>
       )}

--- a/web/src/app/dashboard/categories/_components/bucket-section.tsx
+++ b/web/src/app/dashboard/categories/_components/bucket-section.tsx
@@ -56,6 +56,10 @@ export const BucketSection = ({
   );
   const unallocated = budget - allocated;
   const overAllocated = unallocated < 0;
+  // Spend not attributed to any listed category (uncategorized or hidden
+  // system-category spend) — surfaced so the rows reconcile with the bucket total.
+  const shownSpend = categories.reduce((s, c) => s + c.spend, 0);
+  const uncategorized = Math.max(0, spent - shownSpend);
 
   const groupedCategories = useMemo(() => {
     const map = new Map<string | null, CategoryStat[]>();
@@ -175,6 +179,12 @@ export const BucketSection = ({
             </div>
           ))}
         </div>
+      )}
+
+      {uncategorized > 0 && (
+        <p className="pt-2 text-xs text-muted-foreground tabular-nums">
+          Uncategorized · {money(uncategorized)} {isSavings ? "saved" : "spent"}
+        </p>
       )}
     </div>
   );

--- a/web/src/app/dashboard/categories/_components/category-row.tsx
+++ b/web/src/app/dashboard/categories/_components/category-row.tsx
@@ -110,6 +110,7 @@ export const CategoryRow = ({
               <TooltipContent side="top" className="max-w-xs text-left">
                 <p>
                   ~{money(pace.dailyRate)}/day · ~{money(pace.weekly)}/wk
+                  projected
                 </p>
                 {hasLimit && (
                   <p>

--- a/web/src/app/dashboard/categories/_components/category-row.tsx
+++ b/web/src/app/dashboard/categories/_components/category-row.tsx
@@ -46,28 +46,43 @@ export const CategoryRow = ({
     remainingDays,
   });
 
+  // Savings is a goal, not a cap: reaching/exceeding the target is good, so it
+  // never shows the over-limit/over-pace warnings used for Needs/Wants.
+  const isSavings = cat.bucket === "SAVINGS";
+  const savedAll = hasLimit && cat.spend >= cat.monthlyBudget!;
+
   const pacingLabel = hasLimit
-    ? pace.overSpent
-      ? "over limit"
-      : pace.overPace
-        ? "over pace"
-        : "on track"
+    ? isSavings
+      ? savedAll
+        ? "saved"
+        : "saving"
+      : pace.overSpent
+        ? "over limit"
+        : pace.overPace
+          ? "over pace"
+          : "on track"
     : null;
 
   const pacingVariant = hasLimit
-    ? pace.overSpent
-      ? "destructive"
-      : pace.overPace
-        ? "secondary"
-        : "outline"
+    ? isSavings
+      ? "outline"
+      : pace.overSpent
+        ? "destructive"
+        : pace.overPace
+          ? "secondary"
+          : "outline"
     : null;
 
   const pacingColor = hasLimit
-    ? pace.overSpent
-      ? "text-red-600"
-      : pace.overPace
-        ? "text-amber-600"
-        : "text-emerald-600"
+    ? isSavings
+      ? savedAll
+        ? "text-emerald-600"
+        : "text-muted-foreground"
+      : pace.overSpent
+        ? "text-red-600"
+        : pace.overPace
+          ? "text-amber-600"
+          : "text-emerald-600"
     : null;
 
   return (
@@ -96,11 +111,15 @@ export const CategoryRow = ({
                 </p>
                 {hasLimit && (
                   <p>
-                    {pace.overSpent
-                      ? "Already over limit"
-                      : pace.overPace
-                        ? `Projected ${money(pace.projectedMonth)} — safe ${money(pace.safeDaily)}/day`
-                        : `On track — safe ${money(pace.safeDaily)}/day`}
+                    {isSavings
+                      ? savedAll
+                        ? `Target reached — ${money(cat.spend)} saved`
+                        : `Save ${money(pace.safeDaily)}/day to reach ${money(cat.monthlyBudget!)}`
+                      : pace.overSpent
+                        ? "Already over limit"
+                        : pace.overPace
+                          ? `Projected ${money(pace.projectedMonth)} — safe ${money(pace.safeDaily)}/day`
+                          : `On track — safe ${money(pace.safeDaily)}/day`}
                   </p>
                 )}
               </TooltipContent>
@@ -108,16 +127,24 @@ export const CategoryRow = ({
           )}
         </div>
         <p className="text-xs tabular-nums text-muted-foreground">
-          {money(cat.spend)} spent
+          {money(cat.spend)} {isSavings ? "saved" : "spent"}
           {hasLimit && (
             <>
               {" "}
               of {money(cat.monthlyBudget!)} ·{" "}
-              <span className={cn(left! < 0 && "text-red-600")}>
-                {left! < 0
-                  ? `${money(Math.abs(left!))} over`
-                  : `${money(left!)} left`}
-              </span>
+              {isSavings ? (
+                <span className={cn(left! <= 0 && "text-emerald-600")}>
+                  {left! <= 0
+                    ? `${money(Math.abs(left!))} beyond target`
+                    : `${money(left!)} to go`}
+                </span>
+              ) : (
+                <span className={cn(left! < 0 && "text-red-600")}>
+                  {left! < 0
+                    ? `${money(Math.abs(left!))} over`
+                    : `${money(left!)} left`}
+                </span>
+              )}
             </>
           )}
         </p>

--- a/web/src/app/dashboard/categories/_components/category-row.tsx
+++ b/web/src/app/dashboard/categories/_components/category-row.tsx
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2, Lock } from "lucide-react";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { categoryPacing } from "@/lib/budget";
@@ -134,7 +134,14 @@ export const CategoryRow = ({
           {hasLimit && (
             <>
               {" "}
-              of {money(cat.monthlyBudget!)} ·{" "}
+              of {money(cat.monthlyBudget!)}
+              {cat.budgetLocked && (
+                <Lock
+                  className="ml-1 inline size-3 align-[-1px]"
+                  aria-label="Fixed — Auto-balance won't change this"
+                />
+              )}{" "}
+              ·{" "}
               {isSavings ? (
                 <span className={cn(left! <= 0 && "text-emerald-600")}>
                   {left! <= 0

--- a/web/src/app/dashboard/categories/_components/category-row.tsx
+++ b/web/src/app/dashboard/categories/_components/category-row.tsx
@@ -50,6 +50,8 @@ export const CategoryRow = ({
   // never shows the over-limit/over-pace warnings used for Needs/Wants.
   const isSavings = cat.bucket === "SAVINGS";
   const savedAll = hasLimit && cat.spend >= cat.monthlyBudget!;
+  // Only trust the "over pace" projection once a few days into the cycle.
+  const overPace = pace.overPace && pace.reliable;
 
   const pacingLabel = hasLimit
     ? isSavings
@@ -58,7 +60,7 @@ export const CategoryRow = ({
         : "saving"
       : pace.overSpent
         ? "over limit"
-        : pace.overPace
+        : overPace
           ? "over pace"
           : "on track"
     : null;
@@ -68,7 +70,7 @@ export const CategoryRow = ({
       ? "outline"
       : pace.overSpent
         ? "destructive"
-        : pace.overPace
+        : overPace
           ? "secondary"
           : "outline"
     : null;
@@ -80,7 +82,7 @@ export const CategoryRow = ({
         : "text-muted-foreground"
       : pace.overSpent
         ? "text-red-600"
-        : pace.overPace
+        : overPace
           ? "text-amber-600"
           : "text-emerald-600"
     : null;
@@ -117,7 +119,7 @@ export const CategoryRow = ({
                         : `Save ${money(pace.safeDaily)}/day to reach ${money(cat.monthlyBudget!)}`
                       : pace.overSpent
                         ? "Already over limit"
-                        : pace.overPace
+                        : overPace
                           ? `Projected ${money(pace.projectedMonth)} — safe ${money(pace.safeDaily)}/day`
                           : `On track — safe ${money(pace.safeDaily)}/day`}
                   </p>

--- a/web/src/app/dashboard/categories/_components/edit-category-modal.tsx
+++ b/web/src/app/dashboard/categories/_components/edit-category-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -41,21 +41,25 @@ export const EditCategoryModal = ({
   onSaved,
 }: EditCategoryModalProps) => {
   const [isPending, startTransition] = useTransition();
+  const [trackedId, setTrackedId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   const [editBucket, setEditBucket] = useState<Bucket>("NEEDS");
   const [editBudget, setEditBudget] = useState("");
   const [error, setError] = useState("");
 
-  useEffect(() => {
-    if (category) {
-      setEditName(category.name);
-      setEditBucket(category.bucket);
-      setEditBudget(
-        category.monthlyBudget == null ? "" : String(category.monthlyBudget),
-      );
-      setError("");
-    }
-  }, [category]);
+  // Sync the form when a different category is opened (and reset the tracker on
+  // close). This adjusts state during render on a prop change — the recommended
+  // pattern that avoids a setState-in-effect cascade.
+  if (!category && trackedId !== null) setTrackedId(null);
+  if (category && category.id !== trackedId) {
+    setTrackedId(category.id);
+    setEditName(category.name);
+    setEditBucket(category.bucket);
+    setEditBudget(
+      category.monthlyBudget == null ? "" : String(category.monthlyBudget),
+    );
+    setError("");
+  }
 
   const handleOpenChange = (open: boolean) => {
     if (!open) onClose();

--- a/web/src/app/dashboard/categories/_components/edit-category-modal.tsx
+++ b/web/src/app/dashboard/categories/_components/edit-category-modal.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -45,6 +46,7 @@ export const EditCategoryModal = ({
   const [editName, setEditName] = useState("");
   const [editBucket, setEditBucket] = useState<Bucket>("NEEDS");
   const [editBudget, setEditBudget] = useState("");
+  const [editLocked, setEditLocked] = useState(false);
   const [error, setError] = useState("");
 
   // Sync the form when a different category is opened (and reset the tracker on
@@ -58,6 +60,7 @@ export const EditCategoryModal = ({
     setEditBudget(
       category.monthlyBudget == null ? "" : String(category.monthlyBudget),
     );
+    setEditLocked(category.budgetLocked);
     setError("");
   }
 
@@ -84,8 +87,17 @@ export const EditCategoryModal = ({
       }
       const trimmed = editBudget.trim();
       const nextBudget = trimmed === "" ? null : Number(trimmed);
-      if (nextBudget !== category.monthlyBudget) {
-        const r = await setCategoryBudget(category.id, nextBudget);
+      if (
+        editLocked &&
+        (nextBudget == null || !Number.isFinite(nextBudget) || nextBudget < 0)
+      ) {
+        return setError("Enter a valid amount to pin");
+      }
+      if (
+        nextBudget !== category.monthlyBudget ||
+        editLocked !== category.budgetLocked
+      ) {
+        const r = await setCategoryBudget(category.id, nextBudget, editLocked);
         if (!r.success) {
           toast.error(r.message ?? "Failed to set budget");
           return setError(r.message ?? "Failed to set budget");
@@ -143,6 +155,22 @@ export const EditCategoryModal = ({
               placeholder="No limit"
               onChange={(e) => {
                 setEditBudget(e.target.value);
+                setError("");
+              }}
+            />
+          </div>
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-0.5">
+              <Label htmlFor="edit-lock">Pin this amount (fixed)</Label>
+              <p className="text-xs text-muted-foreground">
+                Auto-balance won&apos;t change a pinned limit.
+              </p>
+            </div>
+            <Switch
+              id="edit-lock"
+              checked={editLocked}
+              onCheckedChange={(v) => {
+                setEditLocked(v);
                 setError("");
               }}
             />

--- a/web/src/app/dashboard/categories/page.tsx
+++ b/web/src/app/dashboard/categories/page.tsx
@@ -62,8 +62,10 @@ export default function CategoriesPage() {
     return m;
   }, [categories]);
 
+  // Only leaf categories are spendable/budgetable; group rows are organization
+  // only and never render as categories.
   const leaves = useMemo(
-    () => categories.filter((c) => !c.isGroup || c.spend > 0 || c.monthlyBudget !== null),
+    () => categories.filter((c) => !c.isGroup),
     [categories],
   );
 

--- a/web/src/app/dashboard/categories/page.tsx
+++ b/web/src/app/dashboard/categories/page.tsx
@@ -97,8 +97,8 @@ export default function CategoriesPage() {
         <div className="space-y-1">
           <p className="text-sm text-muted-foreground">
             Your spending split into 50/30/20 buckets. Each bucket is your
-            budget for the month; a category limit is an optional cap the bot
-            warns you about.
+            budget this cycle; a category limit is an optional cap the bot warns
+            you about.
           </p>
           {overview?.periodLabel && (
             <p className="text-xs text-muted-foreground">

--- a/web/src/app/dashboard/recurring/_components/recurring-form-modal.tsx
+++ b/web/src/app/dashboard/recurring/_components/recurring-form-modal.tsx
@@ -204,7 +204,7 @@ export function RecurringFormModal({
                           // Auto-set the bucket if they pick a category
                           const cat = leaves.find((c) => c.id === val);
                           if (cat) {
-                            form.setValue("bucket", cat.bucket as any);
+                            form.setValue("bucket", cat.bucket as Bucket);
                           }
                         }}
                         defaultValue={field.value || undefined}

--- a/web/src/components/confirm-dialog.tsx
+++ b/web/src/components/confirm-dialog.tsx
@@ -12,6 +12,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
 import { playSound } from "@/lib/sound";
 
 interface ConfirmDialogProps {
@@ -19,6 +20,8 @@ interface ConfirmDialogProps {
   title?: string;
   description?: string;
   confirmLabel?: string;
+  // Red confirm button (deletes etc.); pass false for a neutral action.
+  destructive?: boolean;
   // Uncontrolled: render this element as the trigger.
   trigger?: React.ReactNode;
   // Controlled: drive open state from the parent (e.g. a toolbar button).
@@ -26,13 +29,14 @@ interface ConfirmDialogProps {
   onOpenChange?: (open: boolean) => void;
 }
 
-// Confirmation gate for destructive actions. Pass either a `trigger` element or
-// controlled `open`/`onOpenChange`. The confirm button is styled destructive.
+// Confirmation gate. Pass either a `trigger` element or controlled
+// `open`/`onOpenChange`. Destructive by default (red confirm button).
 export function ConfirmDialog({
   onConfirm,
   title = "Are you sure?",
   description = "This action cannot be undone.",
   confirmLabel = "Delete",
+  destructive = true,
   trigger,
   open,
   onOpenChange,
@@ -54,7 +58,9 @@ export function ConfirmDialog({
               playSound("confirm");
               onConfirm();
             }}
-            className="bg-red-600 text-white hover:bg-red-700"
+            className={cn(
+              destructive && "bg-red-600 text-white hover:bg-red-700",
+            )}
           >
             {confirmLabel}
           </AlertDialogAction>

--- a/web/src/lib/actions/categories.ts
+++ b/web/src/lib/actions/categories.ts
@@ -105,7 +105,11 @@ export async function getCategories(): Promise<CategoryStat[]> {
 export async function createCategory(
   name: string,
   bucket: Bucket,
-  opts?: { parentId?: string | null; monthlyBudget?: number | null },
+  opts?: {
+    parentId?: string | null;
+    monthlyBudget?: number | null;
+    locked?: boolean;
+  },
 ): Promise<{ success: boolean; message?: string }> {
   const session = await auth();
   if (!session?.user?.id) return { success: false, message: "Unauthorized" };
@@ -137,6 +141,7 @@ export async function createCategory(
       userId: session.user.id,
       parentId,
       monthlyBudget: opts?.monthlyBudget ?? null,
+      budgetLocked: opts?.locked ?? false,
     },
   });
 
@@ -147,6 +152,7 @@ export async function createCategory(
 export async function setCategoryBudget(
   id: string,
   monthlyBudget: number | null,
+  locked?: boolean,
 ): Promise<{ success: boolean; message?: string }> {
   const session = await auth();
   if (!session?.user?.id) return { success: false, message: "Unauthorized" };
@@ -165,7 +171,10 @@ export async function setCategoryBudget(
 
   await prisma.category.update({
     where: { id },
-    data: { monthlyBudget },
+    data: {
+      monthlyBudget,
+      ...(locked !== undefined ? { budgetLocked: locked } : {}),
+    },
   });
 
   revalidatePath("/dashboard/categories");

--- a/web/src/lib/actions/categories.ts
+++ b/web/src/lib/actions/categories.ts
@@ -158,6 +158,8 @@ export async function setCategoryBudget(
   const cat = await ownedCategory(id, session.user.id);
   if (!cat)
     return { success: false, message: "Category not found or not editable" };
+  if (cat.isGroup)
+    return { success: false, message: "Groups don't hold a budget" };
 
   await prisma.category.update({
     where: { id },
@@ -183,12 +185,13 @@ export async function setCategoryBudgets(
   )
     return { success: false, message: "Invalid amount" };
 
-  // All targets must belong to this user.
+  // All targets must belong to this user and be leaf categories (groups don't
+  // hold budgets).
   const owned = await prisma.category.findMany({
     where: { userId, id: { in: updates.map((u) => u.id) } },
-    select: { id: true },
+    select: { id: true, isGroup: true },
   });
-  if (owned.length !== updates.length)
+  if (owned.length !== updates.length || owned.some((c) => c.isGroup))
     return { success: false, message: "Category not found or not editable" };
 
   await prisma.$transaction(

--- a/web/src/lib/actions/categories.ts
+++ b/web/src/lib/actions/categories.ts
@@ -15,6 +15,7 @@ export type CategoryStat = {
   isGroup: boolean;
   parentId: string | null;
   monthlyBudget: number | null;
+  budgetLocked: boolean;
   spend: number;
 };
 
@@ -96,6 +97,7 @@ export async function getCategories(): Promise<CategoryStat[]> {
     isGroup: c.isGroup,
     parentId: c.parentId,
     monthlyBudget: c.monthlyBudget === null ? null : Number(c.monthlyBudget),
+    budgetLocked: c.budgetLocked,
     spend: spendById.get(c.id) ?? 0,
   }));
 }

--- a/web/src/lib/budget.ts
+++ b/web/src/lib/budget.ts
@@ -116,6 +116,10 @@ export function weightedBudgets(
 ): { id: string; monthlyBudget: number }[] {
   const n = cats.length;
   if (n === 0 || budget <= 0) return [];
+  // Floor so a never-used category never lands at ₹0 (which would instantly read
+  // "over limit"); the rest of the budget is distributed by weight on top.
+  const minShare = Math.floor((budget / n) * 0.1);
+  const pool = budget - minShare * n;
   const totalSpend = cats.reduce((s, c) => s + Math.max(0, c.spend), 0);
   const totalLimit = cats.reduce((s, c) => s + (c.monthlyBudget ?? 0), 0);
   const weightOf = (c: { spend: number; monthlyBudget: number | null }) =>
@@ -127,7 +131,7 @@ export function weightedBudgets(
   const totalWeight = cats.reduce((s, c) => s + weightOf(c), 0);
   const raw = cats.map((c) => ({
     id: c.id,
-    amount: Math.floor((budget * weightOf(c)) / totalWeight),
+    amount: minShare + Math.floor((pool * weightOf(c)) / totalWeight),
     w: weightOf(c),
   }));
   let remainder = budget - raw.reduce((s, r) => s + r.amount, 0);

--- a/web/src/lib/budget.ts
+++ b/web/src/lib/budget.ts
@@ -108,33 +108,45 @@ export function categoryPacing(args: {
 }
 
 // Distribute `budget` across categories weighted by recent spend; fall back to
-// current limits, then an even split, when there's nothing to weight by. Integer
-// amounts that sum to `budget` exactly (rounding remainder to the largest share).
+// current limits, then an even split, when there's nothing to weight by.
+// Pinned (budgetLocked) categories keep their amount and are excluded — only the
+// remainder (budget − Σ pinned) is spread across the un-pinned ones, and only
+// they are returned. Integer amounts that sum to the remainder exactly.
 export function weightedBudgets(
-  cats: { id: string; spend: number; monthlyBudget: number | null }[],
+  cats: {
+    id: string;
+    spend: number;
+    monthlyBudget: number | null;
+    budgetLocked?: boolean;
+  }[],
   budget: number,
 ): { id: string; monthlyBudget: number }[] {
-  const n = cats.length;
+  const unlocked = cats.filter((c) => !c.budgetLocked);
+  const n = unlocked.length;
   if (n === 0 || budget <= 0) return [];
-  // Floor so a never-used category never lands at ₹0 (which would instantly read
-  // "over limit"); the rest of the budget is distributed by weight on top.
-  const minShare = Math.floor((budget / n) * 0.1);
-  const pool = budget - minShare * n;
-  const totalSpend = cats.reduce((s, c) => s + Math.max(0, c.spend), 0);
-  const totalLimit = cats.reduce((s, c) => s + (c.monthlyBudget ?? 0), 0);
+  const lockedTotal = cats
+    .filter((c) => c.budgetLocked)
+    .reduce((s, c) => s + (c.monthlyBudget ?? 0), 0);
+  const target = Math.max(0, budget - lockedTotal); // spread over un-pinned
+  if (target <= 0) return unlocked.map((c) => ({ id: c.id, monthlyBudget: 0 }));
+  // Floor so a never-used category never lands at ₹0; the rest is by weight.
+  const minShare = Math.floor((target / n) * 0.1);
+  const pool = target - minShare * n;
+  const totalSpend = unlocked.reduce((s, c) => s + Math.max(0, c.spend), 0);
+  const totalLimit = unlocked.reduce((s, c) => s + (c.monthlyBudget ?? 0), 0);
   const weightOf = (c: { spend: number; monthlyBudget: number | null }) =>
     totalSpend > 0
       ? Math.max(0, c.spend)
       : totalLimit > 0
         ? (c.monthlyBudget ?? 0)
         : 1; // even
-  const totalWeight = cats.reduce((s, c) => s + weightOf(c), 0);
-  const raw = cats.map((c) => ({
+  const totalWeight = unlocked.reduce((s, c) => s + weightOf(c), 0);
+  const raw = unlocked.map((c) => ({
     id: c.id,
     amount: minShare + Math.floor((pool * weightOf(c)) / totalWeight),
     w: weightOf(c),
   }));
-  let remainder = budget - raw.reduce((s, r) => s + r.amount, 0);
+  let remainder = target - raw.reduce((s, r) => s + r.amount, 0);
   // Hand the rounding leftover to the largest-weight categories.
   raw.sort((a, b) => b.w - a.w);
   for (let i = 0; remainder > 0; i = (i + 1) % n, remainder--)

--- a/web/src/lib/budget.ts
+++ b/web/src/lib/budget.ts
@@ -79,6 +79,7 @@ export interface CategoryPacing {
   safeDaily: number; // ₹/day left to stay under the limit (0 if no limit)
   overPace: boolean; // projected to exceed the limit
   overSpent: boolean; // already over the limit
+  reliable: boolean; // enough of the cycle elapsed for the projection to mean anything
 }
 
 // Burn-rate guidance for one category from spend-so-far + where we are in the
@@ -100,6 +101,9 @@ export function categoryPacing(args: {
     safeDaily: hasLimit ? Math.max(0, limit - spent) / remainingDays : 0,
     overPace: hasLimit ? dailyRate * daysInPeriod > limit : false,
     overSpent: hasLimit ? spent > limit : false,
+    // First couple of days, one expense skews the run-rate wildly — don't trust
+    // the projection yet.
+    reliable: day >= 3,
   };
 }
 


### PR DESCRIPTION
Reworks the Categories section so the budget model is coherent and the page stops confusing users. Four themes, all small commits.

## 1. Clarity fixes
- **Savings framed as a goal**, not a warning — no red "over"; shows "saved / X to go / X beyond target" and "save X/day to target".
- **Uncategorized line per bucket** so category rows reconcile with the bucket total (bucket spend includes uncategorized/hidden spend).
- **Early-cycle projection guard** — `categoryPacing.reliable` (≥ day 3); a single day-1 expense no longer projects a scary overshoot.
- **Wording** — "this cycle" (not "month"); weekly labeled "projected".
- **Auto-balance safety** — min floor (no category lands at ₹0); non-destructive (non-red) confirm.

## 2. Groups are organization-only (the "Food & Drinks inside Food & Drinks" bug)
- Group rows **never render as categories** (dropped the spend/budget escape hatch).
- **Flat list with the group as a subtle tag** instead of sub-headers — each category appears once under its bucket; no header/row collision, no group spanning two buckets.
- **Expenses/budgets never attach to groups**: a group-name expense keeps its bucket but stays uncategorized (→ Needs Review), never creates a twin leaf; `setCategoryBudget(s)` reject groups.
- **`scripts/cleanup-group-data.mjs`** (idempotent) detaches legacy group-attached expenses and clears group budgets.

## 3. Pinned (fixed) category budgets
- New **`Category.budgetLocked`** flag (migration).
- A **"Set a fixed monthly limit"** toggle in Add + a **"Pin this amount"** switch in Edit; pinned rows show a 🔒.
- **Auto-balance is lock-aware**: pinned amounts are kept exactly; only `budget − Σ pinned` is distributed across the un-pinned categories.

## 4. Pre-existing lint cleanup
Fixed the repo's standing eslint errors (unescaped apostrophe, `setState`-in-effect, `any`) from an earlier UX refactor — `pnpm lint` is green again.

## Verification
- Web `pnpm lint` (0 errors) + `pnpm build`; backend `pnpm build` + `pnpm test:unit` (91 passing).

## Deploy notes
- Migrations (`add_category_weight`, `add_category_budget_lock`) apply via the Railway predeploy (`prisma migrate deploy`).
- Run once against prod: `node scripts/cleanup-group-data.mjs` (detach legacy group spend + clear group budgets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)