### PR TITLE
fix(time): format cycle labels in the user's timezone

### DIFF
--- a/src/application/use-cases/budgetMath.spec.ts
+++ b/src/application/use-cases/budgetMath.spec.ts
@@ -12,8 +12,14 @@ import {
   progressBar,
   sanitizeMd,
 } from "./budgetMath";
+import { zonedStartOfDayUtc } from "../../utils/time";
 
 const SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
+
+// Cycle boundaries are IST midnights, not the runner's local midnight — assert
+// against the instant so these pass in any TZ. Month is 1-based here.
+const ist = (y: number, m: number, d: number) =>
+  zonedStartOfDayUtc(y, m, d, "Asia/Kolkata");
 
 describe("budgetMath", () => {
   it("effective income floors at expected and grows with actual", () => {
@@ -61,38 +67,40 @@ describe("budgetMath", () => {
     // payday=1 → cycles are calendar months. On Jun 10, current cycle is June;
     // the prior complete cycles are May, then April.
     const cycles = previousCycles(1, 2, new Date(2026, 5, 10));
-    expect(cycles[0].start).toEqual(new Date(2026, 4, 1)); // May
-    expect(cycles[0].end).toEqual(new Date(2026, 5, 1));
-    expect(cycles[1].start).toEqual(new Date(2026, 3, 1)); // April
-    expect(cycles[1].end).toEqual(new Date(2026, 4, 1));
+    expect(cycles[0].start).toEqual(ist(2026, 5, 1)); // May
+    expect(cycles[0].end).toEqual(ist(2026, 6, 1));
+    expect(cycles[1].start).toEqual(ist(2026, 4, 1)); // April
+    expect(cycles[1].end).toEqual(ist(2026, 5, 1));
   });
 
   it("previousCycles handles a mid-month payday across month lengths", () => {
     // payday=25: on Jun 26 current cycle is Jun 25–Jul 25; just-ended is May 25–Jun 25.
     const [ended] = previousCycles(25, 1, new Date(2026, 5, 26));
-    expect(ended.start).toEqual(new Date(2026, 4, 25));
-    expect(ended.end).toEqual(new Date(2026, 5, 25));
+    expect(ended.start).toEqual(ist(2026, 5, 25));
+    expect(ended.end).toEqual(ist(2026, 6, 25));
   });
 
   it("payday=1 budget period equals the calendar month", () => {
     const { start, end } = currentBudgetPeriod(1, new Date(2026, 4, 10));
-    expect(start).toEqual(new Date(2026, 4, 1));
-    expect(end).toEqual(new Date(2026, 5, 1));
+    expect(start).toEqual(ist(2026, 5, 1));
+    expect(end).toEqual(ist(2026, 6, 1));
   });
 
   it("payday cycle spans payday→payday across the month boundary", () => {
     // June 12 with payday 25 → cycle is May 25 .. Jun 25
     const before = currentBudgetPeriod(25, new Date(2026, 5, 12));
-    expect(before.start).toEqual(new Date(2026, 4, 25));
-    expect(before.end).toEqual(new Date(2026, 5, 25));
+    expect(before.start).toEqual(ist(2026, 5, 25));
+    expect(before.end).toEqual(ist(2026, 6, 25));
     // June 26 with payday 25 → cycle is Jun 25 .. Jul 25
     const after = currentBudgetPeriod(25, new Date(2026, 5, 26));
-    expect(after.start).toEqual(new Date(2026, 5, 25));
-    expect(after.end).toEqual(new Date(2026, 6, 25));
+    expect(after.start).toEqual(ist(2026, 6, 25));
+    expect(after.end).toEqual(ist(2026, 7, 25));
   });
 
   it("periodDayInfo counts days within the cycle", () => {
-    const info = periodDayInfo(1, new Date(2026, 4, 10)); // May 10, payday 1
+    // May 10 IST, payday 1 — spelled with an offset so the day index doesn't
+    // shift on runners east of IST.
+    const info = periodDayInfo(1, new Date("2026-05-10T12:00:00+05:30"));
     expect(info.day).toBe(10);
     expect(info.daysInPeriod).toBe(31);
     expect(info.remainingDays).toBe(22); // 31 - 10 + 1

--- a/src/application/use-cases/categoryName.spec.ts
+++ b/src/application/use-cases/categoryName.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { normalizeCategoryName } from "./categoryName";
+
+describe("normalizeCategoryName", () => {
+  it("passes a clean name through", () => {
+    expect(normalizeCategoryName("Food")).toBe("Food");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeCategoryName("  Food  ")).toBe("Food");
+  });
+
+  it("collapses internal whitespace runs", () => {
+    expect(normalizeCategoryName("Eating   out\tdaily")).toBe(
+      "Eating out daily",
+    );
+  });
+
+  it("rejects an empty or whitespace-only name", () => {
+    expect(normalizeCategoryName("")).toBeUndefined();
+    expect(normalizeCategoryName("   ")).toBeUndefined();
+  });
+
+  it("rejects undefined", () => {
+    expect(normalizeCategoryName(undefined)).toBeUndefined();
+  });
+
+  it("accepts exactly 50 characters", () => {
+    const name = "x".repeat(50);
+    expect(normalizeCategoryName(name)).toBe(name);
+  });
+
+  it("rejects 51 characters", () => {
+    expect(normalizeCategoryName("x".repeat(51))).toBeUndefined();
+  });
+
+  it("measures length after trimming, unlike the web nameSchema", () => {
+    // 50 real chars wrapped in spaces — the web path's z.max(50) would reject
+    // this because .trim() runs after .max(); here it survives.
+    expect(normalizeCategoryName(`  ${"x".repeat(50)}  `)).toBe("x".repeat(50));
+  });
+});

--- a/src/application/use-cases/categoryName.ts
+++ b/src/application/use-cases/categoryName.ts
@@ -1,0 +1,21 @@
+// Category names coming off the AI parser are unvalidated free text — the model
+// can return whitespace, or a whole sentence, and it lands straight in the DB.
+// The web path already constrains this (nameSchema in
+// web/src/lib/actions/categories.ts); this is the same rule for the bot path.
+//
+// One deliberate difference: the length check runs AFTER trimming. Zod's
+// `.trim()` is a transform that runs after `.max(50)`, so the web path measures
+// the untrimmed string.
+//
+// Returning undefined means "no usable category" — resolveExpenseCategory
+// already treats a missing name that way, so the expense still lands in the
+// right bucket, just uncategorized.
+
+const MAX_NAME_CHARS = 50;
+
+export function normalizeCategoryName(raw?: string): string | undefined {
+  if (!raw) return undefined;
+  const name = raw.trim().replace(/\s+/g, " ");
+  if (!name || name.length > MAX_NAME_CHARS) return undefined;
+  return name;
+}

--- a/src/application/use-cases/cycleReport.spec.ts
+++ b/src/application/use-cases/cycleReport.spec.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { buildCycleReport } from "./cycleReport";
+import { zonedParts } from "../../utils/time";
 
 // payday=1 → calendar-month cycles. On Jun 10 the ended cycle is May, prior is April.
 const NOW = new Date(2026, 5, 10);
 const user = { id: "u1", monthlyIncome: 50000, payday: 1 };
 
-// Distinguish ended (May, month 4) from prior (April, month 3) by the range start.
-const isEnded = (start: Date) => start.getMonth() === 4;
+// Distinguish ended (May) from prior (April) by the range start. Read in IST —
+// the boundary is that zone's midnight, which is the prior month in UTC.
+const isEnded = (start: Date) => zonedParts(start, "Asia/Kolkata").month === 5;
 
 describe("buildCycleReport", () => {
   let expenseRepository: any;

--- a/src/application/use-cases/cycleReport.ts
+++ b/src/application/use-cases/cycleReport.ts
@@ -36,12 +36,23 @@ export interface CycleReport {
   endedKey: string; // period key of the ended cycle — idempotency scope
 }
 
-// "May" for calendar-month cycles (payday=1), else "May 25 – Jun 25".
-function cycleLabel(start: Date, end: Date, payday: number): string {
+// "May" for calendar-month cycles (payday=1), else "May 25 – Jun 25". Formats in
+// `tz` — the boundaries are that zone's midnights, so the server's clock must not
+// decide which month they land in.
+function cycleLabel(
+  start: Date,
+  end: Date,
+  payday: number,
+  tz: string,
+): string {
   if (payday <= 1) {
-    return new Intl.DateTimeFormat("en-IN", { month: "long" }).format(start);
+    return new Intl.DateTimeFormat("en-IN", {
+      timeZone: tz,
+      month: "long",
+    }).format(start);
   }
   const fmt = new Intl.DateTimeFormat("en-IN", {
+    timeZone: tz,
     month: "short",
     day: "numeric",
   });
@@ -189,7 +200,7 @@ export async function buildCycleReport(
   }
 
   const { up, down } = await movers(deps, user.id, ended, prior);
-  const label = cycleLabel(ended.start, ended.end, payday);
+  const label = cycleLabel(ended.start, ended.end, payday, tz);
   const net = endedIncome - totalSpent;
 
   // Headline: overall spend vs last cycle, framed for a decision.

--- a/src/application/use-cases/expenseFlow.spec.ts
+++ b/src/application/use-cases/expenseFlow.spec.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { buildCategoryBudgetLine, buildBucketBudgetLine } from "./expenseFlow";
+import {
+  buildCategoryBudgetLine,
+  buildBucketBudgetLine,
+  resolveExpenseCategory,
+} from "./expenseFlow";
+import { Category } from "@prisma/client";
+import { ICategoryRepository } from "../../domain/repositories/ICategoryRepository";
+
+// Minimal stub — resolveExpenseCategory only ever calls these two methods.
+function stubCategoryRepo(existing: Partial<Category> | null) {
+  const created: Array<{ name: string; bucket: string }> = [];
+  const repo = {
+    findByNameForUser: async () => existing as Category | null,
+    create: async (data: { name: string; bucket: string }) => {
+      created.push({ name: data.name, bucket: data.bucket });
+      return { id: "new-cat", name: data.name, isGroup: false } as Category;
+    },
+  } as unknown as ICategoryRepository;
+  return { repo, created };
+}
 
 describe("buildCategoryBudgetLine", () => {
   it("shows remaining when under a cap", () => {
@@ -44,5 +63,75 @@ describe("buildBucketBudgetLine", () => {
     expect(
       buildBucketBudgetLine("NEEDS", 4920, 5000, 10, { compact: true }),
     ).toBe("   · Needs: ₹4,920 left");
+  });
+});
+
+describe("resolveExpenseCategory", () => {
+  it("reuses an existing leaf and reports no creation", async () => {
+    const { repo, created } = stubCategoryRepo({
+      id: "cat-1",
+      name: "Food",
+      bucket: "WANTS",
+      isGroup: false,
+    });
+    const result = await resolveExpenseCategory(repo, "u1", "NEEDS", "food");
+    expect(result.categoryId).toBe("cat-1");
+    expect(result.categoryLabel).toBe("Food");
+    expect(result.bucket).toBe("WANTS"); // the category's bucket wins
+    expect(result.createdCategory).toBe(false);
+    expect(created).toHaveLength(0);
+  });
+
+  it("creates an unknown category and reports it", async () => {
+    const { repo, created } = stubCategoryRepo(null);
+    const result = await resolveExpenseCategory(
+      repo,
+      "u1",
+      "WANTS",
+      "Biriyani",
+    );
+    expect(result.categoryId).toBe("new-cat");
+    expect(result.createdCategory).toBe(true);
+    expect(created).toEqual([{ name: "Biriyani", bucket: "WANTS" }]);
+  });
+
+  it("creates with a trimmed, whitespace-collapsed name", async () => {
+    const { repo, created } = stubCategoryRepo(null);
+    await resolveExpenseCategory(repo, "u1", "WANTS", "  Eating   out  ");
+    expect(created).toEqual([{ name: "Eating out", bucket: "WANTS" }]);
+  });
+
+  it("drops an over-long name instead of writing it", async () => {
+    const { repo, created } = stubCategoryRepo(null);
+    const result = await resolveExpenseCategory(
+      repo,
+      "u1",
+      "WANTS",
+      "x".repeat(51),
+    );
+    expect(created).toHaveLength(0);
+    expect(result.categoryId).toBeUndefined();
+    expect(result.categoryLabel).toBe("General");
+    expect(result.createdCategory).toBe(false);
+    expect(result.bucket).toBe("WANTS"); // still lands in the parsed bucket
+  });
+
+  it("does not create when the name matches a group", async () => {
+    const { repo, created } = stubCategoryRepo({
+      id: "grp-1",
+      name: "Essentials",
+      bucket: "NEEDS",
+      isGroup: true,
+    });
+    const result = await resolveExpenseCategory(
+      repo,
+      "u1",
+      "WANTS",
+      "Essentials",
+    );
+    expect(created).toHaveLength(0);
+    expect(result.categoryId).toBeUndefined();
+    expect(result.bucket).toBe("NEEDS"); // adopts the group's bucket
+    expect(result.createdCategory).toBe(false);
   });
 });

--- a/src/application/use-cases/expenseFlow.ts
+++ b/src/application/use-cases/expenseFlow.ts
@@ -5,6 +5,7 @@ import { IBudgetConfigRepository } from "../../domain/repositories/IBudgetConfig
 import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
 import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import { txnCb } from "./txnCallback";
+import { normalizeCategoryName } from "./categoryName";
 import {
   BUCKET_META,
   bucketBudget,
@@ -100,19 +101,26 @@ export function buildBucketBudgetLine(
 // resolves to a group, it stays uncategorized (still lands in the right bucket).
 // Returns the category's own bucket too, so an edit can re-derive the bucket
 // from a changed category (create keeps its caller-supplied bucket).
+// `createdCategory` lets the caller tell the user a new category was invented.
 export async function resolveExpenseCategory(
   categoryRepository: ICategoryRepository,
   userId: string,
   bucket: Bucket,
-  name?: string | undefined,
+  rawName?: string | undefined,
 ): Promise<{
   categoryId?: string | undefined;
   categoryLabel: string;
   bucket: Bucket;
+  createdCategory: boolean;
 }> {
+  // An unusable name (blank, or a whole sentence) is treated as no category —
+  // the expense stays uncategorized rather than writing junk to the DB.
+  const name = normalizeCategoryName(rawName);
+
   let categoryId: string | undefined;
   let categoryLabel = name ?? "General";
   let resolvedBucket = bucket;
+  let createdCategory = false;
   if (name) {
     const existing = await categoryRepository.findByNameForUser(userId, name);
     if (existing && !existing.isGroup) {
@@ -125,9 +133,10 @@ export async function resolveExpenseCategory(
       const created = await categoryRepository.create({ userId, name, bucket });
       categoryId = created.id;
       categoryLabel = created.name;
+      createdCategory = true;
     }
   }
-  return { categoryId, categoryLabel, bucket: resolvedBucket };
+  return { categoryId, categoryLabel, bucket: resolvedBucket, createdCategory };
 }
 
 // Creates the expense and returns it plus the resolved category label. No
@@ -135,13 +144,18 @@ export async function resolveExpenseCategory(
 export async function recordExpense(
   deps: ExpenseFlowDeps,
   args: RecordExpenseArgs,
-): Promise<{ expense: Expense; categoryLabel: string }> {
+): Promise<{
+  expense: Expense;
+  categoryLabel: string;
+  createdCategory: boolean;
+}> {
   const { user, amount, bucket } = args;
 
   // Use a known leaf id when the caller already resolved one; otherwise
   // find-or-create by name (bucket stays the caller-supplied one).
   let categoryId = args.categoryId;
   let categoryLabel = args.categoryName ?? "General";
+  let createdCategory = false;
   if (!categoryId && args.categoryName) {
     const resolved = await resolveExpenseCategory(
       deps.categoryRepository,
@@ -151,6 +165,7 @@ export async function recordExpense(
     );
     categoryId = resolved.categoryId;
     categoryLabel = resolved.categoryLabel;
+    createdCategory = resolved.createdCategory;
   }
 
   const expense = await deps.expenseRepository.create({
@@ -166,8 +181,13 @@ export async function recordExpense(
     batchId: args.batchId,
   });
 
-  return { expense, categoryLabel };
+  return { expense, categoryLabel, createdCategory };
 }
+
+// Shown once when a spend invents a category, so the user can fix it while it's
+// still fresh instead of finding stray rows on the dashboard weeks later.
+export const NEW_CATEGORY_LINE =
+  "   · new category — rename or set a budget in the dashboard";
 
 // Creates the expense, sends the confirmation + remaining-budget line, and links
 // the confirmation message for later reply/undo. Shared by ExpenseProcessor
@@ -178,7 +198,10 @@ export async function recordExpenseAndReply(
 ): Promise<string> {
   const { user, amount, bucket } = args;
 
-  const { expense, categoryLabel } = await recordExpense(deps, args);
+  const { expense, categoryLabel, createdCategory } = await recordExpense(
+    deps,
+    args,
+  );
 
   const { start, end } = currentBudgetPeriod(user.payday);
 
@@ -226,6 +249,7 @@ export async function recordExpenseAndReply(
   const response = [
     buildExpenseLine(bucket, categoryLabel, amount),
     categoryLine,
+    createdCategory ? NEW_CATEGORY_LINE : null,
     buildBucketBudgetLine(bucket, remaining, budget, remainingDays),
   ]
     .filter(Boolean)

--- a/src/application/use-cases/processors/BatchProcessor.spec.ts
+++ b/src/application/use-cases/processors/BatchProcessor.spec.ts
@@ -134,6 +134,82 @@ describe("BatchProcessor", () => {
     );
   });
 
+  it("counts invented categories in one footer instead of per line", async () => {
+    // "Food" exists; "Dosa" does not.
+    categoryRepository.findByNameForUser.mockImplementation(
+      async (_userId: string, name: string) =>
+        name === "Food"
+          ? { id: "cF", name: "Food", isGroup: false, bucket: "WANTS" }
+          : null,
+    );
+    categoryRepository.create.mockResolvedValue({
+      id: "c9",
+      name: "Dosa",
+      isGroup: false,
+    });
+
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "chai 30, dosa 60",
+      parsedBatch: {
+        transactions: [
+          {
+            intent: "EXPENSE",
+            amount: 30,
+            category: "Food",
+            bucket: "WANTS",
+            confidence: 0.9,
+          },
+          {
+            intent: "EXPENSE",
+            amount: 60,
+            category: "Dosa",
+            bucket: "WANTS",
+            confidence: 0.9,
+          },
+        ],
+      },
+    } as any);
+
+    const summary = messageService.sendInteractiveMessage.mock.calls[0][1];
+    expect(categoryRepository.create).toHaveBeenCalledTimes(1);
+    expect(summary).toContain("1 new category");
+    expect(summary).not.toContain("new categories");
+    // One footer, not one marker per logged line.
+    expect(summary.match(/new categor/g)).toHaveLength(1);
+  });
+
+  it("pluralizes the new-category footer", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "dosa 60, idli 40",
+      parsedBatch: {
+        transactions: [
+          {
+            intent: "EXPENSE",
+            amount: 60,
+            category: "Dosa",
+            bucket: "WANTS",
+            confidence: 0.9,
+          },
+          {
+            intent: "EXPENSE",
+            amount: 40,
+            category: "Idli",
+            bucket: "WANTS",
+            confidence: 0.9,
+          },
+        ],
+      },
+    } as any);
+
+    expect(messageService.sendInteractiveMessage.mock.calls[0][1]).toContain(
+      "2 new categories",
+    );
+  });
+
   it("stages ambiguous expenses and asks in one grouped follow-up", async () => {
     await processor.process({
       user,

--- a/src/application/use-cases/processors/BatchProcessor.ts
+++ b/src/application/use-cases/processors/BatchProcessor.ts
@@ -82,6 +82,8 @@ export class BatchProcessor implements MessageProcessor {
     }[] = [];
     let firstExpenseId: string | undefined;
     let recordedIncome = false;
+    // Counted, not flagged per line — a marker on every row would bury the summary.
+    let newCategories = 0;
 
     const deps = {
       expenseRepository: this.expenseRepository,
@@ -151,18 +153,22 @@ export class BatchProcessor implements MessageProcessor {
         continue;
       }
 
-      const { expense, categoryLabel } = await recordExpense(deps, {
-        user,
-        platformUserId,
-        amount: item.amount,
-        bucket,
-        rawText: textMessage,
-        confidence: item.confidence,
-        note: item.note,
-        categoryId: leaf?.id,
-        categoryName: leaf?.name ?? item.category,
-        batchId,
-      });
+      const { expense, categoryLabel, createdCategory } = await recordExpense(
+        deps,
+        {
+          user,
+          platformUserId,
+          amount: item.amount,
+          bucket,
+          rawText: textMessage,
+          confidence: item.confidence,
+          note: item.note,
+          categoryId: leaf?.id,
+          categoryName: leaf?.name ?? item.category,
+          batchId,
+        },
+      );
+      if (createdCategory) newCategories++;
       firstExpenseId ??= expense.id;
       const bucketSpent = await this.expenseRepository.sumByBucketForMonth(
         user.id,
@@ -205,6 +211,11 @@ export class BatchProcessor implements MessageProcessor {
 
     const parts: string[] = [];
     if (logged.length) parts.push(logged.join("\n"));
+    if (newCategories > 0) {
+      parts.push(
+        `   · ${newCategories} new categor${newCategories === 1 ? "y" : "ies"} — review in the dashboard`,
+      );
+    }
     if (budgetLine) parts.push(budgetLine);
     if (dropped > 0) {
       parts.push(

--- a/src/application/use-cases/processors/ExpenseProcessor.spec.ts
+++ b/src/application/use-cases/processors/ExpenseProcessor.spec.ts
@@ -102,6 +102,82 @@ describe("ExpenseProcessor", () => {
     expect(parseLogRepository.create).not.toHaveBeenCalled();
   });
 
+  it("flags a newly-invented category in the reply", async () => {
+    categoryRepository.create.mockResolvedValue({
+      id: "c9",
+      name: "Biriyani",
+      isGroup: false,
+    });
+
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "biriyani 250",
+      parsed: {
+        intent: "EXPENSE",
+        amount: 250,
+        category: "Biriyani",
+        bucket: "WANTS",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(categoryRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Biriyani", bucket: "WANTS" }),
+    );
+    expect(messageService.sendInteractiveMessage.mock.calls[0][1]).toContain(
+      "new category",
+    );
+  });
+
+  it("stays quiet when the category already exists", async () => {
+    categoryRepository.findByNameForUser.mockResolvedValue({
+      id: "cF",
+      name: "Food",
+      isGroup: false,
+      bucket: "WANTS",
+    });
+
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "dosa 60",
+      parsed: {
+        intent: "EXPENSE",
+        amount: 60,
+        category: "Food",
+        bucket: "WANTS",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(categoryRepository.create).not.toHaveBeenCalled();
+    expect(
+      messageService.sendInteractiveMessage.mock.calls[0][1],
+    ).not.toContain("new category");
+  });
+
+  it("drops an over-long category name instead of writing it", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "paid 500",
+      parsed: {
+        intent: "EXPENSE",
+        amount: 500,
+        category: "x".repeat(51),
+        bucket: "NEEDS",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(categoryRepository.create).not.toHaveBeenCalled();
+    // The expense still lands, just uncategorized in the parsed bucket.
+    expect(expenseRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 500, bucket: "NEEDS" }),
+    );
+  });
+
   it("rejects a NaN amount without writing anything", async () => {
     await processor.process({
       user,

--- a/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
@@ -87,6 +87,57 @@ describe("RecurringSetupProcessor", () => {
     ]);
   });
 
+  it("flags a newly-invented category in the confirmation", async () => {
+    categoryRepository.create.mockResolvedValue({
+      id: "c9",
+      name: "Gym",
+      bucket: "WANTS",
+    });
+
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "gym 1200 every month on 25th",
+      parsed: {
+        intent: "RECURRING",
+        recurringKind: "EXPENSE",
+        amount: 1200,
+        dayOfMonth: 25,
+        category: "Gym",
+        bucket: "WANTS",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(categoryRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Gym", bucket: "WANTS" }),
+    );
+    const body = messageService.sendMessage.mock.calls[0][0].body;
+    expect(body).toContain("new category");
+  });
+
+  it("drops an over-long category name instead of writing it", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "something 500 every month on 25th",
+      parsed: {
+        intent: "RECURRING",
+        recurringKind: "EXPENSE",
+        amount: 500,
+        dayOfMonth: 25,
+        category: "x".repeat(51),
+        bucket: "NEEDS",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(categoryRepository.create).not.toHaveBeenCalled();
+    expect(recurringRuleRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 500, categoryId: undefined }),
+    );
+  });
+
   it("creates a recurring income with no prompt when the day is still ahead", async () => {
     await processor.process({
       user,

--- a/src/application/use-cases/processors/RecurringSetupProcessor.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.ts
@@ -8,6 +8,8 @@ import { IRecurringRuleRepository } from "../../../domain/repositories/IRecurrin
 import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import { BUCKET_META, formatMoney, sanitizeMd } from "../budgetMath";
+import { normalizeCategoryName } from "../categoryName";
+import { NEW_CATEGORY_LINE } from "../expenseFlow";
 
 const MAX_AMOUNT = 1_000_000_000;
 
@@ -63,23 +65,24 @@ export class RecurringSetupProcessor implements MessageProcessor {
     }
 
     // EXPENSE: resolve category; a known category's bucket is authoritative.
-    const matched = parsed.category
-      ? await this.categoryRepository.findByNameForUser(
-          user.id,
-          parsed.category,
-        )
+    // An unusable name is dropped rather than written to the DB.
+    const name = normalizeCategoryName(parsed.category);
+    const matched = name
+      ? await this.categoryRepository.findByNameForUser(user.id, name)
       : null;
     const bucket: Bucket = matched?.bucket ?? parsed.bucket ?? "NEEDS";
     let categoryId = matched?.id;
-    let categoryName = matched?.name ?? parsed.category;
-    if (!categoryId && parsed.category) {
+    let categoryName = matched?.name ?? name;
+    let createdCategory = false;
+    if (!categoryId && name) {
       const created = await this.categoryRepository.create({
         userId: user.id,
-        name: parsed.category,
+        name,
         bucket,
       });
       categoryId = created.id;
       categoryName = created.name;
+      createdCategory = true;
     }
 
     const rule = await this.recurringRuleRepository.create({
@@ -93,11 +96,12 @@ export class RecurringSetupProcessor implements MessageProcessor {
     });
 
     const where = categoryName ? ` · ${sanitizeMd(categoryName)}` : "";
+    const newCategory = createdCategory ? `\n${NEW_CATEGORY_LINE}` : "";
     return this.finish(
       platformUserId,
       rule.id,
       day,
-      `🔁 Recurring set: ${formatMoney(amount)} → ${BUCKET_META[bucket].label}${where} on day ${day} — I'll auto-log it each month.`,
+      `🔁 Recurring set: ${formatMoney(amount)} → ${BUCKET_META[bucket].label}${where} on day ${day} — I'll auto-log it each month.${newCategory}`,
     );
   }
 

--- a/src/application/use-cases/processors/ReportProcessor.ts
+++ b/src/application/use-cases/processors/ReportProcessor.ts
@@ -60,6 +60,7 @@ export class ReportProcessor implements MessageProcessor {
       loggedIncome,
     );
     const monthName = new Intl.DateTimeFormat("en-IN", {
+      timeZone: user.timezone,
       month: "long",
     }).format(start);
 

--- a/src/data/ai/FallbackAiParser.ts
+++ b/src/data/ai/FallbackAiParser.ts
@@ -1,6 +1,15 @@
 import { IAiParser, ParseContext } from "../../domain/services/IAiParser";
 import { ParsedBatch } from "../../domain/entities/ParsedData";
 import { withTimeout } from "../../utils/withTimeout";
+import { logger } from "../../utils/logger";
+
+const log = logger.child({ component: "ai" });
+
+// The logger JSON-stringifies its fields, and an Error serializes to `{}` —
+// which would hide the very Zod message that says what the provider got wrong.
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 // A slow/hung provider call must not block the webhook indefinitely.
 const PARSE_TIMEOUT_MS = 12_000;
@@ -22,10 +31,11 @@ export class FallbackAiParser implements IAiParser {
         "OpenAI parser",
       );
     } catch (error) {
-      console.warn(
-        "Primary AI parser (OpenAI) failed. Falling back to secondary (Gemini).",
-        error,
-      );
+      log.warn("primary parser failed, falling back", {
+        provider: "openai",
+        fallback: "gemini",
+        err: describeError(error),
+      });
       try {
         return await withTimeout(
           this.secondary.parseText(text, ctx),
@@ -33,10 +43,10 @@ export class FallbackAiParser implements IAiParser {
           "Gemini parser",
         );
       } catch (secondaryError) {
-        console.error(
-          "Secondary AI parser (Gemini) also failed.",
-          secondaryError,
-        );
+        log.error("secondary parser also failed", {
+          provider: "gemini",
+          err: describeError(secondaryError),
+        });
         // Both failed — return a safe, low-confidence UNKNOWN so the bot can
         // ask the user to try again rather than crashing.
         return {

--- a/src/data/ai/GeminiParser.ts
+++ b/src/data/ai/GeminiParser.ts
@@ -6,6 +6,9 @@ import {
 } from "../../domain/entities/ParsedData";
 import { buildBudgetSystemPrompt } from "./budgetParserPrompt";
 import { env } from "../../config/env";
+import { logger } from "../../utils/logger";
+
+const log = logger.child({ component: "ai", provider: "gemini" });
 
 // Per-transaction structured-output schema enforced by Gemini.
 const transactionSchema: Schema = {
@@ -108,19 +111,13 @@ export class GeminiParser implements IAiParser {
     const today = new Date().toISOString().split("T")[0];
     const promptText = `[Today: ${today}]\n${text}`;
 
-    const historyContents = (ctx.history ?? []).map((h) => ({
-      role: h.role,
-      parts: [{ text: h.content }],
-    }));
-
     const response = await this.client.models.generateContent({
       model: this.modelName,
-      contents: [
-        ...historyContents,
-        { role: "user", parts: [{ text: promptText }] },
-      ],
+      // History lives inside the system instruction as a bounded data block,
+      // not as real model turns — see historyBlock.ts.
+      contents: [{ role: "user", parts: [{ text: promptText }] }],
       config: {
-        systemInstruction: buildBudgetSystemPrompt(ctx.categories),
+        systemInstruction: buildBudgetSystemPrompt(ctx.categories, ctx.history),
         responseMimeType: "application/json",
         responseSchema: budgetSchema,
         temperature: 0.1,
@@ -128,7 +125,7 @@ export class GeminiParser implements IAiParser {
     });
 
     const responseText = response?.text;
-    console.log("GeminiParser Response:", responseText);
+    log.debug("parser response", { responseText });
     if (!responseText) {
       throw new Error("GeminiParser: Empty response from AI.");
     }

--- a/src/data/ai/OpenAIParser.ts
+++ b/src/data/ai/OpenAIParser.ts
@@ -5,7 +5,11 @@ import {
   ParsedBatchSchema,
 } from "../../domain/entities/ParsedData";
 import { buildBudgetSystemPrompt } from "./budgetParserPrompt";
+import { openaiBudgetSchema, stripNulls } from "./openaiBudgetSchema";
 import { env } from "../../config/env";
+import { logger } from "../../utils/logger";
+
+const log = logger.child({ component: "ai", provider: "openai" });
 
 export class OpenAIParser implements IAiParser {
   private client: OpenAI;
@@ -21,29 +25,38 @@ export class OpenAIParser implements IAiParser {
     const today = new Date().toISOString().split("T")[0];
     const promptText = `[Today: ${today}]\n${text}`;
 
-    const historyMessages = (ctx.history ?? []).map((h) => ({
-      role: (h.role === "model" ? "assistant" : h.role) as "user" | "assistant",
-      content: h.content,
-    }));
-
     const completion = await this.client.chat.completions.create({
       model: "gpt-4o-mini",
+      // History lives inside the system prompt as a bounded data block, not as
+      // real assistant turns — see historyBlock.ts.
       messages: [
-        { role: "system", content: buildBudgetSystemPrompt(ctx.categories) },
-        ...historyMessages,
+        {
+          role: "system",
+          content: buildBudgetSystemPrompt(ctx.categories, ctx.history),
+        },
         { role: "user", content: promptText },
       ],
-      response_format: { type: "json_object" },
+      // Strict json_schema, not json_object: json_object only guarantees valid
+      // JSON *syntax*, which let the model drop the `transactions` envelope and
+      // return a bare transaction object.
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "budget_batch",
+          strict: true,
+          schema: openaiBudgetSchema,
+        },
+      },
       temperature: 0.1,
     });
 
     const responseText = completion.choices[0]?.message?.content ?? "";
-    console.log("OpenAIParser Response:", responseText);
+    log.debug("parser response", { responseText });
     if (!responseText) {
       throw new Error("OpenAIParser: Empty response from AI.");
     }
 
     // Validate with Zod — a throw here lets the fallback parser take over.
-    return ParsedBatchSchema.parse(JSON.parse(responseText));
+    return ParsedBatchSchema.parse(stripNulls(JSON.parse(responseText)));
   }
 }

--- a/src/data/ai/budgetParserPrompt.ts
+++ b/src/data/ai/budgetParserPrompt.ts
@@ -1,4 +1,8 @@
-import { CategoryHint } from "../../domain/services/IAiParser";
+import {
+  CategoryHint,
+  ConversationTurn,
+} from "../../domain/services/IAiParser";
+import { renderHistoryBlock } from "./historyBlock";
 
 // Shared system prompt for both Gemini and OpenAI parsers (brief §9: same prompt
 // for both). This is the make-or-break part — comment and iterate freely.
@@ -8,7 +12,10 @@ import { CategoryHint } from "../../domain/services/IAiParser";
 // We extract the amount, map it to one of the user's categories + a 50/30/20
 // bucket, and score our confidence. Low confidence → the bot asks the user to
 // confirm the bucket before saving (handled downstream).
-export function buildBudgetSystemPrompt(categories: CategoryHint[]): string {
+export function buildBudgetSystemPrompt(
+  categories: CategoryHint[],
+  history?: ConversationTurn[],
+): string {
   const categoryList =
     categories.length > 0
       ? categories.map((c) => `- ${c.name} (${c.bucket})`).join("\n")
@@ -18,69 +25,71 @@ export function buildBudgetSystemPrompt(categories: CategoryHint[]): string {
 
 ### USER'S CATEGORIES (map to one of these when it fits):
 ${categoryList}
-
+${renderHistoryBlock(history)}
 ### OUTPUT (strict JSON, no prose):
-Always return an object with a "transactions" array. A single message usually has
-ONE transaction (array of one). Return MULTIPLE only when the user genuinely logs
-several distinct spends/incomes in one message (a "journal dump").
+Always return an object with a "transactions" array — never a bare transaction
+object. A single message usually has ONE transaction (array of one). Return
+MULTIPLE only when the user genuinely logs several distinct spends/incomes in one
+message (a "journal dump"). Send EVERY key on every transaction; use null for the
+ones that don't apply.
 {
   "transactions": [
     {
       "intent": "EXPENSE | INCOME | UNDO | STATUS | RECURRING | QUERY | BOX | UNKNOWN",
-      "amount": <number>,            // POSITIVE magnitude; omit if none. Ignore any minus sign — direction comes from intent, never the number's sign
+      "amount": <number|null>,       // POSITIVE magnitude; null if none. Ignore any minus sign — direction comes from intent, never the number's sign
       "currency": "INR",
-      "category": "<best category>", // prefer one from the list above; else propose a short new one
-      "bucket": "NEEDS | WANTS | SAVINGS",
-      "note": "<short free-text note, e.g. 'lunch', 'auto to office'>",
-      "dayOfMonth": <1-28>,          // RECURRING only: day it repeats
-      "recurringKind": "INCOME | EXPENSE", // RECURRING only
-      "boxName": "<goal/fund name>", // BOX only: the box the money moves in/out of
-      "boxDirection": "IN | OUT",    // BOX only: IN = add money, OUT = withdraw
+      "category": "<best category|null>", // prefer one from the list above; else propose a short new one
+      "bucket": "NEEDS | WANTS | SAVINGS | null",
+      "note": "<short free-text note, e.g. 'lunch', 'auto to office'|null>",
+      "dayOfMonth": <1-28|null>,     // RECURRING only: day it repeats
+      "recurringKind": "INCOME | EXPENSE | null", // RECURRING only
+      "boxName": "<goal/fund name|null>", // BOX only: the box the money moves in/out of
+      "boxDirection": "IN | OUT | null",  // BOX only: IN = add money, OUT = withdraw
       "confidence": <0..1>,          // your confidence in amount + category + bucket
-      "conversational_response": "<only for UNKNOWN/social messages>"
+      "conversational_response": "<only for UNKNOWN/social messages|null>"
     }
   ]
 }
 
-### INTENTS:
+### INTENTS (examples are shorthand — the real reply is always the JSON envelope above):
 1. EXPENSE — user spent/paid money. This is the common case.
    - English: "spent", "paid", "bought", "gave".
    - Manglish/Malayalam: "koduthu", "chilavayi", "vാങ്ങി" (bought).
    - Hinglish/Hindi: "kharch", "diya", "liya" (bought).
-   - "chai 30" → { "intent":"EXPENSE", "amount":30, "category":"Food", "bucket":"WANTS", "note":"chai", "confidence":0.9 }
-   - "auto 80 office" → { "intent":"EXPENSE", "amount":80, "category":"Transport", "bucket":"NEEDS", "note":"auto to office", "confidence":0.9 }
-   - "petrol 500 koduthu" → { "intent":"EXPENSE", "amount":500, "category":"Transport", "bucket":"NEEDS", "note":"petrol", "confidence":0.9 }
-   - "netflix 199" → { "intent":"EXPENSE", "amount":199, "category":"Subscriptions", "bucket":"WANTS", "note":"netflix", "confidence":0.9 }
+   - "chai 30" → EXPENSE, amount 30, category Food, bucket WANTS, note "chai", confidence 0.9
+   - "auto 80 office" → EXPENSE, amount 80, category Transport, bucket NEEDS, note "auto to office", confidence 0.9
+   - "petrol 500 koduthu" → EXPENSE, amount 500, category Transport, bucket NEEDS, note "petrol", confidence 0.9
+   - "netflix 199" → EXPENSE, amount 199, category Subscriptions, bucket WANTS, note "netflix", confidence 0.9
 2. INCOME — user received income / declares salary.
    - "got salary 50000", "salary aayi", "received 2000 from freelance".
-   - { "intent":"INCOME", "amount":50000, "note":"salary", "confidence":0.9 }
+   - "got salary 50000" → INCOME, amount 50000, note "salary", confidence 0.9
 3. STATUS — asking about budget health / how much is left.
    - "status", "how much wants left", "kitna bacha", "ningalkk evide ethi".
-   - { "intent":"STATUS", "confidence":0.9 }
+   - "status" → STATUS, confidence 0.9
 4. UNDO — wants to remove/correct the last entry.
    - "undo", "delete that", "galti se", "thett—maati".
-   - { "intent":"UNDO", "confidence":0.9 }
+   - "undo" → UNDO, confidence 0.9
 5. RECURRING — set up a repeating income/expense that auto-logs each month.
    - Triggers: "every month", "monthly", "recurring", "on the Nth", "auto".
-   - "rent 8000 on 1st every month" → { "intent":"RECURRING", "recurringKind":"EXPENSE", "amount":8000, "dayOfMonth":1, "category":"Rent", "bucket":"NEEDS", "note":"rent", "confidence":0.9 }
-   - "netflix 199 every month on 5th" → { "intent":"RECURRING", "recurringKind":"EXPENSE", "amount":199, "dayOfMonth":5, "category":"Subscriptions", "bucket":"WANTS", "note":"netflix", "confidence":0.9 }
-   - "salary 50000 on 25th monthly" → { "intent":"RECURRING", "recurringKind":"INCOME", "amount":50000, "dayOfMonth":25, "note":"salary", "confidence":0.9 }
+   - "rent 8000 on 1st every month" → RECURRING, recurringKind EXPENSE, amount 8000, dayOfMonth 1, category Rent, bucket NEEDS, note "rent", confidence 0.9
+   - "netflix 199 every month on 5th" → RECURRING, recurringKind EXPENSE, amount 199, dayOfMonth 5, category Subscriptions, bucket WANTS, note "netflix", confidence 0.9
+   - "salary 50000 on 25th monthly" → RECURRING, recurringKind INCOME, amount 50000, dayOfMonth 25, note "salary", confidence 0.9
    - Cap dayOfMonth at 28. Use EXPENSE intent (not RECURRING) for a one-off spend with no "every month".
 6. QUERY — user ASKS a question about their own spending/income/budget that needs their data to answer. This is a question, NOT a statement of spending.
    - Spending questions: "how much did I spend on food last week?", "what's my biggest expense this month?", "evide poyi ee maasathe panam?" ("where did this month's money go?").
    - Comparisons/trends: "am I spending more than last month?", "how's my wants vs last month?".
    - Affordability: "can I afford a 5000 phone?", "should I buy this?".
-   - { "intent":"QUERY", "confidence":0.9 }
+   - "how much did I spend on food last week?" → QUERY, confidence 0.9
    - Boundary: a plain overall health check ("status", "how much is left") is STATUS, handled instantly. A statement that logs money ("chai 30", "paid 500") is EXPENSE — never QUERY. Only route a genuine information-seeking question to QUERY.
 7. BOX — move money into or out of a named savings goal / fund the user keeps separate (a "box"). Trigger ONLY on explicit box phrasing that names the goal/fund: "add/save/put/deposit/set aside <amt> to/for/in <box>" → boxDirection "IN"; "withdraw/take/use <amt> from <box>" → boxDirection "OUT". Put the goal/fund name in "boxName".
-   - "add 5000 to New York trip" → { "intent":"BOX", "amount":5000, "boxName":"New York trip", "boxDirection":"IN", "confidence":0.9 }
-   - "put 2000 in the house maintenance fund" → { "intent":"BOX", "amount":2000, "boxName":"house maintenance", "boxDirection":"IN", "confidence":0.9 }
-   - "brother gave 5000 for the house maintenance fund" → { "intent":"BOX", "amount":5000, "boxName":"house maintenance", "boxDirection":"IN", "note":"from brother", "confidence":0.85 }
-   - "take 1500 from new york" → { "intent":"BOX", "amount":1500, "boxName":"new york", "boxDirection":"OUT", "confidence":0.9 }
+   - "add 5000 to New York trip" → BOX, amount 5000, boxName "New York trip", boxDirection IN, confidence 0.9
+   - "put 2000 in the house maintenance fund" → BOX, amount 2000, boxName "house maintenance", boxDirection IN, confidence 0.9
+   - "brother gave 5000 for the house maintenance fund" → BOX, amount 5000, boxName "house maintenance", boxDirection IN, note "from brother", confidence 0.85
+   - "take 1500 from new york" → BOX, amount 1500, boxName "new york", boxDirection OUT, confidence 0.9
    - Do NOT use BOX for ordinary spending ("spent 500 groceries" is EXPENSE). Only when money is explicitly added to / taken from a NAMED goal or fund.
 8. UNKNOWN — social/non-financial or unintelligible.
    - "hi", "thanks", "what can you do".
-   - { "intent":"UNKNOWN", "confidence":0.9, "conversational_response":"Hi! Text me a spend like \\"chai 30\\" and I'll track it." }
+   - "hi" → UNKNOWN, confidence 0.9, conversational_response "Hi! Text me a spend like \\"chai 30\\" and I'll track it."
 
 ### MULTIPLE TRANSACTIONS:
 - Split into multiple "transactions" entries ONLY for genuine EXPENSE/INCOME dumps. Mixed expense+income is fine.
@@ -88,6 +97,7 @@ several distinct spends/incomes in one message (a "journal dump").
     { "intent":"EXPENSE","amount":30,"category":"Food","bucket":"WANTS","note":"chai","confidence":0.9 },
     { "intent":"EXPENSE","amount":80,"category":"Transport","bucket":"NEEDS","note":"auto","confidence":0.9 },
     { "intent":"INCOME","amount":50000,"note":"salary","confidence":0.9 } ] }
+  (keys are elided above for brevity — in your real reply send every key, null where it doesn't apply)
 - Do NOT over-split one transaction (e.g. "petrol 500" is ONE entry, not "petrol" + "500").
 - STATUS, QUERY, UNDO, RECURRING, BOX, UNKNOWN are always a single-entry array — never split those.
 

--- a/src/data/ai/historyBlock.spec.ts
+++ b/src/data/ai/historyBlock.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { renderHistoryBlock } from "./historyBlock";
+
+describe("renderHistoryBlock", () => {
+  it("returns an empty string for no history", () => {
+    expect(renderHistoryBlock(undefined)).toBe("");
+    expect(renderHistoryBlock([])).toBe("");
+  });
+
+  it("labels turns and keeps oldest-to-newest order", () => {
+    const block = renderHistoryBlock([
+      { role: "user", content: "chai 30" },
+      { role: "model", content: "Wants · Food ₹30" },
+    ]);
+    expect(block).toContain("user: chai 30");
+    expect(block).toContain("bot: Wants · Food ₹30");
+    expect(block.indexOf("user: chai 30")).toBeLessThan(
+      block.indexOf("bot: Wants"),
+    );
+  });
+
+  it("truncates a long turn", () => {
+    const block = renderHistoryBlock([
+      { role: "model", content: "x".repeat(1000) },
+    ]);
+    expect(block).toContain("…");
+    expect(block.length).toBeLessThan(500);
+  });
+
+  it("drops the oldest turns when over the total cap", () => {
+    const history = Array.from({ length: 12 }, (_, i) => ({
+      role: "model" as const,
+      content: `turn-${i} ${"y".repeat(190)}`,
+    }));
+    const block = renderHistoryBlock(history);
+    expect(block).toContain("turn-11");
+    expect(block).not.toContain("turn-0 ");
+  });
+
+  it("collapses whitespace so multi-line replies stay one line each", () => {
+    const block = renderHistoryBlock([
+      { role: "model", content: "line one\n\nline two" },
+    ]);
+    expect(block).toContain("bot: line one line two");
+  });
+});

--- a/src/data/ai/historyBlock.ts
+++ b/src/data/ai/historyBlock.ts
@@ -1,0 +1,41 @@
+import { ConversationTurn } from "../../domain/services/IAiParser";
+
+// Recent turns go into the system prompt as a labelled data block, NOT as real
+// user/assistant messages. Two reasons:
+//   1. The stored "model" turns are rendered Telegram prose ("✅ Wants · Food
+//      ₹220"). Replayed as assistant messages they teach the model to answer in
+//      prose, fighting the JSON schema.
+//   2. As real turns they were unbounded — a long /report or query answer got
+//      replayed in full on every subsequent message.
+// Bounded here so context stays useful for resolving references ("make it 50")
+// without growing the prompt without limit.
+
+const MAX_TURN_CHARS = 200;
+const MAX_BLOCK_CHARS = 1200;
+
+export function renderHistoryBlock(
+  history: ConversationTurn[] | undefined,
+): string {
+  if (!history || history.length === 0) return "";
+
+  const lines = history.map((turn) => {
+    const label = turn.role === "model" ? "bot" : "user";
+    const content = turn.content.replace(/\s+/g, " ").trim();
+    const clipped =
+      content.length > MAX_TURN_CHARS
+        ? `${content.slice(0, MAX_TURN_CHARS)}…`
+        : content;
+    return `${label}: ${clipped}`;
+  });
+
+  // Over budget → drop the oldest. Recent turns are what resolve references.
+  const kept: string[] = [];
+  let used = 0;
+  for (const line of [...lines].reverse()) {
+    if (kept.length > 0 && used + line.length > MAX_BLOCK_CHARS) break;
+    kept.unshift(line);
+    used += line.length + 1;
+  }
+
+  return `\n### RECENT CONVERSATION (context only — never copy this format, always answer with the JSON schema):\n${kept.join("\n")}\n`;
+}

--- a/src/data/ai/openaiBudgetSchema.spec.ts
+++ b/src/data/ai/openaiBudgetSchema.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { openaiBudgetSchema, stripNulls } from "./openaiBudgetSchema";
+import { ParsedBatchSchema } from "../../domain/entities/ParsedData";
+
+// The schema object is untyped JSON Schema; these helpers keep the assertions
+// readable without sprinkling casts through every test.
+const envelope = openaiBudgetSchema as {
+  required: string[];
+  additionalProperties: boolean;
+  properties: { transactions: { items: Record<string, unknown> } };
+};
+const transaction = envelope.properties.transactions.items as {
+  properties: Record<string, { type: unknown; enum?: unknown[] }>;
+  required: string[];
+  additionalProperties: boolean;
+};
+
+describe("openaiBudgetSchema (OpenAI strict mode)", () => {
+  it("requires the transactions envelope", () => {
+    expect(envelope.required).toEqual(["transactions"]);
+    expect(envelope.additionalProperties).toBe(false);
+  });
+
+  it("lists every transaction property in required", () => {
+    const properties = Object.keys(transaction.properties).sort();
+    expect([...transaction.required].sort()).toEqual(properties);
+  });
+
+  it("forbids additional properties on a transaction", () => {
+    expect(transaction.additionalProperties).toBe(false);
+  });
+
+  it("includes null in every nullable enum", () => {
+    for (const [name, prop] of Object.entries(transaction.properties)) {
+      const nullable = Array.isArray(prop.type) && prop.type.includes("null");
+      if (!nullable || !prop.enum) continue;
+      expect(prop.enum, `${name} enum must allow null`).toContain(null);
+    }
+  });
+
+  it("keeps intent and confidence non-nullable", () => {
+    expect(transaction.properties["intent"]?.type).toBe("string");
+    expect(transaction.properties["confidence"]?.type).toBe("number");
+  });
+});
+
+describe("stripNulls", () => {
+  it("turns a fully null-padded wire object into a valid ParsedBatch", () => {
+    // What strict mode actually returns: every key present, nulls for N/A.
+    const wire = {
+      transactions: [
+        {
+          intent: "STATUS",
+          amount: null,
+          currency: null,
+          category: null,
+          bucket: null,
+          note: null,
+          dayOfMonth: null,
+          recurringKind: null,
+          boxName: null,
+          boxDirection: null,
+          confidence: 0.9,
+          conversational_response: null,
+        },
+      ],
+    };
+
+    const result = ParsedBatchSchema.safeParse(stripNulls(wire));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.transactions[0]?.intent).toBe("STATUS");
+      expect(result.data.transactions[0]?.amount).toBeUndefined();
+      expect(result.data.transactions[0]?.bucket).toBeUndefined();
+    }
+  });
+
+  it("leaves non-null values untouched", () => {
+    expect(
+      stripNulls({ intent: "EXPENSE", amount: 30, note: null, zero: 0 }),
+    ).toEqual({ intent: "EXPENSE", amount: 30, zero: 0 });
+  });
+});

--- a/src/data/ai/openaiBudgetSchema.ts
+++ b/src/data/ai/openaiBudgetSchema.ts
@@ -1,0 +1,123 @@
+import { BUCKETS, PARSED_INTENTS } from "../../domain/entities/ParsedData";
+
+// OpenAI structured-output schema — the counterpart to GeminiParser's
+// `budgetSchema`. Field descriptions are kept identical between the two so both
+// providers read the same contract.
+//
+// Strict mode has three hard rules: `additionalProperties: false` on every
+// object, EVERY property listed in `required`, and optionality expressed as
+// nullability (a nullable enum must carry `null` in its own enum list).
+//
+// Hand-written rather than derived with `zodResponseFormat(ParsedBatchSchema)`:
+// that helper throws on any `.optional()` field that isn't also `.nullable()`,
+// and ParsedDataSchema is optional-heavy. `stripNulls` below drops the nulls
+// back off so the wire object lands on those `.optional()` fields.
+
+const transactionSchema: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    intent: {
+      type: "string",
+      enum: [...PARSED_INTENTS],
+      description:
+        'EXPENSE if the user spent money. INCOME if they received money/declared salary. STATUS for a plain overall budget-health check ("status", "how much is left"). UNDO to remove the last entry. RECURRING to set up a repeating monthly income/expense ("every month", "monthly", "on the Nth"). QUERY when the user ASKS a data-backed question about their spending/income/budget ("how much did I spend on food?", "biggest expense?", "can I afford X?", trends/comparisons) — a question, never a statement that logs money. BOX to add money to / withdraw from a NAMED savings goal or fund ("add 5000 to New York", "take 2000 from house fund") — only with explicit box phrasing, never ordinary spending. UNKNOWN for social/non-financial messages.',
+    },
+    amount: {
+      type: ["number", "null"],
+      description: "The numeric amount. 0 if none mentioned.",
+    },
+    currency: {
+      type: ["string", "null"],
+      description: "Currency code, default INR.",
+    },
+    category: {
+      type: ["string", "null"],
+      description: "Best category — prefer one from the user's list.",
+    },
+    bucket: {
+      type: ["string", "null"],
+      enum: [...BUCKETS, null],
+      description: "The 50/30/20 bucket this spend belongs to.",
+    },
+    note: {
+      type: ["string", "null"],
+      description: "Short free-text note (e.g. 'lunch', 'auto to office').",
+    },
+    dayOfMonth: {
+      type: ["number", "null"],
+      description: "RECURRING only: day of month (1-28) it repeats.",
+    },
+    recurringKind: {
+      type: ["string", "null"],
+      enum: ["INCOME", "EXPENSE", null],
+      description:
+        "RECURRING only: whether the repeating item is income or expense.",
+    },
+    boxName: {
+      type: ["string", "null"],
+      description:
+        "BOX only: the savings goal / fund the money moves in/out of.",
+    },
+    boxDirection: {
+      type: ["string", "null"],
+      enum: ["IN", "OUT", null],
+      description: "BOX only: IN to add money to the box, OUT to withdraw.",
+    },
+    confidence: {
+      type: "number",
+      description:
+        "0..1 confidence in amount + category + bucket. Below 0.6 when ambiguous.",
+    },
+    conversational_response: {
+      type: ["string", "null"],
+      description: "Friendly reply, only for UNKNOWN/social messages.",
+    },
+  },
+  // Strict mode: every property, no exceptions. Fields that don't apply are null.
+  required: [
+    "intent",
+    "amount",
+    "currency",
+    "category",
+    "bucket",
+    "note",
+    "dayOfMonth",
+    "recurringKind",
+    "boxName",
+    "boxDirection",
+    "confidence",
+    "conversational_response",
+  ],
+  additionalProperties: false,
+};
+
+// The envelope: one message → one or more transactions.
+export const openaiBudgetSchema: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    transactions: {
+      type: "array",
+      items: transactionSchema,
+      description:
+        "One entry per transaction. A single spend is an array of one; only genuine multi-transaction dumps have more.",
+    },
+  },
+  required: ["transactions"],
+  additionalProperties: false,
+};
+
+// Strict mode forces the model to emit every key, so inapplicable fields arrive
+// as null. ParsedDataSchema models those as `.optional()`, so drop the nulls
+// before validating.
+export function stripNulls(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripNulls);
+  if (typeof value === "object" && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      if (item === null) continue;
+      out[key] = stripNulls(item);
+    }
+    return out;
+  }
+  return value;
+}

--- a/src/domain/entities/ParsedData.spec.ts
+++ b/src/domain/entities/ParsedData.spec.ts
@@ -85,4 +85,14 @@ describe("ParsedBatchSchema", () => {
     const result = ParsedBatchSchema.safeParse({ transactions: [] });
     expect(result.success).toBe(false);
   });
+
+  it("rejects a bare transaction with no envelope", () => {
+    // What a schema-free provider returns when it copies a per-transaction
+    // example instead of the envelope.
+    const result = ParsedBatchSchema.safeParse({
+      intent: "QUERY",
+      confidence: 0.9,
+    });
+    expect(result.success).toBe(false);
+  });
 });


### PR DESCRIPTION
## What

`cycleLabel()` in `cycleReport.ts` and the `/report` month name in `ReportProcessor.ts` built `Intl.DateTimeFormat` without a `timeZone`, so they rendered in the **server's** zone. Cycle boundaries are IST-midnight instants (May 1 IST = `2026-04-30T18:30Z`), and Railway sets no `TZ` — so production containers run UTC and labelled the May cycle **"April"** in live user messages.

The specs hid this by asserting local-time `Date` constructors, which only line up on an IST machine. That is why the `Test` workflow has failed on **every run since ~2026-07-07** — the job dies at `pnpm test:unit`, so the Playwright step below it had never executed.

## Changes

- `cycleReport.ts` — `cycleLabel()` takes `tz` and passes `timeZone` to both formatters; call site forwards the `tz` that `buildCycleReport` already receives.
- `ReportProcessor.ts` — month name formats in `user.timezone`.
- `budgetMath.spec.ts` / `cycleReport.spec.ts` — assert against explicit zoned instants via the existing `zonedStartOfDayUtc` / `zonedParts` helpers instead of local-time `Date` constructors. `periodDayInfo`'s `now` input is now an explicit `+05:30` instant (it also broke east of IST).

No `TZ` pin was added to the workflow — the suite is zone-independent now, so CI keeps catching this class of bug rather than masking it.

## Verification

| Check | Result |
|---|---|
| `vitest run` @ UTC, Asia/Kolkata, America/New_York, Pacific/Kiritimati, Pacific/Honolulu | 177 passed, all five |
| `pnpm lint` | clean |
| `pnpm build` | clean |
| Playwright API suite (never ran on CI before) | 3 passed — pre-flighted locally against a throwaway DB |

## Flagged, not touched

Same TZ-dependence class, pre-existing, no failing test:
- `RecurringSetupProcessor.ts:120-126` (due day) and `RecurringConfirmProcessor.ts:48` (`monthKey`) use local-time getters.
- `budgetMath.ts` `currentMonthRange` is effectively dead in the backend — the live copy is `web/src/lib/budget.ts`.