### PR TITLE
feat(categories): per-category transaction breakdown page

### DIFF
--- a/web/src/app/dashboard/_components/boxes-trend-chart.tsx
+++ b/web/src/app/dashboard/_components/boxes-trend-chart.tsx
@@ -20,8 +20,8 @@ interface BoxesTrendChartProps {
 }
 
 const chartConfig = {
-  in: { label: "Added", color: "hsl(var(--chart-3))" },
-  out: { label: "Spent", color: "hsl(var(--chart-2))" },
+  in: { label: "Added", color: "var(--chart-positive)" },
+  out: { label: "Spent", color: "var(--chart-negative)" },
 } satisfies ChartConfig;
 
 // Aggregate box contributions/withdrawals across all boxes (analytics page).
@@ -49,8 +49,8 @@ export function BoxesTrendChart({ data }: BoxesTrendChartProps) {
               />
               <ChartTooltip content={<ChartTooltipContent indicator="dashed" />} />
               <Legend />
-              <Bar dataKey="in" name="Added" fill="#a3b18a" radius={4} />
-              <Bar dataKey="out" name="Spent" fill="#dba19b" radius={4} />
+              <Bar dataKey="in" name="Added" fill="var(--color-in)" radius={4} />
+              <Bar dataKey="out" name="Spent" fill="var(--color-out)" radius={4} />
             </BarChart>
           </ChartContainer>
         ) : (

--- a/web/src/app/dashboard/_components/income-expense-chart.tsx
+++ b/web/src/app/dashboard/_components/income-expense-chart.tsx
@@ -26,9 +26,9 @@ interface BucketTrendChartProps {
 }
 
 const chartConfig = {
-    NEEDS: { label: BUCKET_META.NEEDS.label, color: "hsl(var(--chart-1))" },
-    WANTS: { label: BUCKET_META.WANTS.label, color: "hsl(var(--chart-2))" },
-    SAVINGS: { label: BUCKET_META.SAVINGS.label, color: "hsl(var(--chart-3))" },
+    NEEDS: { label: BUCKET_META.NEEDS.label, color: "var(--chart-needs)" },
+    WANTS: { label: BUCKET_META.WANTS.label, color: "var(--chart-wants)" },
+    SAVINGS: { label: BUCKET_META.SAVINGS.label, color: "var(--chart-savings)" },
 } satisfies ChartConfig;
 
 export function BucketTrendChart({ data }: BucketTrendChartProps) {
@@ -50,9 +50,9 @@ export function BucketTrendChart({ data }: BucketTrendChartProps) {
                         />
                         <ChartTooltip content={<ChartTooltipContent indicator="dashed" />} />
                         <Legend />
-                        <Bar dataKey="NEEDS" fill="#829496" radius={4} />
-                        <Bar dataKey="WANTS" fill="#dba19b" radius={4} />
-                        <Bar dataKey="SAVINGS" fill="#a3b18a" radius={4} />
+                        <Bar dataKey="NEEDS" fill="var(--color-NEEDS)" radius={4} />
+                        <Bar dataKey="WANTS" fill="var(--color-WANTS)" radius={4} />
+                        <Bar dataKey="SAVINGS" fill="var(--color-SAVINGS)" radius={4} />
                     </BarChart>
                 </ChartContainer>
             </CardContent>

--- a/web/src/app/dashboard/_components/income-expense-trend-chart.tsx
+++ b/web/src/app/dashboard/_components/income-expense-trend-chart.tsx
@@ -25,8 +25,8 @@ interface IncomeExpenseTrendChartProps {
 }
 
 const chartConfig = {
-  income: { label: "Income", color: "hsl(var(--chart-3))" },
-  spend: { label: "Spending", color: "hsl(var(--chart-2))" },
+  income: { label: "Income", color: "var(--chart-positive)" },
+  spend: { label: "Spending", color: "var(--chart-negative)" },
 } satisfies ChartConfig;
 
 export function IncomeExpenseTrendChart({ data }: IncomeExpenseTrendChartProps) {
@@ -50,8 +50,8 @@ export function IncomeExpenseTrendChart({ data }: IncomeExpenseTrendChartProps) 
             />
             <ChartTooltip content={<ChartTooltipContent indicator="dashed" />} />
             <Legend />
-            <Bar dataKey="income" name="Income" fill="#a3b18a" radius={4} />
-            <Bar dataKey="spend" name="Spending" fill="#dba19b" radius={4} />
+            <Bar dataKey="income" name="Income" fill="var(--color-income)" radius={4} />
+            <Bar dataKey="spend" name="Spending" fill="var(--color-spend)" radius={4} />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/web/src/app/dashboard/boxes/[id]/_components/box-contribution-chart.tsx
+++ b/web/src/app/dashboard/boxes/[id]/_components/box-contribution-chart.tsx
@@ -20,8 +20,8 @@ interface BoxContributionChartProps {
 }
 
 const chartConfig = {
-  in: { label: "Added", color: "hsl(var(--chart-3))" },
-  out: { label: "Spent", color: "hsl(var(--chart-2))" },
+  in: { label: "Added", color: "var(--chart-positive)" },
+  out: { label: "Spent", color: "var(--chart-negative)" },
 } satisfies ChartConfig;
 
 export function BoxContributionChart({ data }: BoxContributionChartProps) {
@@ -46,8 +46,8 @@ export function BoxContributionChart({ data }: BoxContributionChartProps) {
               />
               <ChartTooltip content={<ChartTooltipContent indicator="dashed" />} />
               <Legend />
-              <Bar dataKey="in" name="Added" fill="#a3b18a" radius={4} />
-              <Bar dataKey="out" name="Spent" fill="#dba19b" radius={4} />
+              <Bar dataKey="in" name="Added" fill="var(--color-in)" radius={4} />
+              <Bar dataKey="out" name="Spent" fill="var(--color-out)" radius={4} />
             </BarChart>
           </ChartContainer>
         ) : (

--- a/web/src/app/dashboard/categories/[id]/_components/category-detail-header.tsx
+++ b/web/src/app/dashboard/categories/[id]/_components/category-detail-header.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CircularProgress } from "@/components/ui/circular-progress";
+import { categoryPacing, BUCKET_META, formatMoney } from "@/lib/budget";
+import { cn } from "@/lib/utils";
+import { Pencil, Lock } from "lucide-react";
+import { resolveCategoryEmoji } from "@/lib/category-emoji";
+import type { CategoryDetail } from "@/lib/actions/categories";
+import { EditCategoryModal } from "../../_components/edit-category-modal";
+
+export function CategoryDetailHeader({ detail }: { detail: CategoryDetail }) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+
+  const money = (n: number) => formatMoney(n, detail.currency, detail.locale);
+  const displayIcon = detail.icon ?? resolveCategoryEmoji(detail.name);
+
+  const hasLimit = detail.monthlyBudget != null;
+  const limit = detail.monthlyBudget ?? 0;
+  const left = limit - detail.spend;
+
+  const pace = categoryPacing({
+    spent: detail.spend,
+    limit: detail.monthlyBudget,
+    day: detail.day,
+    daysInPeriod: detail.daysInPeriod,
+    remainingDays: detail.remainingDays,
+  });
+
+  // Same colour rules as the cards on /dashboard/categories: SAVINGS inverts
+  // (spending toward the target is good), spend buckets go red/amber/emerald.
+  const isSavings = detail.bucket === "SAVINGS";
+  const savedAll = hasLimit && detail.spend >= limit;
+  const overPace = pace.overPace && pace.reliable;
+
+  let toneClass = "text-muted-foreground";
+  if (hasLimit) {
+    if (isSavings) {
+      toneClass = savedAll
+        ? "text-emerald-500 dark:text-emerald-400"
+        : "text-primary";
+    } else if (pace.overSpent) {
+      toneClass = "text-red-500 dark:text-red-400";
+    } else if (overPace) {
+      toneClass = "text-amber-500 dark:text-amber-400";
+    } else {
+      toneClass = "text-emerald-500 dark:text-emerald-400";
+    }
+  }
+
+  const pct = hasLimit && limit > 0 ? (detail.spend / limit) * 100 : 0;
+
+  return (
+    <>
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 rounded-2xl bg-card border shadow-sm p-5">
+        <div className="flex items-center gap-4 min-w-0">
+          {hasLimit ? (
+            <CircularProgress
+              value={pct}
+              size={64}
+              strokeWidth={5}
+              color={toneClass}
+            />
+          ) : (
+            <div className="flex items-center justify-center w-16 h-16 rounded-full bg-muted/50 text-2xl shrink-0">
+              {displayIcon}
+            </div>
+          )}
+
+          <div className="flex flex-col min-w-0">
+            <div className="flex items-center gap-2">
+              <h2 className="text-xl font-bold tracking-tight truncate">
+                {hasLimit ? `${displayIcon} ` : ""}
+                {detail.name}
+              </h2>
+              <Badge
+                variant="outline"
+                className="text-[10px] h-4 px-1.5 font-normal"
+              >
+                {BUCKET_META[detail.bucket].emoji}{" "}
+                {BUCKET_META[detail.bucket].label}
+              </Badge>
+              {detail.budgetLocked && (
+                <Lock className="w-3 h-3 text-muted-foreground/50" />
+              )}
+            </div>
+
+            <div className="text-2xl font-bold font-mono tabular-nums text-foreground mt-0.5">
+              {money(detail.spend)}
+              {hasLimit && (
+                <span className="text-sm font-normal text-muted-foreground">
+                  {" "}
+                  of {money(limit)}
+                </span>
+              )}
+            </div>
+
+            <div className={cn("text-xs font-medium", toneClass)}>
+              {hasLimit
+                ? isSavings
+                  ? left <= 0
+                    ? `${money(Math.abs(left))} beyond target`
+                    : `${money(left)} to go · ${money(pace.safeDaily)}/day to hit it`
+                  : left < 0
+                    ? `${money(Math.abs(left))} over`
+                    : `${money(left)} left · safe ${money(pace.safeDaily)}/day`
+                : isSavings
+                  ? "saved (no limit)"
+                  : "spent (no limit)"}
+            </div>
+
+            <div className="text-[11px] text-muted-foreground mt-0.5">
+              {detail.periodLabel} · day {detail.day} of {detail.daysInPeriod}
+            </div>
+          </div>
+        </div>
+
+        <div className="shrink-0">
+          <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
+            <Pencil className="mr-1 h-3.5 w-3.5" /> Edit
+          </Button>
+        </div>
+      </div>
+
+      <EditCategoryModal
+        category={editing ? detail : null}
+        onClose={() => setEditing(false)}
+        onSaved={() => {
+          setEditing(false);
+          router.refresh();
+        }}
+      />
+    </>
+  );
+}

--- a/web/src/app/dashboard/categories/[id]/_components/category-spend-chart.tsx
+++ b/web/src/app/dashboard/categories/[id]/_components/category-spend-chart.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ReferenceLine,
+  XAxis,
+} from "recharts";
+import type { Bucket } from "@prisma/client";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+interface CategorySpendChartProps {
+  data: { label: string; spend: number }[];
+  bucket: Bucket;
+  budget: number | null;
+}
+
+const BUCKET_COLOR: Record<Bucket, string> = {
+  NEEDS: "var(--chart-needs)",
+  WANTS: "var(--chart-wants)",
+  SAVINGS: "var(--chart-savings)",
+};
+
+export function CategorySpendChart({
+  data,
+  bucket,
+  budget,
+}: CategorySpendChartProps) {
+  const hasActivity = data.some((d) => d.spend > 0);
+  const hasBudget = budget != null && budget > 0;
+  const chartConfig = {
+    spend: { label: "Spent", color: BUCKET_COLOR[bucket] },
+  } satisfies ChartConfig;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Spend over time</CardTitle>
+        <CardDescription>
+          This category per budget cycle
+          {hasBudget ? " — dashed line is the monthly limit" : ""}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {hasActivity ? (
+          <ChartContainer config={chartConfig} className="h-[300px] w-full">
+            <BarChart accessibilityLayer data={data}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="label"
+                tickLine={false}
+                tickMargin={10}
+                axisLine={false}
+              />
+              <ChartTooltip
+                content={<ChartTooltipContent indicator="dashed" />}
+              />
+              {hasBudget && (
+                <ReferenceLine
+                  y={budget}
+                  stroke="currentColor"
+                  className="text-muted-foreground"
+                  strokeDasharray="4 4"
+                />
+              )}
+              <Bar
+                dataKey="spend"
+                name="Spent"
+                fill="var(--color-spend)"
+                radius={4}
+              />
+            </BarChart>
+          </ChartContainer>
+        ) : (
+          <div className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
+            No spend recorded yet in this category.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/app/dashboard/categories/[id]/_components/category-stats.tsx
+++ b/web/src/app/dashboard/categories/[id]/_components/category-stats.tsx
@@ -1,0 +1,89 @@
+import { formatMoney } from "@/lib/budget";
+import { cn } from "@/lib/utils";
+import { TrendingUp, TrendingDown } from "lucide-react";
+import type { CategoryDetail } from "@/lib/actions/categories";
+
+function Tile({
+  label,
+  value,
+  hint,
+  tone,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  tone?: string;
+}) {
+  return (
+    <div className="rounded-2xl bg-card border p-4">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div
+        className={cn(
+          "text-xl font-bold font-mono tabular-nums mt-1",
+          tone ?? "text-foreground",
+        )}
+      >
+        {value}
+      </div>
+      {hint && (
+        <div className="text-[11px] text-muted-foreground mt-0.5 truncate">
+          {hint}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CategoryStats({ detail }: { detail: CategoryDetail }) {
+  const money = (n: number) => formatMoney(n, detail.currency, detail.locale);
+  const up = detail.deltaPct != null && detail.deltaPct > 0;
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <Tile label="Spent this cycle" value={money(detail.spend)} />
+      <Tile label="Transactions" value={String(detail.txnCount)} />
+      <Tile
+        label="Average"
+        value={money(detail.avgTxn)}
+        hint={
+          detail.largest
+            ? `largest ${money(detail.largest.amount)}${detail.largest.note ? ` · ${detail.largest.note}` : ""}`
+            : undefined
+        }
+      />
+      {detail.deltaPct == null ? (
+        <Tile
+          label="vs last cycle"
+          value="—"
+          hint="nothing spent last cycle"
+          tone="text-muted-foreground"
+        />
+      ) : (
+        <div className="rounded-2xl bg-card border p-4">
+          <div className="text-xs text-muted-foreground">vs last cycle</div>
+          <div
+            className={cn(
+              "text-xl font-bold font-mono tabular-nums mt-1 flex items-center gap-1",
+              // Spending more is bad everywhere except SAVINGS, where the
+              // "spend" is money moving toward the goal.
+              up === (detail.bucket === "SAVINGS")
+                ? "text-emerald-500 dark:text-emerald-400"
+                : "text-red-500 dark:text-red-400",
+            )}
+          >
+            {up ? (
+              <TrendingUp className="h-4 w-4" />
+            ) : (
+              <TrendingDown className="h-4 w-4" />
+            )}
+            {up ? "+" : ""}
+            {Math.round(detail.deltaPct)}%
+          </div>
+          <div className="text-[11px] text-muted-foreground mt-0.5">
+            was {money(detail.prevSpend)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/dashboard/categories/[id]/_components/category-top-notes.tsx
+++ b/web/src/app/dashboard/categories/[id]/_components/category-top-notes.tsx
@@ -1,0 +1,43 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { formatMoney } from "@/lib/budget";
+import type { CategoryDetail } from "@/lib/actions/categories";
+
+export function CategoryTopNotes({ detail }: { detail: CategoryDetail }) {
+  // Nothing repeated this cycle — the table below already says everything.
+  if (detail.topNotes.length === 0) return null;
+
+  const money = (n: number) => formatMoney(n, detail.currency, detail.locale);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Most frequent</CardTitle>
+        <CardDescription>
+          Notes you logged more than once this cycle
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {detail.topNotes.map((n) => (
+          <div
+            key={n.note}
+            className="flex items-center justify-between gap-3 text-sm"
+          >
+            <span className="truncate">{n.note}</span>
+            <span className="shrink-0 text-muted-foreground">
+              <span className="text-xs">{n.count}×</span>{" "}
+              <span className="font-mono tabular-nums text-foreground">
+                {money(n.total)}
+              </span>
+            </span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/app/dashboard/categories/[id]/loading.tsx
+++ b/web/src/app/dashboard/categories/[id]/loading.tsx
@@ -1,0 +1,23 @@
+import { ContentLayout } from "@/components/admin-panel/content-layout";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <ContentLayout title="Category">
+      <div className="flex flex-col gap-6">
+        <Skeleton className="h-28 w-full rounded-2xl" />
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {[...Array(4)].map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-2xl" />
+          ))}
+        </div>
+        <Skeleton className="h-[380px] w-full rounded-2xl" />
+        <div className="space-y-3">
+          {[...Array(6)].map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      </div>
+    </ContentLayout>
+  );
+}

--- a/web/src/app/dashboard/categories/[id]/page.tsx
+++ b/web/src/app/dashboard/categories/[id]/page.tsx
@@ -1,0 +1,132 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ContentLayout } from "@/components/admin-panel/content-layout";
+import { ExpenseTable } from "@/app/dashboard/expenses/expense-table";
+import { getExpenses } from "@/lib/actions/expenses";
+import {
+  getCategories,
+  getCategoryDetail,
+  getCategorySpendTrend,
+} from "@/lib/actions/categories";
+import { cn } from "@/lib/utils";
+import { CategoryDetailHeader } from "./_components/category-detail-header";
+import { CategoryStats } from "./_components/category-stats";
+import { CategorySpendChart } from "./_components/category-spend-chart";
+import { CategoryTopNotes } from "./_components/category-top-notes";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{
+    page?: string;
+    perPage?: string;
+    search?: string;
+    sort?: string;
+    from?: string;
+    to?: string;
+    all?: string;
+  }>;
+}
+
+export default async function CategoryDetailPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { id } = await params;
+  const sp = await searchParams;
+
+  const detail = await getCategoryDetail(id);
+  if (!detail) notFound();
+
+  // The table defaults to the current cycle so it agrees with the header ring.
+  // `?all=1` is what makes that default escapable — without an explicit marker,
+  // clearing the date filter would just re-apply it.
+  const showAll = sp.all === "1";
+  const scoped = !showAll && !sp.from && !sp.to;
+  const end = detail.periodEnd;
+  // buildWhere widens `to` to end-of-day, so `to` is the cycle's last day. Built
+  // via the Date constructor rather than end - 86400000: subtracting a fixed day
+  // lands on 23:00 of the wrong day across a DST shift, which would drop that
+  // hour's expenses.
+  const lastDay = new Date(end.getFullYear(), end.getMonth(), end.getDate() - 1);
+  const from = scoped ? String(detail.periodStart.getTime()) : sp.from || "";
+  const to = scoped ? String(lastDay.getTime()) : sp.to || "";
+
+  const [expenses, trend, categories] = await Promise.all([
+    getExpenses({
+      categoryId: id,
+      page: Number(sp.page) || 1,
+      limit: Number(sp.perPage) || 10,
+      search: sp.search || "",
+      sort: sp.sort || "date.desc",
+      from,
+      to,
+    }),
+    getCategorySpendTrend(id),
+    // Only needed so the row-edit modal can offer other categories.
+    getCategories(),
+  ]);
+
+  const tabClass = (active: boolean) =>
+    cn(
+      "text-xs px-2 py-1 rounded-md transition-colors",
+      active
+        ? "bg-muted text-foreground font-medium"
+        : "text-muted-foreground hover:text-foreground",
+    );
+
+  return (
+    <ContentLayout
+      title={detail.name}
+      breadcrumbs={[
+        { label: "Dashboard", href: "/dashboard" },
+        { label: "Categories", href: "/dashboard/categories" },
+        { label: detail.name },
+      ]}
+    >
+      <div className="flex flex-col gap-6">
+        <CategoryDetailHeader detail={detail} />
+        <CategoryStats detail={detail} />
+        <CategorySpendChart
+          data={trend}
+          bucket={detail.bucket}
+          budget={detail.monthlyBudget}
+        />
+        <CategoryTopNotes detail={detail} />
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-medium">
+              Transactions
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                {scoped ? detail.periodLabel : showAll ? "all time" : "filtered"}
+              </span>
+            </h3>
+            <div className="flex items-center gap-1">
+              <Link
+                href={`/dashboard/categories/${id}`}
+                className={tabClass(scoped)}
+              >
+                This cycle
+              </Link>
+              <Link
+                href={`/dashboard/categories/${id}?all=1`}
+                className={tabClass(showAll)}
+              >
+                All time
+              </Link>
+            </div>
+          </div>
+
+          <ExpenseTable
+            data={expenses.data}
+            pageCount={expenses.pageCount}
+            total={expenses.total}
+            categoryOptions={[]}
+            categories={categories}
+            lockedCategoryId={id}
+          />
+        </div>
+      </div>
+    </ContentLayout>
+  );
+}

--- a/web/src/app/dashboard/categories/_components/category-card.tsx
+++ b/web/src/app/dashboard/categories/_components/category-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { motion, useReducedMotion } from "motion/react";
 import { Button } from "@/components/ui/button";
 import {
@@ -114,7 +115,10 @@ export function CategoryCard({
   return (
     <>
       <div className="relative flex items-center justify-between p-5 rounded-2xl bg-card border shadow-sm overflow-hidden group hover:border-border/80 transition-colors">
-        <div className="flex items-center gap-4 min-w-0">
+        <Link
+          href={`/dashboard/categories/${cat.id}`}
+          className="flex items-center gap-4 min-w-0 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
           <div className="flex items-center justify-center w-10 h-10 rounded-full bg-muted/50 shrink-0">
             <motion.span
               key={displayIcon}
@@ -129,7 +133,7 @@ export function CategoryCard({
           
           <div className="flex flex-col gap-0.5 min-w-0">
             <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-muted-foreground truncate">{cat.name}</span>
+              <span className="text-sm font-medium text-muted-foreground truncate group-hover:text-foreground transition-colors">{cat.name}</span>
               {cat.budgetLocked && (
                 <Lock className="w-3 h-3 text-muted-foreground/50" />
               )}
@@ -152,8 +156,8 @@ export function CategoryCard({
                </div>
             )}
           </div>
-        </div>
-        
+        </Link>
+
         <div className="flex items-center gap-3 shrink-0">
           <CircularProgress 
             value={pct} 

--- a/web/src/app/dashboard/expenses/expense-table.tsx
+++ b/web/src/app/dashboard/expenses/expense-table.tsx
@@ -22,6 +22,10 @@ interface ExpenseTableProps {
     total: number;
     categoryOptions: { label: string; value: string }[];
     categories: CategoryStat[];
+    // Pins the table to one category (the /categories/[id] detail page). The
+    // category is then fixed context, not a filter: it stays out of the URL and
+    // its column is hidden, but exports stay scoped to it.
+    lockedCategoryId?: string;
 }
 
 export function ExpenseTable({
@@ -29,6 +33,7 @@ export function ExpenseTable({
     pageCount,
     categoryOptions,
     categories,
+    lockedCategoryId,
 }: ExpenseTableProps) {
     const columns = React.useMemo(
         () => getExpenseColumns(categories),
@@ -72,7 +77,7 @@ export function ExpenseTable({
     const columnFilters = React.useMemo<ColumnFiltersState>(() => {
         const filters: ColumnFiltersState = [];
         if (bucket) filters.push({ id: "bucket", value: bucket.split(".") });
-        if (categoryId)
+        if (categoryId && !lockedCategoryId)
             filters.push({ id: "categoryName", value: categoryId.split(".") });
         if (from || to) {
             filters.push({
@@ -81,7 +86,7 @@ export function ExpenseTable({
             });
         }
         return filters;
-    }, [bucket, categoryId, from, to]);
+    }, [bucket, categoryId, from, to, lockedCategoryId]);
 
     // Derive table sorting state
     const sorting: SortingState = React.useMemo(() => {
@@ -112,11 +117,13 @@ export function ExpenseTable({
             setBucket(null);
         }
 
-        const categoryFilter = newFilters.find((f) => f.id === "categoryName");
-        if (categoryFilter && Array.isArray(categoryFilter.value)) {
-            setCategoryId(categoryFilter.value.join("."));
-        } else {
-            setCategoryId(null);
+        if (!lockedCategoryId) {
+            const categoryFilter = newFilters.find((f) => f.id === "categoryName");
+            if (categoryFilter && Array.isArray(categoryFilter.value)) {
+                setCategoryId(categoryFilter.value.join("."));
+            } else {
+                setCategoryId(null);
+            }
         }
 
         const dateFilter = newFilters.find((f) => f.id === "date");
@@ -138,7 +145,7 @@ export function ExpenseTable({
     const currentFilters: ExpenseFilters = {
         search: search || undefined,
         bucket: bucket || undefined,
-        categoryId: categoryId || undefined,
+        categoryId: lockedCategoryId ?? categoryId ?? undefined,
         from: from || undefined,
         to: to || undefined,
     };
@@ -147,6 +154,10 @@ export function ExpenseTable({
         data,
         columns,
         getCoreRowModel: getCoreRowModel(),
+        // Every row shares the pinned category, so the column carries no signal.
+        initialState: lockedCategoryId
+            ? { columnVisibility: { categoryName: false } }
+            : undefined,
         manualPagination: true,
         manualSorting: true,
         manualFiltering: true,

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -93,6 +93,15 @@
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
+  /* Chart series colors: the bucket pastels, plus the in/out pair shared by the
+     box and income-vs-spend charts. Deliberately outside --chart-1..5, which are
+     stock shadcn values with no bucket meaning. Same in both themes for now —
+     defined once here so the fills have one source instead of a hex per chart. */
+  --chart-needs: #829496;
+  --chart-wants: #dba19b;
+  --chart-savings: #a3b18a;
+  --chart-positive: #a3b18a;
+  --chart-negative: #dba19b;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);

--- a/web/src/lib/actions/categories.ts
+++ b/web/src/lib/actions/categories.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { Bucket } from "@prisma/client";
 import {
   currentBudgetPeriod,
+  periodDayInfo,
   previousCycles,
   median,
   allocateByWeight,
@@ -530,4 +531,177 @@ export async function deleteCategory(
 
   revalidatePath("/dashboard/categories");
   return { success: true };
+}
+
+export type CategoryDetail = CategoryStat & {
+  periodLabel: string;
+  periodStart: Date;
+  periodEnd: Date; // exclusive
+  day: number;
+  daysInPeriod: number;
+  remainingDays: number;
+  txnCount: number;
+  avgTxn: number;
+  largest: { amount: number; note: string | null; date: Date } | null;
+  prevSpend: number; // previous complete cycle
+  deltaPct: number | null; // null when there is nothing to compare against
+  topNotes: { note: string; count: number; total: number }[];
+  currency: string;
+  locale: string;
+};
+
+// Everything the per-category detail page needs about one leaf category, scoped
+// to the current payday cycle so the numbers match the cards on /categories.
+export async function getCategoryDetail(
+  id: string,
+): Promise<CategoryDetail | null> {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+  const userId = session.user.id;
+
+  const cat = await ownedCategory(id, userId);
+  // Groups hold no expenses of their own — only leaves get a detail page.
+  if (!cat || cat.isGroup) return null;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { payday: true, currency: true, locale: true },
+  });
+  const payday = user?.payday ?? 1;
+  const { start, end } = currentBudgetPeriod(payday);
+  const { day, daysInPeriod, remainingDays } = periodDayInfo(payday);
+  const prev = previousCycles(payday, 1)[0];
+
+  const [rows, prevAgg] = await Promise.all([
+    prisma.expense.findMany({
+      where: {
+        userId,
+        categoryId: id,
+        isDeleted: false,
+        date: { gte: start, lt: end },
+      },
+      select: { amount: true, note: true, date: true },
+      orderBy: { amount: "desc" },
+    }),
+    prisma.expense.aggregate({
+      _sum: { amount: true },
+      where: {
+        userId,
+        categoryId: id,
+        isDeleted: false,
+        date: { gte: prev.start, lt: prev.end },
+      },
+    }),
+  ]);
+
+  // One pass over the cycle's rows covers spend, count, average and the notes
+  // histogram. Notes are freeform from Telegram, so they're keyed case- and
+  // whitespace-insensitively ("Bigbasket weekly" and "bigbasket weekly" are one).
+  let spend = 0;
+  const notes = new Map<
+    string,
+    { note: string; count: number; total: number }
+  >();
+  for (const r of rows) {
+    const amount = Number(r.amount);
+    spend += amount;
+    const raw = r.note?.trim();
+    if (!raw) continue;
+    const hit = notes.get(raw.toLowerCase());
+    if (hit) {
+      hit.count += 1;
+      hit.total += amount;
+    } else {
+      notes.set(raw.toLowerCase(), { note: raw, count: 1, total: amount });
+    }
+  }
+
+  const prevSpend = Number(prevAgg._sum.amount ?? 0);
+  const locale = user?.locale ?? "en-IN";
+  const fmt = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+  });
+
+  return {
+    id: cat.id,
+    name: cat.name,
+    bucket: cat.bucket,
+    isSystem: cat.userId === null,
+    isGroup: cat.isGroup,
+    parentId: cat.parentId,
+    monthlyBudget:
+      cat.monthlyBudget === null ? null : Number(cat.monthlyBudget),
+    budgetLocked: cat.budgetLocked,
+    icon: cat.icon,
+    spend,
+    periodLabel: `${fmt.format(start)} – ${fmt.format(new Date(end.getTime() - 86400000))}`,
+    periodStart: start,
+    periodEnd: end,
+    day,
+    daysInPeriod,
+    remainingDays,
+    txnCount: rows.length,
+    avgTxn: rows.length > 0 ? spend / rows.length : 0,
+    // Rows are ordered by amount, so the first one is the biggest hit.
+    largest: rows[0]
+      ? {
+          amount: Number(rows[0].amount),
+          note: rows[0].note,
+          date: rows[0].date,
+        }
+      : null,
+    prevSpend,
+    deltaPct: prevSpend > 0 ? ((spend - prevSpend) / prevSpend) * 100 : null,
+    // Only repeats are interesting — a list of unique notes is just the table again.
+    topNotes: [...notes.values()]
+      .filter((n) => n.count > 1)
+      .sort((a, b) => b.count - a.count || b.total - a.total)
+      .slice(0, 5),
+    currency: user?.currency ?? "INR",
+    locale,
+  };
+}
+
+// One category's spend per budget cycle, oldest first, with the current partial
+// cycle as the last point. Mirrors getBoxContributionTrend in boxes.ts.
+export async function getCategorySpendTrend(
+  id: string,
+  cycles: number = 6,
+): Promise<{ label: string; spend: number }[]> {
+  const session = await auth();
+  if (!session?.user?.id) return [];
+  const userId = session.user.id;
+
+  const n = Math.min(Math.max(Math.floor(cycles) || 6, 1), 24);
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { payday: true, locale: true },
+  });
+  const payday = user?.payday ?? 1;
+  const windows = [
+    ...previousCycles(payday, n - 1).reverse(),
+    currentBudgetPeriod(payday),
+  ];
+
+  const rows = await prisma.expense.findMany({
+    where: {
+      userId,
+      categoryId: id,
+      isDeleted: false,
+      date: { gte: windows[0].start, lt: windows[windows.length - 1].end },
+    },
+    select: { amount: true, date: true },
+  });
+
+  const fmt = new Intl.DateTimeFormat(user?.locale ?? "en-IN", {
+    month: "short",
+    year: "2-digit",
+  });
+  const series = windows.map((w) => ({ label: fmt.format(w.start), spend: 0 }));
+  for (const r of rows) {
+    const i = windows.findIndex((w) => r.date >= w.start && r.date < w.end);
+    if (i >= 0) series[i].spend += Number(r.amount);
+  }
+  return series;
 }


### PR DESCRIPTION
## What

Category cards on `/dashboard/categories` were a dead end — no way to see what made up a category's spend. `getExpenses` has supported a `categoryId` filter since it was written, but nothing linked to it.

Adds `/dashboard/categories/[id]`, following the existing `boxes/[id]` pattern.

### `feat(categories)` — the breakdown page

- **Budget header** — spend/limit ring, pacing copy, period label. Reuses `categoryPacing` and the colour rules from `CategoryCard` (SAVINGS inverts).
- **Stat tiles** — spent, transaction count, average (with largest as a sub-line), vs-last-cycle delta.
- **Spend-per-cycle chart** — 6 cycles, dashed budget reference line.
- **Most-frequent notes** — repeats only; singletons are dropped as noise.
- **Transactions** — the category's expenses, with search, date filter, sort, CSV export and bulk actions.

Two new actions: `getCategoryDetail` (one `findMany` over the cycle yields spend, count, average, largest and the notes histogram; notes group case- and whitespace-insensitively since they arrive freeform from Telegram) and `getCategorySpendTrend` (mirrors `getBoxContributionTrend`).

`ExpenseTable` gains an optional `lockedCategoryId` rather than duplicating the nuqs/TanStack glue a fourth time. The category becomes fixed context: kept out of the URL, column hidden, exports still scoped to it.

Scoped to the **payday cycle**, not the calendar month, so the numbers match the cards on `/categories`. The `all=1` param escapes that default — without an explicit marker, clearing the date filter would just re-apply it.

### `fix(web)` — chart colour tokens

Every `chartConfig` declared `color: "hsl(var(--chart-N))"`, which expands to `hsl(oklch(...))` — a garbage value. It went unnoticed because nothing read it: `ChartStyle` emits `--color-<key>` on the container, but tooltip and legend swatches use recharts' own `item.color`/`payload.fill`, so the only consumer would be an explicit `fill="var(--color-…)"` — and every `<Bar>` hardcoded a hex instead.

Adds dedicated tokens for the bucket pastels and the in/out pair, points the configs at them, and has the bars read `var(--color-<key>)`. The hexes were repeated across five charts and now live in one place. Kept separate from `--chart-1..5`, which are stock shadcn values with no bucket meaning. **Token values are identical to the hexes they replace, so nothing changes visually.**

## Not included

Income has no `categoryId` in the schema, so per-category income needs a migration plus backend `IncomeProcessor` changes. Deferred.

## Verification

- `pnpm build` compiles; `pnpm lint` holds at 0 errors / 22 pre-existing warnings.
- Cycle-window math checked across all 28 paydays × 60 reference dates (1,680 cases): cycle containment, previous-cycle contiguity, gapless trend windows, and the table's default range covering exactly the cycle with no leak into the next.
- Both new actions replayed against a dev database: numbers match what the category cards compute, trend's last bar equals cycle spend, zero-spend category safe, group id returns null (404), cross-user id returns null.
- `ChartStyle` rendered directly for all four chart configs: emits plain `var()` refs, and every emitted key matches a `fill="var(--color-KEY)"` name.

**Not verified in a browser** — auth middleware redirects every dashboard route, so nothing here has been seen rendered. Also, both dev users have `payday = 1`, so the non-1-payday path rests on the pure-function test rather than real rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)