### PR TITLE
feat(web): restructure Account settings (sectioned rows + modal editing)

### DIFF
--- a/web/src/app/dashboard/account/account-settings.tsx
+++ b/web/src/app/dashboard/account/account-settings.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useState, useTransition } from "react";
+import type { ReactNode } from "react";
 import { useTheme } from "next-themes";
+import { Wallet, Globe, Bell, Palette, type LucideIcon } from "lucide-react";
 import {
     Card,
     CardContent,
@@ -13,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { useSoundStore } from "@/hooks/use-sound-store";
+import { Badge } from "@/components/ui/badge";
 import {
     Select,
     SelectContent,
@@ -21,61 +23,20 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import {
+    ResponsiveModal,
+    ResponsiveModalContent,
+    ResponsiveModalHeader,
+    ResponsiveModalTitle,
+    ResponsiveModalDescription,
+    ResponsiveModalFooter,
+} from "@/components/ui/responsive-modal";
 import { TimezoneSelect } from "@/components/timezone-select";
+import { useSoundStore } from "@/hooks/use-sound-store";
+import { cn } from "@/lib/utils";
 import { toast } from "@/lib/toast";
 import { updateBudgetSettings } from "@/lib/actions/budget";
 import { BUCKET_META, CURRENCIES, DOSAGES } from "@/lib/budget";
-
-export function AppearanceCard() {
-    const { theme, setTheme } = useTheme();
-    const soundEnabled = useSoundStore((s) => s.enabled);
-    const setSoundEnabled = useSoundStore((s) => s.setEnabled);
-    const [mounted, setMounted] = useState(false);
-    // next-themes: render only after mount to avoid a hydration mismatch on the bound value.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    useEffect(() => setMounted(true), []);
-    if (!mounted) return null;
-
-    return (
-        <Card>
-            <CardHeader>
-                <CardTitle>Appearance</CardTitle>
-                <CardDescription>
-                    Customize the look and feel of the application.
-                </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-                <div className="space-y-2">
-                    <Label htmlFor="theme">Theme</Label>
-                    <Select value={theme} onValueChange={setTheme}>
-                        <SelectTrigger id="theme">
-                            <SelectValue placeholder="Select theme" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            <SelectItem value="light">Light</SelectItem>
-                            <SelectItem value="dark">Dark</SelectItem>
-                            <SelectItem value="system">System</SelectItem>
-                        </SelectContent>
-                    </Select>
-                </div>
-
-                <div className="flex items-start justify-between gap-3">
-                    <div className="space-y-0.5">
-                        <Label htmlFor="sound">Interaction sounds</Label>
-                        <p className="text-xs text-muted-foreground">
-                            Subtle crisp clicks and chimes as you use the dashboard.
-                        </p>
-                    </div>
-                    <Switch
-                        id="sound"
-                        checked={soundEnabled}
-                        onCheckedChange={(v) => setSoundEnabled(v)}
-                    />
-                </div>
-            </CardContent>
-        </Card>
-    );
-}
 
 export type NotificationDosage = "OFF" | "GENTLE" | "AGGRESSIVE" | "RELENTLESS";
 
@@ -91,48 +52,193 @@ export type BudgetSettings = {
     notificationDosage: NotificationDosage;
 };
 
-export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
-    const [income, setIncome] = useState(String(initial.monthlyIncome));
-    const [payday, setPayday] = useState(String(initial.payday));
-    const [currency, setCurrency] = useState(initial.currency);
-    const [timezone, setTimezone] = useState(initial.timezone);
-    const [needs, setNeeds] = useState(initial.needsPct);
-    const [wants, setWants] = useState(initial.wantsPct);
-    const [savings, setSavings] = useState(initial.savingsPct);
-    const [dosage, setDosage] = useState<NotificationDosage>(
-        initial.notificationDosage,
+// ── Shared layout primitives ──────────────────────────────────────────────────
+
+function SettingsSection({
+    icon: Icon,
+    title,
+    description,
+    children,
+}: {
+    icon: LucideIcon;
+    title: string;
+    description: string;
+    children: ReactNode;
+}) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <Icon className="size-4 text-muted-foreground" />
+                    {title}
+                </CardTitle>
+                <CardDescription>{description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="divide-y">{children}</div>
+            </CardContent>
+        </Card>
     );
-    const [isPending, startTransition] = useTransition();
+}
 
-    const sum = needs + wants + savings;
+// A read-only value row with an Edit button (opens a ResponsiveModal).
+function SettingRow({
+    label,
+    description,
+    value,
+    onEdit,
+}: {
+    label: string;
+    description?: string;
+    value: ReactNode;
+    onEdit: () => void;
+}) {
+    return (
+        <div className="flex items-center justify-between gap-4 py-4 first:pt-0 last:pb-0">
+            <div className="min-w-0 space-y-0.5">
+                <p className="text-sm font-medium">{label}</p>
+                {description && (
+                    <p className="text-xs text-muted-foreground">{description}</p>
+                )}
+            </div>
+            <div className="flex shrink-0 items-center gap-3">
+                <span className="max-w-[150px] truncate text-sm text-muted-foreground sm:max-w-[280px]">
+                    {value}
+                </span>
+                <Button variant="outline" size="sm" onClick={onEdit}>
+                    Edit
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+// A row with an inline control on the right (instant settings, no save).
+function InlineRow({
+    label,
+    htmlFor,
+    description,
+    children,
+}: {
+    label: string;
+    htmlFor?: string;
+    description?: string;
+    children: ReactNode;
+}) {
+    return (
+        <div className="flex flex-col gap-2 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-0.5">
+                <Label htmlFor={htmlFor}>{label}</Label>
+                {description && (
+                    <p className="text-xs text-muted-foreground">{description}</p>
+                )}
+            </div>
+            <div className="w-full sm:w-64 sm:shrink-0">{children}</div>
+        </div>
+    );
+}
+
+// Reusable edit dialog/drawer with a dirty-gated Save.
+function EditModal({
+    open,
+    onOpenChange,
+    title,
+    description,
+    canSave,
+    saving,
+    onSave,
+    children,
+}: {
+    open: boolean;
+    onOpenChange: (o: boolean) => void;
+    title: string;
+    description?: string;
+    canSave: boolean;
+    saving: boolean;
+    onSave: () => void;
+    children: ReactNode;
+}) {
+    return (
+        <ResponsiveModal open={open} onOpenChange={onOpenChange}>
+            <ResponsiveModalContent className="sm:max-w-md">
+                <ResponsiveModalHeader>
+                    <ResponsiveModalTitle>{title}</ResponsiveModalTitle>
+                    {description && (
+                        <ResponsiveModalDescription>
+                            {description}
+                        </ResponsiveModalDescription>
+                    )}
+                </ResponsiveModalHeader>
+                <div className="space-y-4 py-2">{children}</div>
+                <ResponsiveModalFooter className="gap-2 sm:gap-2">
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                        disabled={saving}
+                    >
+                        Cancel
+                    </Button>
+                    <Button onClick={onSave} disabled={!canSave || saving}>
+                        {saving ? "Saving…" : "Save changes"}
+                    </Button>
+                </ResponsiveModalFooter>
+            </ResponsiveModalContent>
+        </ResponsiveModal>
+    );
+}
+
+// ── Section editors ───────────────────────────────────────────────────────────
+
+type BudgetDraft = {
+    income: string;
+    payday: string;
+    needs: number;
+    wants: number;
+    savings: number;
+};
+
+function BudgetRow({ initial }: { initial: BudgetSettings }) {
+    const start: BudgetDraft = {
+        income: String(initial.monthlyIncome),
+        payday: String(initial.payday),
+        needs: initial.needsPct,
+        wants: initial.wantsPct,
+        savings: initial.savingsPct,
+    };
+    const [committed, setCommitted] = useState<BudgetDraft>(start);
+    const [d, setD] = useState<BudgetDraft>(start);
+    const [open, setOpen] = useState(false);
+    const [saving, startSave] = useTransition();
+
+    const sum = d.needs + d.wants + d.savings;
     const splitValid = sum === 100;
-    const paydayNum = Number(payday);
+    const paydayNum = Number(d.payday);
     const paydayValid = paydayNum >= 1 && paydayNum <= 28;
+    const dirty = JSON.stringify(d) !== JSON.stringify(committed);
+    const canSave = dirty && splitValid && paydayValid;
 
-    const handleSave = () =>
-        startTransition(async () => {
-            if (!splitValid) {
-                toast.error("The 50/30/20 split must sum to 100%");
-                return;
-            }
-            if (!paydayValid) {
-                toast.error("Payday must be between 1 and 28");
-                return;
-            }
-            const locale =
-                CURRENCIES.find((c) => c.value === currency)?.locale ?? "en-IN";
+    const money = new Intl.NumberFormat(initial.locale, {
+        style: "currency",
+        currency: initial.currency,
+        maximumFractionDigits: 0,
+    });
+
+    const openModal = () => {
+        setD(committed);
+        setOpen(true);
+    };
+    const save = () =>
+        startSave(async () => {
             const res = await updateBudgetSettings({
-                monthlyIncome: Number(income) || 0,
+                monthlyIncome: Number(d.income) || 0,
                 payday: paydayNum,
-                currency,
-                locale,
-                timezone,
-                needsPct: needs,
-                wantsPct: wants,
-                savingsPct: savings,
-                notificationDosage: dosage,
+                needsPct: d.needs,
+                wantsPct: d.wants,
+                savingsPct: d.savings,
             });
             if (res.success) {
+                setCommitted(d);
+                setOpen(false);
                 toast.signature("Budget saved", {
                     description: "Your 50/30/20 split is updated",
                 });
@@ -142,56 +248,208 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
         });
 
     return (
-        <Card>
-            <CardHeader>
-                <CardTitle>Budget Settings</CardTitle>
-                <CardDescription>
-                    Set your income and how it splits across Needs, Wants, and Savings.
-                </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-                <div className="grid gap-4 md:grid-cols-3">
+        <>
+            <SettingRow
+                label="Budget"
+                description="Monthly income, payday, and how it splits."
+                value={`${money.format(Number(committed.income) || 0)} · Day ${committed.payday} · ${committed.needs}/${committed.wants}/${committed.savings}`}
+                onEdit={openModal}
+            />
+            <EditModal
+                open={open}
+                onOpenChange={setOpen}
+                title="Budget"
+                description="Set your income, cycle day, and 50/30/20 split."
+                canSave={canSave}
+                saving={saving}
+                onSave={save}
+            >
+                <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-2">
-                        <Label htmlFor="income">Monthly Income</Label>
+                        <Label htmlFor="income">Monthly income</Label>
                         <Input
                             id="income"
                             type="number"
                             min={0}
-                            value={income}
-                            onChange={(e) => setIncome(e.target.value)}
+                            value={d.income}
+                            onChange={(e) =>
+                                setD({ ...d, income: e.target.value })
+                            }
                         />
                     </div>
                     <div className="space-y-2">
-                        <Label htmlFor="payday">Payday (day of month)</Label>
+                        <Label htmlFor="payday">Payday</Label>
                         <Input
                             id="payday"
                             type="number"
                             min={1}
                             max={28}
-                            value={payday}
-                            onChange={(e) => setPayday(e.target.value)}
+                            value={d.payday}
+                            onChange={(e) =>
+                                setD({ ...d, payday: e.target.value })
+                            }
+                            aria-invalid={!paydayValid}
                         />
                         {!paydayValid && (
                             <p className="text-xs text-destructive">Must be 1–28</p>
                         )}
                     </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="currency">Currency</Label>
-                        <Select value={currency} onValueChange={setCurrency}>
-                            <SelectTrigger id="currency">
-                                <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {CURRENCIES.map((c) => (
-                                    <SelectItem key={c.value} value={c.value}>
-                                        {c.label}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </div>
                 </div>
 
+                <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                        <Label>Budget split</Label>
+                        <Badge
+                            variant={splitValid ? "outline" : "destructive"}
+                            className={cn(
+                                splitValid && "border-green-600 text-green-600",
+                            )}
+                        >
+                            {sum}%{splitValid ? "" : " · must total 100%"}
+                        </Badge>
+                    </div>
+                    <div className="flex h-2 w-full overflow-hidden rounded-full bg-muted">
+                        <div
+                            className="bg-primary"
+                            style={{
+                                width: `${Math.max(0, Math.min(100, d.needs))}%`,
+                            }}
+                        />
+                        <div
+                            className="bg-primary/60"
+                            style={{
+                                width: `${Math.max(0, Math.min(100, d.wants))}%`,
+                            }}
+                        />
+                        <div
+                            className="bg-primary/30"
+                            style={{
+                                width: `${Math.max(0, Math.min(100, d.savings))}%`,
+                            }}
+                        />
+                    </div>
+                    <div className="grid grid-cols-3 gap-3">
+                        <SplitInput
+                            label={`${BUCKET_META.NEEDS.emoji} ${BUCKET_META.NEEDS.label}`}
+                            value={d.needs}
+                            onChange={(n) => setD({ ...d, needs: n })}
+                        />
+                        <SplitInput
+                            label={`${BUCKET_META.WANTS.emoji} ${BUCKET_META.WANTS.label}`}
+                            value={d.wants}
+                            onChange={(n) => setD({ ...d, wants: n })}
+                        />
+                        <SplitInput
+                            label={`${BUCKET_META.SAVINGS.emoji} ${BUCKET_META.SAVINGS.label}`}
+                            value={d.savings}
+                            onChange={(n) => setD({ ...d, savings: n })}
+                        />
+                    </div>
+                </div>
+            </EditModal>
+        </>
+    );
+}
+
+function CurrencyRow({ initial }: { initial: string }) {
+    const [committed, setCommitted] = useState(initial);
+    const [draft, setDraft] = useState(initial);
+    const [open, setOpen] = useState(false);
+    const [saving, startSave] = useTransition();
+    const label = CURRENCIES.find((c) => c.value === committed)?.label ?? committed;
+
+    const openModal = () => {
+        setDraft(committed);
+        setOpen(true);
+    };
+    const save = () =>
+        startSave(async () => {
+            const locale =
+                CURRENCIES.find((c) => c.value === draft)?.locale ?? "en-IN";
+            const res = await updateBudgetSettings({ currency: draft, locale });
+            if (res.success) {
+                setCommitted(draft);
+                setOpen(false);
+                toast.success("Currency updated");
+            } else {
+                toast.error(res.message ?? "Failed to save");
+            }
+        });
+
+    return (
+        <>
+            <SettingRow
+                label="Currency"
+                description="Used to format all amounts."
+                value={label}
+                onEdit={openModal}
+            />
+            <EditModal
+                open={open}
+                onOpenChange={setOpen}
+                title="Currency"
+                canSave={draft !== committed}
+                saving={saving}
+                onSave={save}
+            >
+                <div className="space-y-2">
+                    <Label htmlFor="currency">Currency</Label>
+                    <Select value={draft} onValueChange={setDraft}>
+                        <SelectTrigger id="currency" className="w-full">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {CURRENCIES.map((c) => (
+                                <SelectItem key={c.value} value={c.value}>
+                                    {c.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </EditModal>
+        </>
+    );
+}
+
+function TimezoneRow({ initial }: { initial: string }) {
+    const [committed, setCommitted] = useState(initial);
+    const [draft, setDraft] = useState(initial);
+    const [open, setOpen] = useState(false);
+    const [saving, startSave] = useTransition();
+
+    const openModal = () => {
+        setDraft(committed);
+        setOpen(true);
+    };
+    const save = () =>
+        startSave(async () => {
+            const res = await updateBudgetSettings({ timezone: draft });
+            if (res.success) {
+                setCommitted(draft);
+                setOpen(false);
+                toast.success("Timezone updated");
+            } else {
+                toast.error(res.message ?? "Failed to save");
+            }
+        });
+
+    return (
+        <>
+            <SettingRow
+                label="Timezone"
+                description="When reminders, recurring items, and the cycle report fire."
+                value={committed}
+                onEdit={openModal}
+            />
+            <EditModal
+                open={open}
+                onOpenChange={setOpen}
+                title="Timezone"
+                canSave={draft !== committed}
+                saving={saving}
+                onSave={save}
+            >
                 <div className="space-y-2">
                     <div className="flex items-center justify-between">
                         <Label>Timezone</Label>
@@ -199,79 +457,160 @@ export function BudgetSettingsCard({ initial }: { initial: BudgetSettings }) {
                             type="button"
                             className="text-xs text-muted-foreground underline-offset-2 hover:underline"
                             onClick={() =>
-                                setTimezone(
+                                setDraft(
                                     Intl.DateTimeFormat().resolvedOptions()
                                         .timeZone,
                                 )
                             }
                         >
-                            Use device timezone
+                            Use device
                         </button>
                     </div>
-                    <TimezoneSelect value={timezone} onChange={setTimezone} />
-                    <p className="text-xs text-muted-foreground">
-                        When your reminders, recurring items, and cycle report fire.
-                    </p>
+                    <TimezoneSelect value={draft} onChange={setDraft} />
                 </div>
+            </EditModal>
+        </>
+    );
+}
 
-                <div className="space-y-2">
-                    <Label>
-                        Budget Split{" "}
-                        <span
-                            className={`ml-2 text-xs ${splitValid ? "text-muted-foreground" : "text-destructive"}`}
-                        >
-                            ({sum}% — must total 100%)
-                        </span>
-                    </Label>
-                    <div className="grid gap-4 md:grid-cols-3">
-                        <SplitInput
-                            label={`${BUCKET_META.NEEDS.emoji} ${BUCKET_META.NEEDS.label} %`}
-                            value={needs}
-                            onChange={setNeeds}
-                        />
-                        <SplitInput
-                            label={`${BUCKET_META.WANTS.emoji} ${BUCKET_META.WANTS.label} %`}
-                            value={wants}
-                            onChange={setWants}
-                        />
-                        <SplitInput
-                            label={`${BUCKET_META.SAVINGS.emoji} ${BUCKET_META.SAVINGS.label} %`}
-                            value={savings}
-                            onChange={setSavings}
-                        />
-                    </div>
-                </div>
+function ReminderRow({ initial }: { initial: NotificationDosage }) {
+    const [committed, setCommitted] = useState(initial);
+    const [draft, setDraft] = useState(initial);
+    const [open, setOpen] = useState(false);
+    const [saving, startSave] = useTransition();
+    const label = DOSAGES.find((x) => x.value === committed)?.label ?? committed;
 
+    const openModal = () => {
+        setDraft(committed);
+        setOpen(true);
+    };
+    const save = () =>
+        startSave(async () => {
+            const res = await updateBudgetSettings({ notificationDosage: draft });
+            if (res.success) {
+                setCommitted(draft);
+                setOpen(false);
+                toast.success("Reminders updated");
+            } else {
+                toast.error(res.message ?? "Failed to save");
+            }
+        });
+
+    return (
+        <>
+            <SettingRow
+                label="Reminder frequency"
+                description="How often the bot nudges you when a bucket runs hot."
+                value={label}
+                onEdit={openModal}
+            />
+            <EditModal
+                open={open}
+                onOpenChange={setOpen}
+                title="Reminder frequency"
+                canSave={draft !== committed}
+                saving={saving}
+                onSave={save}
+            >
                 <div className="space-y-2">
-                    <Label htmlFor="dosage">Telegram reminders</Label>
+                    <Label htmlFor="dosage">Frequency</Label>
                     <Select
-                        value={dosage}
-                        onValueChange={(v) => setDosage(v as NotificationDosage)}
+                        value={draft}
+                        onValueChange={(v) => setDraft(v as NotificationDosage)}
                     >
-                        <SelectTrigger id="dosage">
+                        <SelectTrigger id="dosage" className="w-full">
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                            {DOSAGES.map((d) => (
-                                <SelectItem key={d.value} value={d.value}>
-                                    {d.label} — {d.hint}
+                            {DOSAGES.map((x) => (
+                                <SelectItem key={x.value} value={x.value}>
+                                    {x.label} — {x.hint}
                                 </SelectItem>
                             ))}
                         </SelectContent>
                     </Select>
-                    <p className="text-xs text-muted-foreground">
-                        How often the bot nudges you when a bucket runs hot.
-                    </p>
                 </div>
+            </EditModal>
+        </>
+    );
+}
 
-                <Button
-                    onClick={handleSave}
-                    disabled={isPending || !splitValid || !paydayValid}
-                >
-                    Save changes
-                </Button>
-            </CardContent>
-        </Card>
+// ── Composed sections ─────────────────────────────────────────────────────────
+
+export function AccountSettings({ initial }: { initial: BudgetSettings }) {
+    return (
+        <>
+            <SettingsSection
+                icon={Wallet}
+                title="Budget"
+                description="Income, cycle, and how it splits across your buckets."
+            >
+                <BudgetRow initial={initial} />
+            </SettingsSection>
+
+            <SettingsSection
+                icon={Globe}
+                title="Preferences"
+                description="Regional formatting and scheduling."
+            >
+                <CurrencyRow initial={initial.currency} />
+                <TimezoneRow initial={initial.timezone} />
+            </SettingsSection>
+
+            <SettingsSection
+                icon={Bell}
+                title="Notifications"
+                description="How the Blipko bot keeps you on track."
+            >
+                <ReminderRow initial={initial.notificationDosage} />
+            </SettingsSection>
+        </>
+    );
+}
+
+export function AppearanceCard() {
+    const { theme, setTheme } = useTheme();
+    const soundEnabled = useSoundStore((s) => s.enabled);
+    const setSoundEnabled = useSoundStore((s) => s.setEnabled);
+    const [mounted, setMounted] = useState(false);
+    // next-themes: render only after mount to avoid a hydration mismatch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    useEffect(() => setMounted(true), []);
+    if (!mounted) return null;
+
+    return (
+        <SettingsSection
+            icon={Palette}
+            title="Appearance"
+            description="Customize the look and feel of the dashboard."
+        >
+            <InlineRow htmlFor="theme" label="Theme">
+                <Select value={theme} onValueChange={setTheme}>
+                    <SelectTrigger id="theme" className="w-full">
+                        <SelectValue placeholder="Select theme" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="light">Light</SelectItem>
+                        <SelectItem value="dark">Dark</SelectItem>
+                        <SelectItem value="system">System</SelectItem>
+                    </SelectContent>
+                </Select>
+            </InlineRow>
+
+            <InlineRow
+                htmlFor="sound"
+                label="Interaction sounds"
+                description="Subtle crisp clicks and chimes as you use the dashboard."
+            >
+                <div className="flex sm:justify-end">
+                    <Switch
+                        id="sound"
+                        checked={soundEnabled}
+                        onCheckedChange={(v) => setSoundEnabled(v)}
+                    />
+                </div>
+            </InlineRow>
+        </SettingsSection>
     );
 }
 
@@ -285,15 +624,23 @@ function SplitInput({
     onChange: (n: number) => void;
 }) {
     return (
-        <div className="space-y-2">
-            <Label>{label}</Label>
-            <Input
-                type="number"
-                min={0}
-                max={100}
-                value={value}
-                onChange={(e) => onChange(Number(e.target.value) || 0)}
-            />
+        <div className="space-y-1.5">
+            <Label className="text-xs font-normal text-muted-foreground">
+                {label}
+            </Label>
+            <div className="relative">
+                <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={value}
+                    onChange={(e) => onChange(Number(e.target.value) || 0)}
+                    className="pr-7"
+                />
+                <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-muted-foreground">
+                    %
+                </span>
+            </div>
         </div>
     );
 }

--- a/web/src/app/dashboard/account/page.tsx
+++ b/web/src/app/dashboard/account/page.tsx
@@ -1,18 +1,23 @@
 import { ContentLayout } from "@/components/admin-panel/content-layout";
 import { TelegramCard } from "@/components/telegram-card";
 import { getBudgetSettings } from "@/lib/actions/budget";
-import {
-    AppearanceCard,
-    BudgetSettingsCard,
-} from "./account-settings";
+import { AccountSettings, AppearanceCard } from "./account-settings";
 
 export default async function Page() {
     const settings = await getBudgetSettings();
 
     return (
         <ContentLayout title="Account">
-            <div className="space-y-6">
-                <BudgetSettingsCard initial={settings} />
+            <div className="mx-auto max-w-3xl space-y-6">
+                <div className="space-y-1">
+                    <h2 className="text-lg font-semibold tracking-tight">
+                        Settings
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                        Manage your budget, appearance, and Telegram connection.
+                    </p>
+                </div>
+                <AccountSettings initial={settings} />
                 <AppearanceCard />
                 <TelegramCard />
             </div>

--- a/web/src/components/telegram-card.tsx
+++ b/web/src/components/telegram-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Send } from "lucide-react";
 import {
     Card,
     CardContent,
@@ -35,7 +36,10 @@ export function TelegramCard() {
     return (
         <Card>
             <CardHeader>
-                <CardTitle>Telegram</CardTitle>
+                <CardTitle className="flex items-center gap-2">
+                    <Send className="size-4 text-muted-foreground" />
+                    Telegram
+                </CardTitle>
                 <CardDescription>
                     Connect your Telegram account to track payments via the Blipko bot.
                 </CardDescription>


### PR DESCRIPTION
Restructures the Account settings page for a cleaner, aligned, scannable UX.

## Changes
- **Currency, Timezone, and Reminders** moved out of the crammed Budget card into their own sections: **Preferences** (currency + timezone) and **Notifications** (reminder frequency).
- Each setting is a **value row** with an **Edit** button that opens a **`ResponsiveModal`** (Dialog on desktop, Drawer on mobile).
- **Save is disabled until the value changes** (Budget also requires split = 100% and payday 1–28). Each section saves independently via a partial `updateBudgetSettings` and updates its row on success.
- Reusable `SettingsSection` / `SettingRow` / `InlineRow` / `EditModal` helpers; icon-headed cards; centered `max-w-3xl` column + subtitle. Budget modal keeps the total pill + split preview bar. Appearance (theme/sound) stays inline/instant.

No action/schema/migration changes. web build + lint green (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)