### PR TITLE
fix(web): keep onboarding modal open through the Telegram step

### DIFF
--- a/web/src/components/onboarding.tsx
+++ b/web/src/components/onboarding.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/lib/budget";
 import {
   submitOnboarding,
+  markOnboardingComplete,
   type OnboardingGroup,
 } from "@/lib/actions/onboarding";
 import { ConnectTelegram } from "@/components/connect-telegram";
@@ -141,7 +142,15 @@ export default function Onboarding({
       {step === 4 && (
         <Confetti className="fixed inset-0 h-full w-full pointer-events-none z-100" />
       )}
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog
+        open={open}
+        onOpenChange={(o) => {
+          // Closing from the final (Telegram) step — via Connect, "Do this
+          // later", or Escape — is what completes onboarding.
+          if (!o && step === 4) void markOnboardingComplete();
+          setOpen(o);
+        }}
+      >
         <DialogContent
           className="gap-0 p-0 [&>button:last-child]:text-white sm:max-w-[440px]"
           showCloseButton={false}

--- a/web/src/lib/actions/onboarding.ts
+++ b/web/src/lib/actions/onboarding.ts
@@ -142,7 +142,6 @@ export async function submitOnboarding(
         locale: localeForCurrency(d.currency),
         ...(d.payday !== undefined ? { payday: d.payday } : {}),
         notificationDosage: d.notificationDosage,
-        hasOnboarded: true,
         onboardingStep: null,
       },
     });
@@ -189,7 +188,27 @@ export async function submitOnboarding(
     }
   });
 
-  revalidatePath("/dashboard");
+  // NOTE: hasOnboarded is set only when the wizard actually finishes (Telegram
+  // step) via markOnboardingComplete — setting it here would flip the dashboard
+  // flag mid-wizard and unmount the modal before step 4. Don't revalidate
+  // /dashboard for the same reason.
   revalidatePath("/dashboard/categories");
+  return { success: true };
+}
+
+// Marks onboarding complete once the user reaches the end of the wizard (after
+// the Telegram step — whether they connect or tap "Do this later"). Kept
+// separate from submitOnboarding so the flag flips only when the modal should
+// actually close.
+export async function markOnboardingComplete(): Promise<{ success: boolean }> {
+  const session = await auth();
+  if (!session?.user?.id) return { success: false };
+
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: { hasOnboarded: true },
+  });
+
+  revalidatePath("/dashboard");
   return { success: true };
 }


### PR DESCRIPTION
## Bug
On a fresh account the onboarding modal closed right after **Finish setup**, so the Telegram/QR step (step 4) was never reachable from the wizard.

**Cause:** `submitOnboarding` set `hasOnboarded=true` + `revalidatePath("/dashboard")` at step 3. The dashboard renders the modal only while `!hasOnboarded`, so the revalidation re-rendered the page and unmounted the whole modal the instant it advanced to step 4.

## Fix
Defer completion to the end of the wizard:
- `submitOnboarding` now only persists income/categories/dosage (no `hasOnboarded`, no `/dashboard` revalidate) → modal stays mounted through step 4.
- New `markOnboardingComplete()` flips the flag + revalidates `/dashboard`, called when the modal closes **from step 4** (Connect, "Do this later", or Escape).

Telegram stays optional; the dashboard connect banner still nudges unlinked users. Flipping to "Telegram required" later is just: don't complete on skip.

## Verification
- `pnpm build` + `pnpm lint` green (0 errors).
- Manual: fresh user → Finish setup → modal stays on step 4 (QR + auto-detect); Connect or "Do this later" closes it and marks onboarded; reload doesn't re-onboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)