### PR TITLE
feat: end-of-cycle report over Telegram (cycle vs cycle)

### DIFF
--- a/prisma/migrations/20260629180409_add_cycle_report_nudge_kind/migration.sql
+++ b/prisma/migrations/20260629180409_add_cycle_report_nudge_kind/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "NudgeKind" ADD VALUE 'CYCLE_REPORT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ enum NudgeKind {
   WARN_80
   OVER
   CHECKIN
+  CYCLE_REPORT
 }
 
 enum RecurringKind {

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import {
   telegramWebhookController,
   sendBudgetNudges,
   postRecurringCharges,
+  sendCycleReport,
 } from "./presentation/controllers/TelegramWebhookController";
 import { startScheduler } from "./infrastructure/scheduler";
 import { logger } from "./utils/logger";
@@ -50,7 +51,7 @@ if (process.env.NODE_ENV !== "test") {
         "SARVAM_API_KEY not set — voice transcription disabled; users will be asked to type instead.",
       );
     }
-    startScheduler(sendBudgetNudges, postRecurringCharges);
+    startScheduler(sendBudgetNudges, postRecurringCharges, sendCycleReport);
     telegramWebhookController
       .registerBotCommands()
       .catch((err) => logger.error("registerBotCommands failed", { err }));

--- a/src/application/use-cases/SendCycleReport.spec.ts
+++ b/src/application/use-cases/SendCycleReport.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SendCycleReportUseCase } from "./SendCycleReport";
+
+// payday=1 → cycle rolls over on the 1st. Jun 1 is day 1; Jun 10 is not.
+const user = { id: "u1", telegramId: "123", monthlyIncome: 50000, payday: 1 };
+
+describe("SendCycleReport", () => {
+  let userRepository: any;
+  let expenseRepository: any;
+  let budgetConfigRepository: any;
+  let nudgeRepository: any;
+  let incomeRepository: any;
+  let messageService: any;
+  let useCase: SendCycleReportUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userRepository = {
+      findOnboardedWithTelegram: vi.fn().mockResolvedValue([user]),
+    };
+    expenseRepository = {
+      sumByBucketForMonth: vi.fn().mockResolvedValue(0),
+      categoryTotals: vi.fn().mockResolvedValue([]),
+    };
+    budgetConfigRepository = {
+      findByUserId: vi
+        .fn()
+        .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
+    };
+    nudgeRepository = { recordSentIfNew: vi.fn().mockResolvedValue(true) };
+    incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
+    messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    useCase = new SendCycleReportUseCase(
+      userRepository,
+      expenseRepository,
+      budgetConfigRepository,
+      nudgeRepository,
+      incomeRepository,
+      messageService,
+    );
+  });
+
+  it("sends the report on day 1 of a new cycle", async () => {
+    const { sent } = await useCase.execute(new Date(2026, 5, 1));
+    expect(sent).toBe(1);
+    expect(nudgeRepository.recordSentIfNew).toHaveBeenCalledWith(
+      "u1",
+      "NEEDS",
+      "CYCLE_REPORT",
+      "2026-05-01", // ended cycle = May
+    );
+    expect(messageService.sendMessage).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing mid-cycle", async () => {
+    const { sent } = await useCase.execute(new Date(2026, 5, 10));
+    expect(sent).toBe(0);
+    expect(messageService.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — skips when already recorded for this cycle", async () => {
+    nudgeRepository.recordSentIfNew.mockResolvedValue(false);
+    const { sent } = await useCase.execute(new Date(2026, 5, 1));
+    expect(sent).toBe(0);
+    expect(messageService.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/application/use-cases/SendCycleReport.ts
+++ b/src/application/use-cases/SendCycleReport.ts
@@ -1,0 +1,78 @@
+import { IUserRepository } from "../../domain/repositories/IUserRepository";
+import { IExpenseRepository } from "../../domain/repositories/IExpenseRepository";
+import { IBudgetConfigRepository } from "../../domain/repositories/IBudgetConfigRepository";
+import { INudgeRepository } from "../../domain/repositories/INudgeRepository";
+import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
+import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
+import { buildCycleReport } from "./cycleReport";
+import { periodDayInfo } from "./budgetMath";
+
+export interface SendCycleReportResult {
+  sent: number;
+}
+
+// On the first day of a fresh budget cycle (the user's payday), DM the
+// just-ended cycle's summary + comparison to the prior cycle. Idempotent per
+// ended cycle via the BudgetNudge ledger (kind CYCLE_REPORT), so a daily cron
+// only sends once even if it runs every morning.
+export class SendCycleReportUseCase {
+  constructor(
+    private readonly userRepository: IUserRepository,
+    private readonly expenseRepository: IExpenseRepository,
+    private readonly budgetConfigRepository: IBudgetConfigRepository,
+    private readonly nudgeRepository: INudgeRepository,
+    private readonly incomeRepository: IIncomeRepository,
+    private readonly messageService: IMessagingPlatform,
+  ) {}
+
+  async execute(now: Date = new Date()): Promise<SendCycleReportResult> {
+    const users = await this.userRepository.findOnboardedWithTelegram();
+
+    let sent = 0;
+    for (const user of users) {
+      try {
+        sent += await this.reportUser(user, now);
+      } catch (err) {
+        // One user's failure must not abort the batch.
+        console.error(`Cycle report failed for user ${user.id}:`, err);
+      }
+    }
+    return { sent };
+  }
+
+  private async reportUser(
+    user: {
+      id: string;
+      telegramId: string | null;
+      monthlyIncome: unknown;
+      payday: number;
+    },
+    now: Date,
+  ): Promise<number> {
+    if (!user.telegramId) return 0;
+    // Only on the day the cycle just rolled over.
+    if (periodDayInfo(user.payday, now).day !== 1) return 0;
+
+    const { text, endedKey } = await buildCycleReport(
+      {
+        expenseRepository: this.expenseRepository,
+        budgetConfigRepository: this.budgetConfigRepository,
+        incomeRepository: this.incomeRepository,
+      },
+      user,
+      now,
+    );
+
+    // NEEDS is a placeholder bucket — the ledger row is per-user-per-cycle.
+    const isNew = await this.nudgeRepository.recordSentIfNew(
+      user.id,
+      "NEEDS",
+      "CYCLE_REPORT",
+      endedKey,
+    );
+    if (!isNew) return 0;
+
+    await this.messageService.sendMessage({ to: user.telegramId, body: text });
+    return 1;
+  }
+}

--- a/src/application/use-cases/budgetMath.spec.ts
+++ b/src/application/use-cases/budgetMath.spec.ts
@@ -3,6 +3,7 @@ import {
   bucketBudget,
   currentMonthRange,
   currentBudgetPeriod,
+  previousCycles,
   periodDayInfo,
   periodKey,
   effectiveMonthlyIncome,
@@ -54,6 +55,23 @@ describe("budgetMath", () => {
     expect(progressBar(50)).toBe("█████░░░░░");
     expect(progressBar(100)).toBe("██████████");
     expect(progressBar(150)).toBe("██████████"); // clamped
+  });
+
+  it("previousCycles returns the n most recent complete cycles, newest first", () => {
+    // payday=1 → cycles are calendar months. On Jun 10, current cycle is June;
+    // the prior complete cycles are May, then April.
+    const cycles = previousCycles(1, 2, new Date(2026, 5, 10));
+    expect(cycles[0].start).toEqual(new Date(2026, 4, 1)); // May
+    expect(cycles[0].end).toEqual(new Date(2026, 5, 1));
+    expect(cycles[1].start).toEqual(new Date(2026, 3, 1)); // April
+    expect(cycles[1].end).toEqual(new Date(2026, 4, 1));
+  });
+
+  it("previousCycles handles a mid-month payday across month lengths", () => {
+    // payday=25: on Jun 26 current cycle is Jun 25–Jul 25; just-ended is May 25–Jun 25.
+    const [ended] = previousCycles(25, 1, new Date(2026, 5, 26));
+    expect(ended.start).toEqual(new Date(2026, 4, 25));
+    expect(ended.end).toEqual(new Date(2026, 5, 25));
   });
 
   it("payday=1 budget period equals the calendar month", () => {

--- a/src/application/use-cases/budgetMath.ts
+++ b/src/application/use-cases/budgetMath.ts
@@ -42,6 +42,27 @@ export function currentBudgetPeriod(
   return { start: new Date(y, m - 1, d), end: new Date(y, m, d) };
 }
 
+// The `n` most recent COMPLETE cycles (excludes the current partial one), newest
+// first. Steps back one cycle at a time via currentBudgetPeriod so 28–31-day
+// months are handled correctly. Used for cycle-vs-cycle comparison.
+export function previousCycles(
+  payday: number,
+  n: number,
+  now: Date = new Date(),
+): { start: Date; end: Date }[] {
+  const out: { start: Date; end: Date }[] = [];
+  let ref = currentBudgetPeriod(payday, now).start; // start of the current cycle
+  for (let i = 0; i < n; i++) {
+    const prev = currentBudgetPeriod(
+      payday,
+      new Date(ref.getTime() - 86400000),
+    );
+    out.push(prev);
+    ref = prev.start;
+  }
+  return out;
+}
+
 export function bucketPct(split: BudgetSplit, bucket: Bucket): number {
   switch (bucket) {
     case "NEEDS":

--- a/src/application/use-cases/cycleReport.spec.ts
+++ b/src/application/use-cases/cycleReport.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildCycleReport } from "./cycleReport";
+
+// payday=1 → calendar-month cycles. On Jun 10 the ended cycle is May, prior is April.
+const NOW = new Date(2026, 5, 10);
+const user = { id: "u1", monthlyIncome: 50000, payday: 1 };
+
+// Distinguish ended (May, month 4) from prior (April, month 3) by the range start.
+const isEnded = (start: Date) => start.getMonth() === 4;
+
+describe("buildCycleReport", () => {
+  let expenseRepository: any;
+  let budgetConfigRepository: any;
+  let incomeRepository: any;
+  const deps = () => ({
+    expenseRepository,
+    budgetConfigRepository,
+    incomeRepository,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    budgetConfigRepository = {
+      findByUserId: vi
+        .fn()
+        .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
+    };
+    incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(50000) };
+
+    const ended: Record<string, number> = {
+      NEEDS: 20000,
+      WANTS: 10000,
+      SAVINGS: 5000,
+    };
+    const prior: Record<string, number> = {
+      NEEDS: 25000,
+      WANTS: 12000,
+      SAVINGS: 4000,
+    };
+    expenseRepository = {
+      sumByBucketForMonth: vi.fn((_u: string, bucket: string, start: Date) =>
+        Promise.resolve((isEnded(start) ? ended : prior)[bucket] ?? 0),
+      ),
+      categoryTotals: vi.fn((_u: string, start: Date) =>
+        Promise.resolve(
+          isEnded(start)
+            ? [
+                { name: "Groceries", total: 8000 },
+                { name: "Eating Out", total: 3000 },
+              ]
+            : [
+                { name: "Groceries", total: 9000 },
+                { name: "Eating Out", total: 1500 },
+              ],
+        ),
+      ),
+    };
+  });
+
+  it("builds a report keyed to the ended cycle with the ended-cycle label", async () => {
+    const { text, endedKey } = await buildCycleReport(deps(), user, NOW);
+    expect(endedKey).toBe("2026-05-01");
+    expect(text).toContain("May wrapped");
+    expect(text).toContain("Income logged ₹50,000");
+  });
+
+  it("headlines the overall spend change vs the prior cycle", async () => {
+    // ended total 35,000 vs prior 41,000 → ~15% less.
+    const { text } = await buildCycleReport(deps(), user, NOW);
+    expect(text).toContain("Spent 15% less than last cycle");
+  });
+
+  it("shows per-bucket vs-last deltas and over/under status", async () => {
+    const { text } = await buildCycleReport(deps(), user, NOW);
+    // Needs 20,000 / 25,000 budget, down from 25,000 → under, ↓20% vs last.
+    expect(text).toMatch(
+      /Needs.*₹20,000 \/ ₹25,000.*under by ₹5,000.*↓20% vs last/,
+    );
+  });
+
+  it("names the biggest riser and faller", async () => {
+    const { text } = await buildCycleReport(deps(), user, NOW);
+    // Eating Out +1,500 (up), Groceries -1,000 (down).
+    expect(text).toContain("Eating Out ↑₹1,500");
+    expect(text).toContain("Groceries ↓₹1,000");
+  });
+
+  it("reports net saved when income exceeds spend", async () => {
+    const { text } = await buildCycleReport(deps(), user, NOW);
+    // 50,000 income − 35,000 spend = 15,000 saved.
+    expect(text).toContain("Net saved ₹15,000");
+  });
+});

--- a/src/application/use-cases/cycleReport.ts
+++ b/src/application/use-cases/cycleReport.ts
@@ -54,9 +54,18 @@ function cycleLabel(start: Date, end: Date, payday: number): string {
 }
 
 // Signed percent change vs the prior cycle (null when there's no prior baseline).
-function pctChange(now: number, prev: number): number | null {
+export function pctChange(now: number, prev: number): number | null {
   if (prev <= 0) return null;
   return Math.round(((now - prev) / prev) * 100);
+}
+
+// " · ↓20% vs last" / " · ↑12% vs last" / " · same as last cycle" — the spend
+// delta suffix shared by the cycle report and the on-demand /report.
+export function vsLastSuffix(now: number, prev: number): string {
+  const pct = pctChange(now, prev);
+  if (pct == null) return "";
+  if (pct === 0) return " · same as last cycle";
+  return ` · ${pct > 0 ? "↑" : "↓"}${Math.abs(pct)}% vs last`;
 }
 
 // One bucket's line: spent / budget, then Δ vs last cycle (or goal status for
@@ -69,13 +78,7 @@ function bucketLine(
 ): string {
   const meta = BUCKET_META[bucket];
   const amounts = `${formatMoney(spent)} / ${formatMoney(budget)}`;
-  const pct = pctChange(spent, prevSpent);
-  const vs =
-    pct == null
-      ? ""
-      : pct === 0
-        ? " · same as last cycle"
-        : ` · ${pct > 0 ? "↑" : "↓"}${Math.abs(pct)}% vs last`;
+  const vs = vsLastSuffix(spent, prevSpent);
 
   let status: string;
   if (bucket === "SAVINGS") {

--- a/src/application/use-cases/cycleReport.ts
+++ b/src/application/use-cases/cycleReport.ts
@@ -1,0 +1,226 @@
+import { Bucket } from "@prisma/client";
+import { IExpenseRepository } from "../../domain/repositories/IExpenseRepository";
+import { IBudgetConfigRepository } from "../../domain/repositories/IBudgetConfigRepository";
+import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
+import {
+  BUCKET_META,
+  bucketBudget,
+  effectiveMonthlyIncome,
+  formatMoney,
+  previousCycles,
+  sanitizeMd,
+} from "./budgetMath";
+
+const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
+const ORDER: Bucket[] = ["NEEDS", "WANTS", "SAVINGS"];
+// How many categories to scan per cycle when ranking movers.
+const MOVER_SCAN = 50;
+
+export interface CycleReportDeps {
+  expenseRepository: IExpenseRepository;
+  budgetConfigRepository: IBudgetConfigRepository;
+  incomeRepository: IIncomeRepository;
+}
+
+export interface CycleReportUser {
+  id: string;
+  monthlyIncome: unknown;
+  payday: number;
+}
+
+export interface CycleReport {
+  text: string;
+  endedKey: string; // period key of the ended cycle — idempotency scope
+}
+
+// "YYYY-MM-DD" of a date — matches periodKey's format.
+function dateKey(d: Date): string {
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${y}-${mo}-${da}`;
+}
+
+// "May" for calendar-month cycles (payday=1), else "May 25 – Jun 25".
+function cycleLabel(start: Date, end: Date, payday: number): string {
+  if (payday <= 1) {
+    return new Intl.DateTimeFormat("en-IN", { month: "long" }).format(start);
+  }
+  const fmt = new Intl.DateTimeFormat("en-IN", {
+    month: "short",
+    day: "numeric",
+  });
+  return `${fmt.format(start)} – ${fmt.format(end)}`;
+}
+
+// Signed percent change vs the prior cycle (null when there's no prior baseline).
+function pctChange(now: number, prev: number): number | null {
+  if (prev <= 0) return null;
+  return Math.round(((now - prev) / prev) * 100);
+}
+
+// One bucket's line: spent / budget, then Δ vs last cycle (or goal status for
+// SAVINGS, where spending more is good).
+function bucketLine(
+  bucket: Bucket,
+  spent: number,
+  budget: number,
+  prevSpent: number,
+): string {
+  const meta = BUCKET_META[bucket];
+  const amounts = `${formatMoney(spent)} / ${formatMoney(budget)}`;
+  const pct = pctChange(spent, prevSpent);
+  const vs =
+    pct == null
+      ? ""
+      : pct === 0
+        ? " · same as last cycle"
+        : ` · ${pct > 0 ? "↑" : "↓"}${Math.abs(pct)}% vs last`;
+
+  let status: string;
+  if (bucket === "SAVINGS") {
+    status =
+      spent >= budget && budget > 0
+        ? "✅ goal hit"
+        : `⚠️ short by ${formatMoney(budget - spent)}`;
+  } else {
+    const delta = budget - spent;
+    status =
+      delta >= 0
+        ? `✅ under by ${formatMoney(delta)}`
+        : `❌ over by ${formatMoney(-delta)}`;
+  }
+  return `${meta.emoji} ${meta.label}  ${amounts}  ${status}${vs}`;
+}
+
+// Category deltas (ended − prior) across the union of both cycles' categories,
+// sorted by signed change. Returns the single biggest riser and faller.
+async function movers(
+  deps: CycleReportDeps,
+  userId: string,
+  ended: { start: Date; end: Date },
+  prior: { start: Date; end: Date },
+): Promise<{
+  up: { name: string; delta: number } | null;
+  down: { name: string; delta: number } | null;
+}> {
+  const [endedCats, priorCats] = await Promise.all([
+    deps.expenseRepository.categoryTotals(
+      userId,
+      ended.start,
+      ended.end,
+      null,
+      MOVER_SCAN,
+    ),
+    deps.expenseRepository.categoryTotals(
+      userId,
+      prior.start,
+      prior.end,
+      null,
+      MOVER_SCAN,
+    ),
+  ]);
+
+  const deltas = new Map<string, number>();
+  for (const c of endedCats)
+    deltas.set(c.name, (deltas.get(c.name) ?? 0) + c.total);
+  for (const c of priorCats)
+    deltas.set(c.name, (deltas.get(c.name) ?? 0) - c.total);
+
+  let up: { name: string; delta: number } | null = null;
+  let down: { name: string; delta: number } | null = null;
+  for (const [name, delta] of deltas) {
+    if (delta > 0 && (!up || delta > up.delta)) up = { name, delta };
+    if (delta < 0 && (!down || delta < down.delta)) down = { name, delta };
+  }
+  return { up, down };
+}
+
+// End-of-cycle summary comparing the just-ended cycle to the one before it:
+// income, per-bucket spent vs budget with vs-last deltas, biggest movers, and a
+// decision-oriented headline. Pure formatting on top of the repositories.
+export async function buildCycleReport(
+  deps: CycleReportDeps,
+  user: CycleReportUser,
+  now: Date = new Date(),
+): Promise<CycleReport> {
+  const { payday } = user;
+  const cycles = previousCycles(payday, 2, now);
+  const ended = cycles[0]!;
+  const prior = cycles[1]!;
+  const expected = Number(user.monthlyIncome ?? 0);
+  const config =
+    (await deps.budgetConfigRepository.findByUserId(user.id)) ?? DEFAULT_SPLIT;
+
+  const endedLogged = await deps.incomeRepository.sumForMonth(
+    user.id,
+    ended.start,
+    ended.end,
+  );
+  const endedIncome = effectiveMonthlyIncome(expected, endedLogged);
+
+  const lines: string[] = [];
+  let totalSpent = 0;
+  let totalPrev = 0;
+  for (const bucket of ORDER) {
+    const [spent, prevSpent] = await Promise.all([
+      deps.expenseRepository.sumByBucketForMonth(
+        user.id,
+        bucket,
+        ended.start,
+        ended.end,
+      ),
+      deps.expenseRepository.sumByBucketForMonth(
+        user.id,
+        bucket,
+        prior.start,
+        prior.end,
+      ),
+    ]);
+    totalSpent += spent;
+    totalPrev += prevSpent;
+    lines.push(
+      bucketLine(
+        bucket,
+        spent,
+        bucketBudget(endedIncome, config, bucket),
+        prevSpent,
+      ),
+    );
+  }
+
+  const { up, down } = await movers(deps, user.id, ended, prior);
+  const label = cycleLabel(ended.start, ended.end, payday);
+  const net = endedIncome - totalSpent;
+
+  // Headline: overall spend vs last cycle, framed for a decision.
+  const change = pctChange(totalSpent, totalPrev);
+  let headline: string;
+  if (change == null) {
+    headline = `You spent ${formatMoney(totalSpent)} this cycle.`;
+  } else if (change < 0) {
+    headline = `Spent ${Math.abs(change)}% less than last cycle 🎉 (${formatMoney(totalSpent)}).`;
+  } else if (change > 0) {
+    headline = `Spent ${change}% more than last cycle (${formatMoney(totalSpent)}).`;
+  } else {
+    headline = `Spent the same as last cycle (${formatMoney(totalSpent)}).`;
+  }
+
+  const moverBits: string[] = [];
+  if (up) moverBits.push(`${sanitizeMd(up.name)} ↑${formatMoney(up.delta)}`);
+  if (down)
+    moverBits.push(`${sanitizeMd(down.name)} ↓${formatMoney(-down.delta)}`);
+
+  let text =
+    `📊 ${label} wrapped\n\n` +
+    headline +
+    `\n\nIncome logged ${formatMoney(endedLogged)} (budget on ${formatMoney(endedIncome)})\n` +
+    lines.join("\n") +
+    `\n\n${net >= 0 ? "Net saved" : "Net overspent"} ${formatMoney(Math.abs(net))} (income − spend)`;
+
+  if (moverBits.length > 0) {
+    text += `\n\nBiggest movers: ${moverBits.join(" · ")}`;
+  }
+
+  return { text, endedKey: dateKey(ended.start) };
+}

--- a/src/application/use-cases/processors/ReportProcessor.ts
+++ b/src/application/use-cases/processors/ReportProcessor.ts
@@ -14,8 +14,10 @@ import {
   currentBudgetPeriod,
   effectiveMonthlyIncome,
   formatMoney,
+  previousCycles,
   sanitizeMd,
 } from "../budgetMath";
+import { vsLastSuffix } from "../cycleReport";
 
 const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
 const ORDER: Bucket[] = ["NEEDS", "WANTS", "SAVINGS"];
@@ -47,6 +49,7 @@ export class ReportProcessor implements MessageProcessor {
       (await this.budgetConfigRepository.findByUserId(user.id)) ??
       DEFAULT_SPLIT;
     const { start, end } = currentBudgetPeriod(user.payday);
+    const prior = previousCycles(user.payday, 1)[0]!;
     const loggedIncome = await this.incomeRepository.sumForMonth(
       user.id,
       start,
@@ -61,18 +64,28 @@ export class ReportProcessor implements MessageProcessor {
     }).format(start);
 
     const lines: string[] = [];
+    let totalSpent = 0;
+    let totalPrev = 0;
     for (const bucket of ORDER) {
       const budget = bucketBudget(monthlyIncome, config, bucket);
-      const spent = await this.expenseRepository.sumByBucketForMonth(
-        user.id,
-        bucket,
-        start,
-        end,
-      );
-      lines.push(this.bucketLine(bucket, spent, budget));
+      const [spent, prevSpent] = await Promise.all([
+        this.expenseRepository.sumByBucketForMonth(user.id, bucket, start, end),
+        this.expenseRepository.sumByBucketForMonth(
+          user.id,
+          bucket,
+          prior.start,
+          prior.end,
+        ),
+      ]);
+      totalSpent += spent;
+      totalPrev += prevSpent;
+      lines.push(this.bucketLine(bucket, spent, budget, prevSpent));
     }
 
     let body = `📅 ${monthName} summary\n\nIncome logged ${formatMoney(loggedIncome)} (budget on ${formatMoney(monthlyIncome)})\n${lines.join("\n")}`;
+
+    const vs = vsLastSuffix(totalSpent, totalPrev);
+    if (vs) body += `\n\nTotal spend ${formatMoney(totalSpent)}${vs}`;
 
     const leaks = await this.expenseRepository.topCategoriesForMonth(
       user.id,
@@ -93,7 +106,12 @@ export class ReportProcessor implements MessageProcessor {
     return { response: body, parsed: { intent: "UNKNOWN", confidence: 1 } };
   }
 
-  private bucketLine(bucket: Bucket, spent: number, budget: number): string {
+  private bucketLine(
+    bucket: Bucket,
+    spent: number,
+    budget: number,
+    prevSpent: number,
+  ): string {
     const meta = BUCKET_META[bucket];
     const amounts = `${formatMoney(spent)} / ${formatMoney(budget)}`;
     let status: string;
@@ -109,6 +127,6 @@ export class ReportProcessor implements MessageProcessor {
           ? `✅ under by ${formatMoney(delta)}`
           : `❌ over by ${formatMoney(-delta)}`;
     }
-    return `${meta.emoji} ${meta.label}  ${amounts}  ${status}`;
+    return `${meta.emoji} ${meta.label}  ${amounts}  ${status}${vsLastSuffix(spent, prevSpent)}`;
   }
 }

--- a/src/infrastructure/scheduler.ts
+++ b/src/infrastructure/scheduler.ts
@@ -2,6 +2,7 @@ import cron from "node-cron";
 import { prisma } from "../data/prisma/client";
 import { SendBudgetNudgesUseCase } from "../application/use-cases/SendBudgetNudges";
 import { PostRecurringChargesUseCase } from "../application/use-cases/PostRecurringCharges";
+import { SendCycleReportUseCase } from "../application/use-cases/SendCycleReport";
 import { logger } from "../utils/logger";
 
 const log = logger.child({ component: "scheduler" });
@@ -9,6 +10,7 @@ const log = logger.child({ component: "scheduler" });
 export function startScheduler(
   sendBudgetNudges: SendBudgetNudgesUseCase,
   postRecurringCharges: PostRecurringChargesUseCase,
+  sendCycleReport: SendCycleReportUseCase,
 ): void {
   // Daily recurring auto-post at 6 AM IST (00:30 UTC).
   cron.schedule("30 0 * * *", async () => {
@@ -27,6 +29,17 @@ export function startScheduler(
       log.info("SendBudgetNudges complete", { job: "nudges", sent });
     } catch (err) {
       log.error("SendBudgetNudges failed", { job: "nudges", err });
+    }
+  });
+
+  // End-of-cycle report at ~7 AM IST (01:30 UTC), after recurring auto-posts.
+  // Fires only for users whose cycle rolled over today (day 1); idempotent.
+  cron.schedule("30 1 * * *", async () => {
+    try {
+      const { sent } = await sendCycleReport.execute();
+      log.info("SendCycleReport complete", { job: "cycle-report", sent });
+    } catch (err) {
+      log.error("SendCycleReport failed", { job: "cycle-report", err });
     }
   });
 
@@ -56,6 +69,7 @@ export function startScheduler(
   log.info("Scheduler started", {
     recurring: "00:30 UTC",
     nudges: "13:30 UTC",
+    cycleReport: "01:30 UTC",
     prune: "Sun 00:00 UTC",
   });
 }

--- a/src/presentation/controllers/TelegramWebhookController.ts
+++ b/src/presentation/controllers/TelegramWebhookController.ts
@@ -22,6 +22,7 @@ import { PrismaConversationRepository } from "../../data/repositories/PrismaConv
 import { PrismaNudgeRepository } from "../../data/repositories/PrismaNudgeRepository";
 import { SendBudgetNudgesUseCase } from "../../application/use-cases/SendBudgetNudges";
 import { PostRecurringChargesUseCase } from "../../application/use-cases/PostRecurringCharges";
+import { SendCycleReportUseCase } from "../../application/use-cases/SendCycleReport";
 import { prisma } from "../../data/prisma/client";
 import { RunInTransaction } from "../../domain/repositories/UnitOfWork";
 import { logger } from "../../utils/logger";
@@ -308,4 +309,13 @@ export const postRecurringCharges = new PostRecurringChargesUseCase(
   categoryRepository,
   messageService,
   runInTransaction,
+);
+
+export const sendCycleReport = new SendCycleReportUseCase(
+  userRepository,
+  expenseRepository,
+  budgetConfigRepository,
+  nudgeRepository,
+  incomeRepository,
+  messageService,
 );


### PR DESCRIPTION
## What

When a budget cycle ends, DM the user a **summary + comparison report** over Telegram. The cycle is payday-based (`User.payday`), so the report fires on **day 1 of each new cycle**, summarizing the **just-ended cycle vs the one before it**. The on-demand `/report` gets the same this-vs-last framing.

## How

- **`previousCycles(payday, n)`** (`budgetMath.ts`) — the n most recent complete cycles, newest first; steps back via `currentBudgetPeriod` so 28–31-day months are handled.
- **`CYCLE_REPORT`** added to `NudgeKind` (+ migration) — reuses the `BudgetNudge` ledger so the report sends once per ended cycle.
- **`buildCycleReport`** (`cycleReport.ts`) — per-bucket spent/budget with Δ-vs-last, net saved, biggest category movers, decision-oriented headline. Pure formatting over the repositories.
- **`SendCycleReportUseCase`** — mirrors `SendBudgetNudges`; fires only for users on day 1 of their cycle, idempotent via `recordSentIfNew`. Wired into the composition root + a daily 01:30 UTC cron.
- **`/report`** — enriched with per-bucket vs-last deltas and a total-spend headline, sharing `vsLastSuffix` with the cycle report.

## Tests

`pnpm build` + `pnpm lint` clean; `pnpm test:unit` → 101 passing (new specs: `previousCycles`, `buildCycleReport` comparison/format math, `SendCycleReport` day-gate + idempotency).

## Out of scope

Web monthly-report page; WhatsApp/email channels; detecting actual salary credit (stays payday-date based).

🤖 Generated with [Claude Code](https://claude.com/claude-code)