### PR TITLE
fix(web): complete onboarding on connect / Do this later

### DIFF
--- a/web/src/components/onboarding.tsx
+++ b/web/src/components/onboarding.tsx
@@ -137,6 +137,14 @@ export default function Onboarding({
     else if (step === 3) void saveAndContinue();
   };
 
+  // Finishing the wizard (connect Telegram or "Do this later") completes
+  // onboarding. Programmatic setOpen(false) doesn't fire Radix's onOpenChange,
+  // so mark completion explicitly here.
+  const completeAndClose = () => {
+    void markOnboardingComplete();
+    setOpen(false);
+  };
+
   return (
     <>
       {step === 4 && (
@@ -372,7 +380,7 @@ export default function Onboarding({
                     and get your reminders. Optional, you can do this later.
                   </DialogDescription>
                 </DialogHeader>
-                <ConnectTelegram onConnected={() => setOpen(false)} />
+                <ConnectTelegram onConnected={completeAndClose} />
               </>
             )}
 
@@ -426,7 +434,7 @@ export default function Onboarding({
                   <Button
                     type="button"
                     variant="ghost"
-                    onClick={() => setOpen(false)}
+                    onClick={completeAndClose}
                   >
                     Do this later
                   </Button>


### PR DESCRIPTION
Follow-up to #44. `markOnboardingComplete` was only wired to the Dialog `onOpenChange`, which Radix fires **only** on user-initiated closes (Escape/overlay) — not on programmatic `setOpen(false)`. So connecting Telegram or tapping "Do this later" closed the modal without setting `hasOnboarded`, and the wizard reappeared on reload.

Fix: a `completeAndClose` helper (`markOnboardingComplete()` + `setOpen(false)`) wired to the `ConnectTelegram` `onConnected` and the "Do this later" button. The `onOpenChange` step-4 guard stays for Escape/overlay (no double-call).

Verified: `pnpm build` + `pnpm lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)