### PR TITLE
Smart category budgets: data-driven suggestions, not forced auto-allocation

### DIFF
--- a/web/src/app/dashboard/categories/_components/bucket-section.tsx
+++ b/web/src/app/dashboard/categories/_components/bucket-section.tsx
@@ -5,7 +5,10 @@ import { ConfirmDialog } from "@/components/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { BUCKET_META } from "@/lib/budget";
 import { CategoryRow } from "./category-row";
-import type { CategoryStat } from "@/lib/actions/categories";
+import type {
+  CategoryStat,
+  CategorySuggestion,
+} from "@/lib/actions/categories";
 import type { Bucket } from "@prisma/client";
 
 interface BucketOverview {
@@ -20,6 +23,7 @@ interface BucketSectionProps {
   overview: BucketOverview;
   categories: CategoryStat[];
   groupNameById: Map<string, string>;
+  suggestionById: Map<string, CategorySuggestion>;
   money: (n: number) => string;
   day: number;
   daysInPeriod: number;
@@ -27,7 +31,8 @@ interface BucketSectionProps {
   isPending: boolean;
   onEdit: (cat: CategoryStat) => void;
   onDelete: (cat: CategoryStat) => void;
-  onAutoBalance: (cats: CategoryStat[], budget: number) => void;
+  onApplyBudget: (id: string, amount: number, locked: boolean) => void;
+  onApplyAll: (cats: CategoryStat[]) => void;
 }
 
 export const BucketSection = ({
@@ -35,6 +40,7 @@ export const BucketSection = ({
   overview,
   categories,
   groupNameById,
+  suggestionById,
   money,
   day,
   daysInPeriod,
@@ -42,7 +48,8 @@ export const BucketSection = ({
   isPending,
   onEdit,
   onDelete,
-  onAutoBalance,
+  onApplyBudget,
+  onApplyAll,
 }: BucketSectionProps) => {
   const meta = BUCKET_META[bucket];
   const { budget, spent, remaining, pct } = overview;
@@ -59,6 +66,13 @@ export const BucketSection = ({
   // system-category spend) — surfaced so the rows reconcile with the bucket total.
   const shownSpend = categories.reduce((s, c) => s + c.spend, 0);
   const uncategorized = Math.max(0, spent - shownSpend);
+  // Un-pinned categories whose data-driven suggestion differs from the current
+  // limit — these are what "Apply suggested" would set.
+  const applicable = categories.filter((c) => {
+    if (c.budgetLocked) return false;
+    const s = suggestionById.get(c.id);
+    return s?.amount != null && s.amount !== c.monthlyBudget;
+  });
 
   return (
     <div>
@@ -108,7 +122,7 @@ export const BucketSection = ({
         </p>
       </div>
 
-      {/* Allocation bar + auto-balance */}
+      {/* Allocation (informational) + apply data-driven suggestions */}
       {categories.length > 0 && budget > 0 && (
         <div className="flex items-center justify-between gap-2 border-t pt-2 pb-3">
           <p className="text-xs tabular-nums text-muted-foreground">
@@ -119,23 +133,25 @@ export const BucketSection = ({
                 : `${money(unallocated)} unallocated`}
             </span>
           </p>
-          <ConfirmDialog
-            title={`Auto-balance ${meta.label}?`}
-            description={`Distribute ${money(budget)} across ${meta.label} weighted by your recent spending. This replaces their current limits.`}
-            confirmLabel="Auto-balance"
-            destructive={false}
-            onConfirm={() => onAutoBalance(categories, budget)}
-            trigger={
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 shrink-0 text-xs"
-                disabled={isPending}
-              >
-                Auto-balance
-              </Button>
-            }
-          />
+          {applicable.length > 0 && (
+            <ConfirmDialog
+              title={`Apply suggested budgets to ${meta.label}?`}
+              description={`Set ${applicable.length} categor${applicable.length === 1 ? "y" : "ies"} to budgets suggested from your recurring expenses and recent history. Pinned categories are left untouched.`}
+              confirmLabel="Apply suggested"
+              destructive={false}
+              onConfirm={() => onApplyAll(categories)}
+              trigger={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 shrink-0 text-xs"
+                  disabled={isPending}
+                >
+                  Apply suggested
+                </Button>
+              }
+            />
+          )}
         </div>
       )}
 
@@ -156,6 +172,7 @@ export const BucketSection = ({
                   ? (groupNameById.get(cat.parentId) ?? null)
                   : null
               }
+              suggestion={suggestionById.get(cat.id) ?? null}
               money={money}
               day={day}
               daysInPeriod={daysInPeriod}
@@ -163,6 +180,7 @@ export const BucketSection = ({
               isPending={isPending}
               onEdit={onEdit}
               onDelete={onDelete}
+              onApplyBudget={onApplyBudget}
             />
           ))}
         </div>

--- a/web/src/app/dashboard/categories/_components/category-row.tsx
+++ b/web/src/app/dashboard/categories/_components/category-row.tsx
@@ -11,11 +11,15 @@ import { Pencil, Trash2, Lock } from "lucide-react";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { categoryPacing } from "@/lib/budget";
-import type { CategoryStat } from "@/lib/actions/categories";
+import type {
+  CategoryStat,
+  CategorySuggestion,
+} from "@/lib/actions/categories";
 
 interface CategoryRowProps {
   cat: CategoryStat;
   groupName: string | null;
+  suggestion: CategorySuggestion | null;
   money: (n: number) => string;
   day: number;
   daysInPeriod: number;
@@ -23,11 +27,19 @@ interface CategoryRowProps {
   isPending: boolean;
   onEdit: (cat: CategoryStat) => void;
   onDelete: (cat: CategoryStat) => void;
+  onApplyBudget: (id: string, amount: number, locked: boolean) => void;
 }
+
+const BASIS_LABEL: Record<CategorySuggestion["basis"], string> = {
+  recurring: "fixed",
+  history: "3-mo median",
+  new: "",
+};
 
 export const CategoryRow = ({
   cat,
   groupName,
+  suggestion,
   money,
   day,
   daysInPeriod,
@@ -35,8 +47,16 @@ export const CategoryRow = ({
   isPending,
   onEdit,
   onDelete,
+  onApplyBudget,
 }: CategoryRowProps) => {
   const hasLimit = cat.monthlyBudget != null;
+  // Show a suggestion only when it differs from the current limit and isn't pinned.
+  const suggest =
+    !cat.budgetLocked &&
+    suggestion?.amount != null &&
+    suggestion.amount !== cat.monthlyBudget
+      ? suggestion
+      : null;
   const left = hasLimit ? cat.monthlyBudget! - cat.spend : null;
   const pace = categoryPacing({
     spent: cat.spend,
@@ -158,6 +178,26 @@ export const CategoryRow = ({
             </>
           )}
         </p>
+        {suggest && (
+          <p className="text-xs tabular-nums text-muted-foreground">
+            Suggested {money(suggest.amount!)}
+            {BASIS_LABEL[suggest.basis] && ` · ${BASIS_LABEL[suggest.basis]}`} ·{" "}
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={() =>
+                onApplyBudget(
+                  cat.id,
+                  suggest.amount!,
+                  suggest.basis === "recurring",
+                )
+              }
+              className="font-medium text-primary hover:underline disabled:opacity-50"
+            >
+              Apply
+            </button>
+          </p>
+        )}
       </div>
       <div className="flex shrink-0 items-center gap-1">
         <Button

--- a/web/src/app/dashboard/categories/page.tsx
+++ b/web/src/app/dashboard/categories/page.tsx
@@ -11,17 +11,15 @@ import {
 } from "@/components/ui/accordion";
 import {
   getCategories,
+  getCategorySuggestions,
   deleteCategory,
+  setCategoryBudget,
+  setCategoryBudgets,
   type CategoryStat,
+  type CategorySuggestion,
 } from "@/lib/actions/categories";
 import { getBudgetOverview } from "@/lib/actions/budget";
-import {
-  BUCKETS,
-  BUCKET_META,
-  formatMoney,
-  weightedBudgets,
-} from "@/lib/budget";
-import { setCategoryBudgets } from "@/lib/actions/categories";
+import { BUCKETS, BUCKET_META, formatMoney } from "@/lib/budget";
 import { toast } from "@/lib/toast";
 import { AddCategoryForm } from "./_components/add-category-form";
 import { BucketSection } from "./_components/bucket-section";
@@ -32,17 +30,20 @@ type Overview = Awaited<ReturnType<typeof getBudgetOverview>>;
 export default function CategoriesPage() {
   const [categories, setCategories] = useState<CategoryStat[]>([]);
   const [overview, setOverview] = useState<Overview | null>(null);
+  const [suggestions, setSuggestions] = useState<CategorySuggestion[]>([]);
   const [isPending, startTransition] = useTransition();
   const [editing, setEditing] = useState<CategoryStat | null>(null);
 
   const load = () =>
     startTransition(async () => {
-      const [cats, ov] = await Promise.all([
+      const [cats, ov, sugg] = await Promise.all([
         getCategories(),
         getBudgetOverview(),
+        getCategorySuggestions(),
       ]);
       setCategories(cats);
       setOverview(ov);
+      setSuggestions(sugg);
     });
 
   useEffect(() => {
@@ -69,6 +70,11 @@ export default function CategoriesPage() {
     [categories],
   );
 
+  const suggestionById = useMemo(
+    () => new Map(suggestions.map((s) => [s.categoryId, s])),
+    [suggestions],
+  );
+
   const handleDelete = (cat: CategoryStat) =>
     startTransition(async () => {
       const res = await deleteCategory(cat.id);
@@ -80,16 +86,40 @@ export default function CategoriesPage() {
       load();
     });
 
-  const autoBalance = (cats: CategoryStat[], budget: number) =>
+  // Apply one category's suggested budget. Fixed (recurring) suggestions are
+  // pinned; history suggestions are a soft accepted estimate.
+  const applyBudget = (id: string, amount: number, locked: boolean) =>
     startTransition(async () => {
-      const updates = weightedBudgets(cats, budget);
-      if (updates.length === 0) return;
-      const res = await setCategoryBudgets(updates);
+      const res = await setCategoryBudget(id, amount, locked);
       if (!res.success) {
-        toast.error(res.message ?? "Failed to auto-balance");
+        toast.error(res.message ?? "Failed to apply");
         return;
       }
-      toast.success("Budgets auto-balanced");
+      toast.success("Budget applied");
+      load();
+    });
+
+  // Apply every non-pinned suggestion in a bucket at once (no forced bucket sum).
+  const applyAll = (cats: CategoryStat[]) =>
+    startTransition(async () => {
+      const updates = cats
+        .filter((c) => !c.budgetLocked)
+        .map((c) => ({ c, amount: suggestionById.get(c.id)?.amount }))
+        .filter(
+          (x): x is { c: CategoryStat; amount: number } =>
+            x.amount != null && x.amount !== x.c.monthlyBudget,
+        )
+        .map((x) => ({ id: x.c.id, monthlyBudget: x.amount }));
+      if (updates.length === 0) {
+        toast("No new suggestions to apply");
+        return;
+      }
+      const res = await setCategoryBudgets(updates);
+      if (!res.success) {
+        toast.error(res.message ?? "Failed to apply suggestions");
+        return;
+      }
+      toast.success("Suggested budgets applied");
       load();
     });
 
@@ -153,6 +183,7 @@ export default function CategoriesPage() {
                       }}
                       categories={inBucket}
                       groupNameById={groupNameById}
+                      suggestionById={suggestionById}
                       money={money}
                       day={day}
                       daysInPeriod={daysInPeriod}
@@ -160,7 +191,8 @@ export default function CategoriesPage() {
                       isPending={isPending}
                       onEdit={setEditing}
                       onDelete={handleDelete}
-                      onAutoBalance={autoBalance}
+                      onApplyBudget={applyBudget}
+                      onApplyAll={applyAll}
                     />
                   </AccordionContent>
                 </AccordionItem>

--- a/web/src/lib/actions/categories.ts
+++ b/web/src/lib/actions/categories.ts
@@ -5,7 +5,7 @@ import { auth } from "@/auth";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { Bucket } from "@prisma/client";
-import { currentBudgetPeriod } from "@/lib/budget";
+import { currentBudgetPeriod, previousCycles, median } from "@/lib/budget";
 
 export type CategoryStat = {
   id: string;
@@ -100,6 +100,94 @@ export async function getCategories(): Promise<CategoryStat[]> {
     budgetLocked: c.budgetLocked,
     spend: spendById.get(c.id) ?? 0,
   }));
+}
+
+export type CategorySuggestion = {
+  categoryId: string;
+  amount: number | null;
+  basis: "recurring" | "history" | "new";
+};
+
+const roundTo50 = (n: number) => Math.round(n / 50) * 50;
+
+// Data-driven per-category budget suggestions:
+// - "recurring": exact sum of the category's active recurring expenses (fixed).
+// - "history": median spend over the last 3 complete cycles, rounded (robust to
+//   lumpy months); only when > 0.
+// - "new": no signal → no suggestion.
+export async function getCategorySuggestions(): Promise<CategorySuggestion[]> {
+  const session = await auth();
+  if (!session?.user?.id) return [];
+  const userId = session.user.id;
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { payday: true },
+  });
+  const payday = user?.payday ?? 1;
+
+  const [cats, rules] = await Promise.all([
+    prisma.category.findMany({
+      where: { userId, isGroup: false },
+      select: { id: true },
+    }),
+    prisma.recurringRule.findMany({
+      where: {
+        userId,
+        isActive: true,
+        kind: "EXPENSE",
+        categoryId: { not: null },
+      },
+      select: { categoryId: true, amount: true },
+    }),
+  ]);
+
+  // Fixed: sum of active recurring expenses per category.
+  const fixedById = new Map<string, number>();
+  for (const r of rules) {
+    if (!r.categoryId) continue;
+    fixedById.set(
+      r.categoryId,
+      (fixedById.get(r.categoryId) ?? 0) + Number(r.amount),
+    );
+  }
+
+  // History: per-category totals across the last 3 complete cycles.
+  const cycles = previousCycles(payday, 3); // newest first
+  const oldest = cycles[cycles.length - 1]?.start;
+  const newestEnd = cycles[0]?.end; // == start of the current (partial) cycle
+  const perCatPerCycle = new Map<string, number[]>();
+  if (oldest && newestEnd) {
+    const expenses = await prisma.expense.findMany({
+      where: {
+        userId,
+        isDeleted: false,
+        categoryId: { not: null },
+        date: { gte: oldest, lt: newestEnd },
+      },
+      select: { categoryId: true, amount: true, date: true },
+    });
+    for (const e of expenses) {
+      if (!e.categoryId) continue;
+      const idx = cycles.findIndex((c) => e.date >= c.start && e.date < c.end);
+      if (idx === -1) continue;
+      const arr =
+        perCatPerCycle.get(e.categoryId) ?? new Array(cycles.length).fill(0);
+      arr[idx] += Number(e.amount);
+      perCatPerCycle.set(e.categoryId, arr);
+    }
+  }
+
+  return cats.map((c): CategorySuggestion => {
+    const fixed = fixedById.get(c.id);
+    if (fixed && fixed > 0)
+      return { categoryId: c.id, amount: fixed, basis: "recurring" };
+    const m = median(
+      perCatPerCycle.get(c.id) ?? new Array(cycles.length).fill(0),
+    );
+    if (m > 0)
+      return { categoryId: c.id, amount: roundTo50(m), basis: "history" };
+    return { categoryId: c.id, amount: null, basis: "new" };
+  });
 }
 
 export async function createCategory(

--- a/web/src/lib/budget.ts
+++ b/web/src/lib/budget.ts
@@ -136,53 +136,6 @@ export function categoryPacing(args: {
   };
 }
 
-// Distribute `budget` across categories weighted by recent spend; fall back to
-// current limits, then an even split, when there's nothing to weight by.
-// Pinned (budgetLocked) categories keep their amount and are excluded — only the
-// remainder (budget − Σ pinned) is spread across the un-pinned ones, and only
-// they are returned. Integer amounts that sum to the remainder exactly.
-export function weightedBudgets(
-  cats: {
-    id: string;
-    spend: number;
-    monthlyBudget: number | null;
-    budgetLocked?: boolean;
-  }[],
-  budget: number,
-): { id: string; monthlyBudget: number }[] {
-  const unlocked = cats.filter((c) => !c.budgetLocked);
-  const n = unlocked.length;
-  if (n === 0 || budget <= 0) return [];
-  const lockedTotal = cats
-    .filter((c) => c.budgetLocked)
-    .reduce((s, c) => s + (c.monthlyBudget ?? 0), 0);
-  const target = Math.max(0, budget - lockedTotal); // spread over un-pinned
-  if (target <= 0) return unlocked.map((c) => ({ id: c.id, monthlyBudget: 0 }));
-  // Floor so a never-used category never lands at ₹0; the rest is by weight.
-  const minShare = Math.floor((target / n) * 0.1);
-  const pool = target - minShare * n;
-  const totalSpend = unlocked.reduce((s, c) => s + Math.max(0, c.spend), 0);
-  const totalLimit = unlocked.reduce((s, c) => s + (c.monthlyBudget ?? 0), 0);
-  const weightOf = (c: { spend: number; monthlyBudget: number | null }) =>
-    totalSpend > 0
-      ? Math.max(0, c.spend)
-      : totalLimit > 0
-        ? (c.monthlyBudget ?? 0)
-        : 1; // even
-  const totalWeight = unlocked.reduce((s, c) => s + weightOf(c), 0);
-  const raw = unlocked.map((c) => ({
-    id: c.id,
-    amount: minShare + Math.floor((pool * weightOf(c)) / totalWeight),
-    w: weightOf(c),
-  }));
-  let remainder = target - raw.reduce((s, r) => s + r.amount, 0);
-  // Hand the rounding leftover to the largest-weight categories.
-  raw.sort((a, b) => b.w - a.w);
-  for (let i = 0; remainder > 0; i = (i + 1) % n, remainder--)
-    raw[i].amount += 1;
-  return raw.map((r) => ({ id: r.id, monthlyBudget: r.amount }));
-}
-
 export function bucketPct(split: BudgetSplit, bucket: Bucket): number {
   switch (bucket) {
     case "NEEDS":

--- a/web/src/lib/budget.ts
+++ b/web/src/lib/budget.ts
@@ -48,6 +48,35 @@ export function currentBudgetPeriod(
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+// The `n` most recent COMPLETE budget cycles (excludes the current partial one),
+// newest first. Used to estimate a category's typical monthly spend.
+export function previousCycles(
+  payday: number,
+  n: number,
+  now: Date = new Date(),
+): { start: Date; end: Date }[] {
+  const out: { start: Date; end: Date }[] = [];
+  let ref = currentBudgetPeriod(payday, now).start; // start of the current cycle
+  for (let i = 0; i < n; i++) {
+    const prev = currentBudgetPeriod(
+      payday,
+      new Date(ref.getTime() - MS_PER_DAY),
+    );
+    out.push(prev);
+    ref = prev.start;
+  }
+  return out;
+}
+
+// Median of a list (0 for empty). Robust central estimate — unlike the mean it
+// isn't dragged up by one lumpy month.
+export function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const s = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
 export interface PeriodDayInfo {
   day: number; // 1-based day within the cycle
   daysInPeriod: number;


### PR DESCRIPTION
Replaces the "Auto-balance" feature (which divided the whole bucket by this-cycle partial spend) with **per-category, data-driven suggestions you accept**. Fixes the real-world problems: forced zero-sum allocation, noisy single-cycle weighting, no fixed/variable distinction, and destructive one-shot overwrite.

> Stacked on `fix/categories-improvement` (PR #39) — review/merge that first, or retarget to `main` after it lands.

## How budgets are suggested now
Per leaf category:
- **Fixed** — has an active recurring expense (`RecurringRule.categoryId`) → suggested = the **exact recurring amount** (rent, EMI, subscriptions). Applying pins it.
- **Variable** — **median of the last 3 complete cycles** (median ⇒ robust to lumpy months like Travel), rounded to ₹50.
- **New / no history** — no suggestion (we don't fabricate a number).

## UX
- Each category shows `Suggested ₹X · fixed / 3-mo median · Apply`. Apply sets just that category (fixed → pinned, history → soft).
- A per-bucket **"Apply suggested"** applies all non-pinned suggestions at once; pinned/fixed are never touched.
- The bucket allocation ("₹X of ₹Y") is **informational only** — no forced sum-to-bucket.

## Implementation
- `getCategorySuggestions()` server action: recurring map + one batched query over the last 3 cycles → per-category median; returns `{ amount, basis }`.
- Pure helpers `previousCycles` + `median` in `budget.ts`.
- Removed the divide-the-bucket `weightedBudgets` and the Auto-balance button. Onboarding's template split is unchanged.

## Verification
- `pnpm lint` (0 errors) + `pnpm build` clean.
- Manual: steady category → "3-mo median" suggestion; recurring-backed category → "fixed" = exact amount (apply pins it); lumpy/no-history → no suggestion; Apply / Apply-suggested set budgets without forcing the bucket sum; pinned untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)