### PR TITLE
feat(web): editable timezone in Account settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "express-rate-limit": "^8.5.1",
-    "node-cron": "^4.2.1",
     "openai": "^6.9.1",
     "sarvamai": "^0.1.10",
     "undici": "^6.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       express-rate-limit:
         specifier: ^8.5.1
         version: 8.5.1(express@5.1.0)
-      node-cron:
-        specifier: ^4.2.1
-        version: 4.2.1
       openai:
         specifier: ^6.9.1
         version: 6.9.1(ws@8.18.3)(zod@4.1.13)
@@ -3789,10 +3786,6 @@ packages:
         optional: true
       sass:
         optional: true
-
-  node-cron@4.2.1:
-    resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
-    engines: {node: '>=6.0.0'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -8380,8 +8373,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-
-  node-cron@4.2.1: {}
 
   node-domexception@1.0.0: {}
 

--- a/web/src/app/dashboard/account/account-settings.tsx
+++ b/web/src/app/dashboard/account/account-settings.tsx
@@ -21,6 +21,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { TimezoneSelect } from "@/components/timezone-select";
 import { toast } from "@/lib/toast";
 import { updateBudgetSettings } from "@/lib/actions/budget";
 import { BUCKET_META, CURRENCIES, DOSAGES } from "@/lib/budget";
@@ -83,6 +84,7 @@ export type BudgetSettings = {
     payday: number;
     currency: string;
     locale: string;
+    timezone: string;
     needsPct: number;
     wantsPct: number;
     savingsPct: number;
@@ -93,6 +95,7 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
     const [income, setIncome] = useState(String(initial.monthlyIncome));
     const [payday, setPayday] = useState(String(initial.payday));
     const [currency, setCurrency] = useState(initial.currency);
+    const [timezone, setTimezone] = useState(initial.timezone);
     const [needs, setNeeds] = useState(initial.needsPct);
     const [wants, setWants] = useState(initial.wantsPct);
     const [savings, setSavings] = useState(initial.savingsPct);
@@ -123,6 +126,7 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
                 payday: paydayNum,
                 currency,
                 locale,
+                timezone,
                 needsPct: needs,
                 wantsPct: wants,
                 savingsPct: savings,
@@ -186,6 +190,28 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
                             </SelectContent>
                         </Select>
                     </div>
+                </div>
+
+                <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                        <Label>Timezone</Label>
+                        <button
+                            type="button"
+                            className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+                            onClick={() =>
+                                setTimezone(
+                                    Intl.DateTimeFormat().resolvedOptions()
+                                        .timeZone,
+                                )
+                            }
+                        >
+                            Use device timezone
+                        </button>
+                    </div>
+                    <TimezoneSelect value={timezone} onChange={setTimezone} />
+                    <p className="text-xs text-muted-foreground">
+                        When your reminders, recurring items, and cycle report fire.
+                    </p>
                 </div>
 
                 <div className="space-y-2">

--- a/web/src/components/timezone-select.tsx
+++ b/web/src/components/timezone-select.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+// Fallback if the runtime lacks Intl.supportedValuesOf (older engines).
+const FALLBACK_ZONES = [
+  "Asia/Kolkata",
+  "UTC",
+  "America/New_York",
+  "America/Los_Angeles",
+  "America/Chicago",
+  "Europe/London",
+  "Europe/Berlin",
+  "Asia/Dubai",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+];
+
+function listZones(): string[] {
+  try {
+    const fn = (
+      Intl as unknown as { supportedValuesOf?: (k: string) => string[] }
+    ).supportedValuesOf;
+    const zones = fn?.("timeZone");
+    if (zones && zones.length) return zones;
+  } catch {
+    /* fall through to the curated list */
+  }
+  return FALLBACK_ZONES;
+}
+
+// e.g. "GMT+5:30" for the given zone right now.
+function offsetLabel(zone: string): string {
+  try {
+    return (
+      new Intl.DateTimeFormat("en-US", {
+        timeZone: zone,
+        timeZoneName: "shortOffset",
+      })
+        .formatToParts(new Date())
+        .find((p) => p.type === "timeZoneName")?.value ?? ""
+    );
+  } catch {
+    return "";
+  }
+}
+
+// Searchable single-select combobox over the IANA timezone list (shadcn Combobox
+// = Popover + Command). Value is the IANA id (e.g. "Asia/Kolkata").
+export function TimezoneSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (tz: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const options = useMemo(
+    () => listZones().map((zone) => ({ zone, offset: offsetLabel(zone) })),
+    [],
+  );
+  const currentOffset = useMemo(() => offsetLabel(value), [value]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          <span className="truncate">
+            {value}
+            {currentOffset && (
+              <span className="ml-2 text-muted-foreground">{currentOffset}</span>
+            )}
+          </span>
+          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="Search timezone…" />
+          <CommandList>
+            <CommandEmpty>No timezone found.</CommandEmpty>
+            <CommandGroup>
+              {options.map(({ zone, offset }) => (
+                <CommandItem
+                  key={zone}
+                  value={zone}
+                  // Use the closured zone (cmdk lowercases the onSelect arg).
+                  onSelect={() => {
+                    onChange(zone);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 size-4",
+                      zone === value ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="truncate">{zone}</span>
+                  <span className="ml-auto pl-2 text-xs text-muted-foreground">
+                    {offset}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/lib/actions/budget.ts
+++ b/web/src/lib/actions/budget.ts
@@ -177,6 +177,7 @@ export async function getBudgetSettings() {
         payday: true,
         currency: true,
         locale: true,
+        timezone: true,
         notificationDosage: true,
       },
     }),
@@ -188,11 +189,22 @@ export async function getBudgetSettings() {
     payday: user?.payday ?? 1,
     currency: user?.currency ?? "INR",
     locale: user?.locale ?? "en-IN",
+    timezone: user?.timezone ?? "Asia/Kolkata",
     needsPct: config?.needsPct ?? DEFAULT_SPLIT.needsPct,
     wantsPct: config?.wantsPct ?? DEFAULT_SPLIT.wantsPct,
     savingsPct: config?.savingsPct ?? DEFAULT_SPLIT.savingsPct,
     notificationDosage: user?.notificationDosage ?? "OFF",
   };
+}
+
+// A valid IANA timezone id — Intl throws RangeError on an unknown zone.
+function isValidTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 const settingsSchema = z
@@ -201,6 +213,12 @@ const settingsSchema = z
     payday: z.number().int().min(1).max(28).optional(),
     currency: z.string().min(1).max(8).optional(),
     locale: z.string().min(2).max(16).optional(),
+    timezone: z
+      .string()
+      .min(1)
+      .max(64)
+      .refine(isValidTimezone, "Invalid timezone")
+      .optional(),
     needsPct: z.number().int().min(0).max(100).optional(),
     wantsPct: z.number().int().min(0).max(100).optional(),
     savingsPct: z.number().int().min(0).max(100).optional(),
@@ -227,6 +245,7 @@ export async function updateBudgetSettings(input: {
   payday?: number;
   currency?: string;
   locale?: string;
+  timezone?: string;
   needsPct?: number;
   wantsPct?: number;
   savingsPct?: number;
@@ -250,12 +269,14 @@ export async function updateBudgetSettings(input: {
     payday?: number;
     currency?: string;
     locale?: string;
+    timezone?: string;
     notificationDosage?: "OFF" | "GENTLE" | "AGGRESSIVE" | "RELENTLESS";
   } = {};
   if (d.monthlyIncome !== undefined) userData.monthlyIncome = d.monthlyIncome;
   if (d.payday !== undefined) userData.payday = d.payday;
   if (d.currency !== undefined) userData.currency = d.currency;
   if (d.locale !== undefined) userData.locale = d.locale;
+  if (d.timezone !== undefined) userData.timezone = d.timezone;
   if (d.notificationDosage !== undefined)
     userData.notificationDosage = d.notificationDosage;
 


### PR DESCRIPTION
Adds a **Timezone** control to Account settings so users can view/change their scheduling timezone (new users get their browser tz at onboarding; existing default to IST). Also drops the unused `node-cron` dependency.

## Changes
- **`TimezoneSelect`** (new): searchable **shadcn Combobox** (Popover + Command, per shadcn docs) over `Intl.supportedValuesOf("timeZone")`, each option labelled with its GMT offset, `Check` on the selected zone. Reuses the repo's `command`/`popover`/`button` primitives — no new deps.
- Added into `BudgetSettingsCard` (same one-Save-button UX) with a **"Use device timezone"** shortcut.
- `getBudgetSettings` returns `timezone`; `updateBudgetSettings` validates (IANA via `Intl`) + persists it. No migration — `User.timezone` already exists.
- Removed `node-cron` (unused since the in-process scheduler was deleted).

## Verification
- Web build + lint (0 errors); backend build + lint + **130 tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)