### PR TITLE
feat(ai): grounded assistant lane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@ NODE_ENV=development
 GEMINI_API_KEY="your_gemini_api_key"
 GEMINI_MODEL="gemini-2.0-flash"
 OPENAI_API_KEY="your_openai_api_key"
+OPENAI_PARSER_MODEL="gpt-4o-mini"
+
+# --- Assistant lane (optional) ---
+# Tool-calling assistant that answers free-form questions ("am I spending more
+# than last month?", "can I afford a 5000 phone?"). Off by default: with the
+# flag off or the key blank, questions fall back to the existing query agent,
+# so an unset key degrades instead of breaking the bot at boot.
+ASSISTANT_ENABLED="false"
+ANTHROPIC_API_KEY=""
+ANTHROPIC_MODEL="claude-sonnet-5"
 
 # --- Voice transcription (optional) ---
 # If blank, voice messages are disabled and users are asked to type instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,21 @@ the agent touch a repository directly.
 `historyTrimmer.ts` drops whole exchanges from the oldest end and never splits a
 `tool_use` from its `tool_result` (an orphan is rejected by the API).
 
+**Product questions are grounded too.** The assistant may discuss the user's money
+*and* Blipko itself — nothing else. Product answers come from
+`src/domain/productFacts.ts` via `get_product_info`, never from model knowledge: an
+invented feature sends the user hunting for something that does not exist.
+
+**Update `productFacts.ts` when you ship or remove a user-facing feature.** It is
+the file the bot speaks from, and it is deliberately *not* generated from
+`README.md` — the README currently still describes the in-chat onboarding wizard
+that `ConnectAccountProcessor` replaced with a dashboard hand-off, and omits
+`/boxes`. Keep it in sync with the code.
+
+`open_dashboard` returns a URL that `AssistantProcessor` renders as a button (a
+pending write takes precedence over it). Every dashboard link — assistant, `/help`,
+the connect hand-off — comes from `env.WEB_APP_URL`, never a hardcoded domain.
+
 ### Frontend: Server Actions pattern
 
 All data fetching/mutations in `web/` use **Next.js Server Actions** in `web/src/lib/actions/` — no custom API routes. Prisma is called directly (`web/src/lib/prisma.ts`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,24 @@ pnpm test
 
 Unit tests use **vitest** with vi mocks. The Playwright suite (`tests/api.spec.ts`) tests HTTP endpoints against a live server and uses `.env.example` for env vars.
 
+`tsconfig.json` **excludes `**/*.spec.ts`**, so `tsc --noEmit` does not typecheck
+tests — a spec can be badly typed and still pass CI's build step. Run
+`pnpm test:unit` too.
+
+AI provider SDKs are mocked at the module boundary (`vi.mock("openai")`,
+`vi.mock("@anthropic-ai/sdk")`) with `vi.hoisted()` for the shared spy — `vi.mock`
+is lifted above the file, so a plain top-level `const` does not exist when the
+factory runs. `src/config/env.ts` parses `process.env` at import and is mocked in
+specs that pull in a provider.
+
+### Environment
+
+`src/config/env.ts` validates everything at boot and **exits** on a bad value.
+`GEMINI_API_KEY`, `OPENAI_API_KEY`, `DATABASE_URL`, `TELEGRAM_*` are required.
+Optional: `OPENAI_PARSER_MODEL`, `SARVAM_API_KEY`, and the assistant lane
+(`ASSISTANT_ENABLED`, `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`) which default to
+off/blank so a missing key degrades instead of breaking boot.
+
 ### Frontend (`web/`)
 
 ```bash
@@ -128,8 +146,10 @@ Both read the **same** `prisma/schema.prisma`. The web app accesses the DB direc
 ```
 domain/          ← Pure interfaces and entity types. No imports from outer layers.
   entities/      ← ParsedData (Zod schema + ParsedIntent / Bucket literals)
+                   PendingAction (Zod payload schemas for proposed writes)
   repositories/  ← I*Repository interfaces
-  services/      ← IAiParser, IFinancialQueryAgent, IFinancialDataTools
+  services/      ← IAiParser, IFinancialQueryAgent, IFinancialDataTools,
+                   IAssistantAgent, IAssistantWriteTools
   categoryTemplate.ts  ← default category taxonomy used by onboarding
 
 application/     ← Use cases. Depends only on domain interfaces.
@@ -140,12 +160,15 @@ application/     ← Use cases. Depends only on domain interfaces.
     PostRecurringCharges.ts     ← Posts due recurring rules as expenses/income
     SendBudgetNudges.ts         ← Dosage-aware budget reminder nudges
     budgetMath.ts, suggestCategoryBudgets.ts  ← budget helpers
+    actCallback.ts, txnCallback.ts  ← callback_data grammars
+    query/                      ← FinancialDataTools (reads), AssistantWriteTools (proposals)
     processors/                 ← One processor per parsed intent / command
 
 data/            ← Concrete implementations. Only layer that imports Prisma.
   repositories/  ← Prisma*Repository classes
-  ai/            ← GeminiParser, OpenAIParser, FallbackAiParser,
-                   OpenAiQueryAgent, SarvamTranscriptionService, budgetParserPrompt
+  ai/            ← GeminiParser, OpenAIParser, FallbackAiParser, budgetParserPrompt,
+                   ClaudeAssistantAgent, OpenAiQueryAgent, assistantTools,
+                   historyTrimmer, groundingCheck, SarvamTranscriptionService
   messaging/     ← TelegramMessageService, TelegramMediaService
 
 presentation/    ← Express routes + controllers (TelegramWebhookController)
@@ -158,48 +181,113 @@ Telegram webhook (POST /api/webhooks/telegram)
   → TelegramWebhookController   (idempotency: ProcessedMessage written here)
   → ProcessIncomingMessageUseCase.execute()
       1. ensureUserExists()        — handles `/start <linkToken>` web↔bot linking
-      2. Load recent conversation history (last 6 turns)
+      2. Load recent conversation history (last 6 rows)
       3. preParseProcessors  — first canHandle() wins, NO AI
-      4. aiParser.parseText(text, { categories, history }) → ParsedData
+      4. aiParser.parseText(text, { categories, history, today, assistantMode })
       5. postParseProcessors — first canHandle() wins
-         (conversation turns saved fire-and-forget after a post-parse handle)
+      → recordExchange() on BOTH paths (fire-and-forget)
 ```
+
+`today` is `YYYY-MM-DD` in the **user's** timezone. Never derive it inside a parser
+from `toISOString()` — a UTC date tells an IST user it is yesterday every evening
+after 18:30.
 
 **Processors** (`src/application/use-cases/processors/`), implement `MessageProcessor`.
 
-Pre-parse (button callbacks, commands, onboarding — run before AI):
+Pre-parse (button callbacks and commands — run before AI):
 
 | Processor | Handles |
 |---|---|
-| `ConfirmBucketProcessor` | inline-keyboard bucket disambiguation replies |
-| `RecurringConfirmProcessor` | recurring income/expense confirm buttons |
-| `OnboardingProcessor` | multi-step wizard: income → category groups → reminder dosage |
-| `SettingsProcessor` | settings (e.g. notification dosage) |
+| `PendingActionProcessor` | `act:<id>:y\|n` — confirms an assistant-proposed write (only when the assistant lane is on) |
+| `TransactionActionProcessor` | `txn:` callbacks — delete/edit/restore |
+| `ConfirmBucketProcessor` | `bkt:` inline-keyboard bucket disambiguation |
+| `RecurringConfirmProcessor` | `rec:` recurring confirm buttons |
+| `ConnectAccountProcessor` | hands unlinked users to the web dashboard |
+| `SettingsProcessor` | `/settings` — income, notification dosage |
 | `HelpProcessor` | `/help` |
 | `StatusProcessor` | `/status` — budget health, safe daily spend |
 | `ReportProcessor` | `/report` — monthly summary |
-| `UndoProcessor` | undo last entry |
+| `BoxCommandProcessor` | `/boxes` |
+| `RecurringCommandProcessor` | `/recurring` |
+| `UndoProcessor` | plain `undo` |
 
 Post-parse (dispatched on `ParsedData.intent`):
 
 | Processor | Intent |
 |---|---|
+| `TransactionReplyProcessor` | reply-to-confirmation → edit/delete |
+| `AssistantProcessor` | `ESCALATE`, `QUERY` — yields when the lane is off |
 | `StatusProcessor` | `STATUS` |
 | `UndoProcessor` | `UNDO` |
+| `BatchProcessor` | ≥2 parsed transactions |
 | `ExpenseProcessor` | `EXPENSE` |
 | `IncomeProcessor` | `INCOME` |
 | `RecurringSetupProcessor` | `RECURRING` |
-| `QueryProcessor` | `QUERY` (delegates to `OpenAiQueryAgent`) |
+| `BoxProcessor` | `BOX` |
+| `QueryProcessor` | `QUERY` (legacy path, `OpenAiQueryAgent`) |
 | `FallbackProcessor` | everything else (`canHandle` always true) |
 
 ### AI parsing
 
-`GeminiParser` uses Gemini structured output (`responseMimeType: "application/json"` + `responseSchema`). `OpenAIParser` mirrors the interface. `FallbackAiParser` chains them: Gemini → OpenAI → hard-coded fallback. Parser output is validated against `ParsedDataSchema` (Zod) in `domain/entities/ParsedData.ts`; the user's existing categories are passed in as hints.
+`FallbackAiParser` chains **OpenAI → Gemini → hard-coded `UNKNOWN` stub**, one
+attempt each, 12s timeout per provider. `GeminiParser` and `OpenAIParser` both use
+structured output; results are validated against `ParsedBatchSchema` (Zod) in
+`domain/entities/ParsedData.ts`. A Zod throw cascades to the next provider.
 
-**Intents:** `EXPENSE`, `INCOME`, `UNDO`, `STATUS`, `RECURRING`, `QUERY`, `UNKNOWN`.
+**Intents:** `EXPENSE`, `INCOME`, `UNDO`, `STATUS`, `RECURRING`, `QUERY`, `BOX`, `ESCALATE`, `UNKNOWN`.
 **Buckets:** `NEEDS`, `WANTS`, `SAVINGS` (50/30/20-style budgeting).
 
-`QUERY` is handled by a separate agent (`OpenAiQueryAgent` / `IFinancialQueryAgent`) with data-access tools, not by the structured parser.
+The parser has **two prompt modes**, selected by `ctx.assistantMode`
+(`budgetParserPrompt.ts`):
+
+- **off** — today's full 8-intent taxonomy, routed to the deterministic processors.
+- **on** — log-or-escalate only. It emits `EXPENSE`/`INCOME` for a clear spend and
+  `ESCALATE` for everything else. Classifying eight ways is where mis-parses came
+  from; when the lane is on, that job no longer exists.
+
+### The assistant lane
+
+Gated on `ASSISTANT_ENABLED` **and** a non-empty `ANTHROPIC_API_KEY`. Off → the
+parser stays in 8-intent mode, `AssistantProcessor` yields, and `QueryProcessor`
+answers as before. There is no half-on state.
+
+`ClaudeAssistantAgent` is a tool-calling loop (max 5 rounds) with prompt caching
+on the system block. `assistantTools.ts` is the single provider-neutral tool
+catalog — both agents render from it, so descriptions and dispatch cannot drift.
+
+**The grounding contract.** Every tool obeys all six; this is what prevents
+hallucinated numbers, not the prompt:
+
+1. **Money is pre-formatted.** `formatMoney()` server-side. The model quotes
+   strings; it never sees a rupee number it could do arithmetic on.
+2. **Verdicts are precomputed.** `check_affordability` returns `YES|TIGHT|NO`,
+   `compare_cycles` returns `direction`/`deltaPct`, `get_period_status` returns a
+   bucket `status` enum. If the model would need to calculate, there is a tool.
+3. **Schemas carry the user's real data.** `category` params are an `enum` built
+   per request from the user's own leaf categories, so an invented category cannot
+   even be asked about.
+4. **Tools never throw.** Failures return `{ ok: false, error, ...options }` so the
+   model self-corrects inside the 5-round budget. A throw would kill the turn with
+   no model-visible recovery.
+5. **Absence ≠ zero.** Empty results carry an explicit `note`. "Nothing logged" is
+   never reported as "spent ₹0".
+6. **One timezone, inclusive end dates.** Tool dates are `YYYY-MM-DD` in the user's
+   timezone and `to` is **inclusive** — exclusive end dates are an off-by-one trap
+   for an LLM.
+
+`groundingCheck.ts` then extracts every `₹` figure from the answer and asserts it
+appears in some tool result. Misses are logged as `grounding_miss` — hallucination
+is measured, not assumed away.
+
+**Writes are proposals.** The agent's `propose_*` tools mutate nothing: each
+resolves its references against real rows, then records a `PendingAction` and
+returns a summary. `AssistantProcessor` renders `act:<id>:y|n` buttons;
+`PendingActionProcessor` re-checks ownership, expiry (30 min), single-use and Zod
+payload shape, then performs the write. Add new write tools this way — never let
+the agent touch a repository directly.
+
+`historyTrimmer.ts` drops whole exchanges from the oldest end and never splits a
+`tool_use` from its `tool_result` (an orphan is rejected by the API).
 
 ### Frontend: Server Actions pattern
 
@@ -216,7 +304,14 @@ Every incoming Telegram update ID is written to `ProcessedMessage` (in `Telegram
 - Core financial models: `Expense`, `Income`, `BudgetConfig` (per-bucket + per-category budgets), `Category` (user taxonomy), `RecurringRule`.
 - `BudgetNudge` + `NotificationDosage` enum (`OFF | GENTLE | AGGRESSIVE | RELENTLESS`) — dosage-aware reminders; sent by `SendBudgetNudges`.
 - `Bucket` enum: `NEEDS | WANTS | SAVINGS`. `ExpenseSource`, `NudgeKind`, `RecurringKind` enums.
-- `ConversationMessage` — rolling chat history fed back to the AI parser.
+- `ConversationMessage` — rolling chat history fed back to the AI. Ordered by
+  `seq` (a Postgres sequence), **never `createdAt`**: two turns written in the same
+  millisecond tie, and the transcript comes back scrambled. Written via
+  `appendExchange()` as one `createMany` so a user turn can never be read back
+  after its own reply. Also carries `intent`, `entityRefs`, `toolCalls`, and
+  per-turn `provider`/`model`/`latencyMs`/`inputTokens`/`outputTokens`/`costUsd`.
+- `PendingAction` — a write the assistant proposed but has not performed
+  (`kind`, Zod-validated `payload`, `summary`, `expiresAt`, `consumedAt`).
 - `ProcessedMessage` — idempotency ledger. `ParseLog` — raw parser audit.
 - `TelegramLinkToken` — short-lived token linking a web account to a Telegram chat (`/start <token>`).
 - `Account` / `Session` / `VerificationToken` are **NextAuth** models (web auth), not financial accounts.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 ![Blipko Banner](public/Banner.png)
 
+
 ### Know where your salary goes. Just chat.
 
 **Blipko is a conversational personal-budget tracker on Telegram.** Log what you spend in plain language —
 by text or voice, in English, Hindi, Hinglish, Malayalam, or Manglish — and Blipko sorts it into a 50/30/20
 budget, tells you what's left, and answers questions about your money. No app to install. No forms. Just a chat.
+
+
+in telegram now: [![Telegram](https://img.shields.io/badge/Telegram-Bot-229ED9?style=flat-square&logo=telegram&logoColor=white)](https://t.me/Blipko_bot)
+
+![Telegram Profile](web/public/blipko.telegram.profile.png)
 
 [![Live](https://img.shields.io/badge/live-blipko.lol-a3b18a?style=flat-square)](https://blipko.lol)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
@@ -146,8 +152,11 @@ income tabs, CSV export), category & per-category-limit editing, recurring manag
 
 <div align="center">
 
-![Dashboard](public/screenshot01.png)
-![Analytics](public/screenshot02.png)
+![Category](web/public/blipko.category.landing.main.png)
+![Analytics](web/public/blipko.dashboard.category.overview.landing.main.webp)
+![Overview](web/public/blipko.dashboard.overview.landing.main.webp)
+![Telegram](web/public/blipko.telegram.landing.main.png)
+
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Blipko: 📊 This cycle — Day 15 of 30
 You:   can I afford a 4000 pair of shoes?
 Blipko: You've got ₹5,800 left in Wants with 15 days to go, so ₹4,000 fits —
         but it leaves you ~₹120/day. Doable if you go easy on eating out.
+
+You:   set aside 2000 for the Goa trip
+Blipko: Ready to move ₹2,000 into your Goa trip box.
+
+        ➡️ Add ₹2,000 to Goa trip
+        [ ✅ Confirm ]  [ ✖️ Cancel ]
 ```
 
 ---
@@ -68,19 +74,36 @@ effective income is `max(expected salary, income logged this cycle)` so salaried
 both work.
 
 ### 🧭 Guided onboarding
-A short wizard, not a form: enter your take-home income → tap the spending groups you actually have (common
-ones pre-ticked) → Blipko auto-creates their subcategories with **income-based budget suggestions** → choose
-how hard it should nudge you. Three taps and you're tracking.
+A short wizard on the dashboard, not a form: enter your take-home income → tap the spending groups you
+actually have (common ones pre-ticked) → Blipko auto-creates their subcategories with **income-based budget
+suggestions** → choose how hard it should nudge you. Then tap **Connect Telegram** to link your chat, and
+you're tracking.
 
 ### 🗂️ Category taxonomy with per-category limits
 Seven parent groups (Essentials, Food & Drinks, Transportation, Entertainment & Leisure, Health & Wellness,
 Miscellaneous, Savings) break down into leaf categories (Rent, Groceries, Eating Out, Fuel…). Each leaf can
 carry a **monthly limit**, editable on the web or via chat.
 
+### 🏦 Boxes — named savings goals
+Set money aside in named funds — a trip, an emergency fund — and track progress toward a target. `add 5000 to
+Goa trip`, or manage them on the dashboard. Savings stop being whatever's left over and become a thing with a
+name and a finish line.
+
 ### 🤖 Ask anything
 Beyond logging, Blipko answers free-form questions grounded in *your* real data via a tool-calling agent:
 
 > "how much did I spend on food this month?" · "what's my biggest expense?" · "am I spending more than last month?"
+> · "can I afford a 5000 phone?" · "what can you do?"
+
+**The numbers aren't the model's.** Every amount is formatted and every comparison decided in code before the
+AI ever sees it — affordability returns a yes/tight/no verdict, cycle comparisons return the delta and
+direction, budget health returns a status. The AI picks which figures to look up; it doesn't do the arithmetic.
+Empty results say *nothing was logged*, never "you spent ₹0", and anything the assistant states that didn't
+come from a lookup is flagged in the logs.
+
+It can also make changes — edit or delete a spend, set up a recurring rule, move money into a box — but it
+only ever *proposes*. You get a one-line summary built from the actual rows it would touch, plus Confirm and
+Cancel buttons. Nothing is written until you tap.
 
 ### 🔔 Reminders you control
 Proactive nudges before you blow a bucket — but **opt-in by intensity**, default off:
@@ -107,14 +130,15 @@ income tabs, CSV export), category & per-category-limit editing, recurring manag
 
 | Command | What it does |
 |---|---|
-| `/start` | Set up (or redo) your budget — runs the onboarding wizard |
+| `/start` | Link this chat to your Blipko account |
 | `/status` | Budget health this cycle + safe daily spend |
 | `/report` | This cycle's summary and your biggest leaks |
 | `/recurring` | Manage repeating income/expenses |
-| `/settings` | Change your reminder intensity |
+| `/boxes` | Savings boxes and progress toward their targets |
+| `/settings` | Change your reminder intensity and income |
 | `/help` | Full guide to everything the bot can do |
 | `undo` | Remove your last entry |
-| *(just ask)* | "how much on groceries?", "can I afford X?", "biggest expense?" |
+| *(just ask)* | "how much on groceries?", "can I afford X?", "biggest expense?", "what can you do?" |
 
 ---
 
@@ -136,7 +160,7 @@ income tabs, CSV export), category & per-category-limit editing, recurring manag
 | Backend | Node.js + Express, TypeScript (strict, Clean Architecture) |
 | Database | PostgreSQL via Prisma (hosted on Railway) |
 | AI parsing | OpenAI `gpt-4o-mini` (primary) → Gemini 2.0 Flash (fallback), structured output |
-| Q&A agent | OpenAI function-calling over read-only data tools |
+| Assistant | Claude Sonnet 5 tool-calling loop over pre-computed data tools, opt-in via env; OpenAI function-calling otherwise |
 | Voice | Sarvam AI transcription |
 | Messaging | Telegram Bot API (webhook) |
 | Scheduler | node-cron (recurring auto-post, nudges, pruning) |
@@ -167,14 +191,20 @@ blipko/                  ← Backend: Express + Prisma (TypeScript, CommonJS)
 Telegram → TelegramWebhookController → ProcessIncomingMessageUseCase
   1. ensureUserExists (+ link Telegram ↔ web account)
   2. load recent conversation history
-  3. pre-parse processors (no AI): onboarding wizard, button callbacks, /status, /report,
-     /settings, /help, undo
+  3. pre-parse processors (no AI): button callbacks, /status, /report, /boxes,
+     /recurring, /settings, /help, undo
   4. AI parse → ParsedData { intent, amount, category, bucket, confidence, … }
-  5. intent processor handles it: Expense · Income · Recurring · Query (ask-anything) · Fallback
+  5. a clear spend or income is logged on the fast path; anything else —
+     a question, a correction, ambiguity — escalates to the assistant
 ```
 
-Low-confidence parses ask you to confirm the bucket with inline buttons; every Telegram message ID is recorded
-so duplicate deliveries are dropped.
+Two lanes, on purpose. Logging `chai 30` should cost one cheap call and land in about a second, so it never
+waits on a reasoning model. Everything conversational goes to the assistant, which has the user's real data in
+front of it. With the assistant lane switched off, the deterministic intent processors handle those cases as
+before.
+
+Low-confidence parses ask you to confirm the bucket with inline buttons; assistant-proposed changes ask you to
+confirm the change itself. Every Telegram message ID is recorded so duplicate deliveries are dropped.
 
 ---
 
@@ -184,7 +214,8 @@ so duplicate deliveries are dropped.
 - Node.js 20+ and **pnpm**
 - A PostgreSQL database URL
 - Telegram bot token (from [@BotFather](https://t.me/BotFather))
-- OpenAI and Gemini API keys (Sarvam key for voice notes, optional)
+- OpenAI and Gemini API keys (both required at boot)
+- Optional: Sarvam key for voice notes, Anthropic key for the assistant lane
 
 ### 1 · Install
 ```bash
@@ -196,9 +227,16 @@ pnpm install
 ### 2 · Configure
 ```bash
 cp .env.example .env
-# DATABASE_URL, OPENAI_API_KEY, GEMINI_API_KEY,
-# TELEGRAM_BOT_TOKEN, TELEGRAM_WEBHOOK_SECRET, SARVAM_API_KEY, PORT
+# Required: DATABASE_URL, OPENAI_API_KEY, GEMINI_API_KEY,
+#           TELEGRAM_BOT_TOKEN, TELEGRAM_WEBHOOK_SECRET
+# Optional: SARVAM_API_KEY (voice), WEB_APP_URL, PORT, CRON_SECRET
 ```
+
+The bot exits at boot if a required key is blank — better than discovering it on the first message.
+
+To turn on the **assistant lane** (Claude answers questions and can propose changes), set
+`ASSISTANT_ENABLED=true` and `ANTHROPIC_API_KEY`. Leave either unset and questions fall back to the OpenAI
+agent, so a missing key degrades rather than breaking anything.
 
 ### 3 · Database
 ```bash

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.116.0",
     "@google/genai": "^1.30.0",
     "@prisma/client": "^5.19.1",
     "dotenv": "^17.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.116.0
+        version: 0.116.0(zod@4.1.13)
       '@google/genai':
         specifier: ^1.30.0
         version: 1.30.0
@@ -338,6 +341,15 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@anthropic-ai/sdk@0.116.0':
+    resolution: {integrity: sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@auth/core@0.41.0':
     resolution: {integrity: sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==}
     peerDependencies:
@@ -425,6 +437,10 @@ packages:
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -3747,6 +3763,10 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -4745,6 +4765,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -4902,6 +4925,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -5292,6 +5318,13 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@anthropic-ai/sdk@0.116.0(zod@4.1.13)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.1.13
+
   '@auth/core@0.41.0':
     dependencies:
       '@panva/hkdf': 1.2.1
@@ -5393,6 +5426,8 @@ snapshots:
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -8907,6 +8942,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -10187,6 +10227,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -10356,6 +10401,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:

--- a/prisma/migrations/20260808214033_conversation_turn_metadata/migration.sql
+++ b/prisma/migrations/20260808214033_conversation_turn_metadata/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "ConversationMessage" ADD COLUMN     "costUsd" DECIMAL(10,6),
+ADD COLUMN     "entityRefs" JSONB,
+ADD COLUMN     "inputTokens" INTEGER,
+ADD COLUMN     "intent" TEXT,
+ADD COLUMN     "latencyMs" INTEGER,
+ADD COLUMN     "model" TEXT,
+ADD COLUMN     "outputTokens" INTEGER,
+ADD COLUMN     "provider" TEXT,
+ADD COLUMN     "toolCalls" JSONB;

--- a/prisma/migrations/20260808214304_conversation_message_seq/migration.sql
+++ b/prisma/migrations/20260808214304_conversation_message_seq/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+DROP INDEX "ConversationMessage_userId_createdAt_idx";
+
+-- AlterTable
+ALTER TABLE "ConversationMessage" ADD COLUMN     "seq" SERIAL NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "ConversationMessage_userId_seq_idx" ON "ConversationMessage"("userId", "seq");

--- a/prisma/migrations/20260809021059_pending_action/migration.sql
+++ b/prisma/migrations/20260809021059_pending_action/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "PendingAction" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "summary" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PendingAction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PendingAction_userId_createdAt_idx" ON "PendingAction"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "PendingAction" ADD CONSTRAINT "PendingAction_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -112,6 +112,7 @@ model User {
   boxEntries     BoxEntry[]
 
   conversationMessages ConversationMessage[]
+  pendingActions       PendingAction[]
   telegramLinkToken    TelegramLinkToken?
 }
 
@@ -383,13 +384,57 @@ model ProcessedMessage {
   processedAt DateTime @default(now())
 }
 
+// Rolling chat history replayed to the AI. Beyond the rendered text, a turn
+// carries what the bot actually DID (intent, the rows it touched, the tools it
+// called) so a follow-up like "make it 50" resolves to a real transaction
+// instead of being guessed from emoji-laden prose. The AI-metadata columns are
+// nullable: deterministic slash-command turns fill none of them.
 model ConversationMessage {
-  id        String   @id @default(cuid())
-  userId    String
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  role      String
-  content   String
+  id String @id @default(cuid())
+  // Append order. createdAt is not safe to order by: two turns written in the
+  // same millisecond tie, and across instances clocks drift — either way the
+  // transcript replayed to the model comes back scrambled.
+  seq     Int    @default(autoincrement())
+  userId  String
+  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  role    String
+  content String
+
+  // What the turn resolved to, and which rows it touched.
+  intent     String?
+  entityRefs Json?
+
+  // Per-turn AI trace: [{ name, args, result }]. Null for non-AI turns.
+  toolCalls Json?
+
+  // Observability — which model answered, how slow, how much it cost.
+  provider     String?
+  model        String?
+  latencyMs    Int?
+  inputTokens  Int?
+  outputTokens Int?
+  costUsd      Decimal? @db.Decimal(10, 6)
+
   createdAt DateTime @default(now())
+
+  @@index([userId, seq])
+}
+
+// A write the assistant has PROPOSED but not performed. The agent's tools only
+// ever create one of these; the user confirms with an inline button and a
+// deterministic processor does the actual write. Keeps a misread instruction
+// from silently mutating the ledger, the way a hallucinated income already
+// inflates every bucket budget today.
+model PendingAction {
+  id         String    @id @default(cuid())
+  userId     String
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  kind       String // PendingActionKind — validated with Zod on read
+  payload    Json
+  summary    String // what the user is shown before confirming
+  expiresAt  DateTime
+  consumedAt DateTime?
+  createdAt  DateTime  @default(now())
 
   @@index([userId, createdAt])
 }

--- a/src/application/use-cases/ProcessIncomingMessage.spec.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.spec.ts
@@ -96,14 +96,14 @@ describe("ProcessIncomingMessage (budget flow)", () => {
     };
     conversationRepository = {
       getRecent: vi.fn().mockResolvedValue([]),
-      append: vi.fn().mockResolvedValue(undefined),
+      appendExchange: vi.fn().mockResolvedValue(undefined),
     };
     aiParser = { parseText: vi.fn() };
     messageService = {
       sendMessage: vi.fn().mockResolvedValue("msg-id-123"),
       sendInteractiveMessage: vi.fn().mockResolvedValue("msg-id-456"),
       editInteractiveMessage: vi.fn().mockResolvedValue(undefined),
-      sendTypingIndicator: vi.fn(),
+      sendTypingIndicator: vi.fn().mockResolvedValue(undefined),
     };
     queryAgent = { answer: vi.fn().mockResolvedValue("agent answer") };
 
@@ -123,6 +123,111 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       async (fn: any) => fn({}),
       "https://blipko.lol",
     );
+  });
+
+  describe("assistant lane", () => {
+    function withAssistant(agent: any) {
+      return new ProcessIncomingMessageUseCase(
+        aiParser,
+        userRepository,
+        expenseRepository,
+        categoryRepository,
+        budgetConfigRepository,
+        parseLogRepository,
+        incomeRepository,
+        recurringRuleRepository,
+        boxRepository,
+        conversationRepository,
+        messageService,
+        queryAgent,
+        async (fn: any) => fn({}),
+        "https://blipko.lol",
+        agent,
+      );
+    }
+
+    const assistantAnswer = {
+      text: "You spent ₹1,200 on Food.",
+      toolCalls: [],
+      model: "claude-sonnet-5",
+      provider: "anthropic",
+      latencyMs: 10,
+      inputTokens: 1,
+      outputTokens: 1,
+      ungroundedAmounts: [],
+    };
+
+    it("puts the parser in log-or-escalate mode only when the lane is on", async () => {
+      aiParser.parseText.mockResolvedValue({
+        transactions: [{ intent: "ESCALATE", confidence: 0.9 }],
+      });
+
+      await withAssistant({
+        answer: vi.fn().mockResolvedValue(assistantAnswer),
+      }).execute({ platformUserId: "123", textMessage: "how much on food?" });
+      expect(aiParser.parseText.mock.calls[0]![1].assistantMode).toBe(true);
+
+      aiParser.parseText.mockClear();
+      aiParser.parseText.mockResolvedValue({
+        transactions: [{ intent: "UNKNOWN", confidence: 0.9 }],
+      });
+      await useCase.execute({ platformUserId: "123", textMessage: "hi" });
+      expect(aiParser.parseText.mock.calls[0]![1].assistantMode).toBe(false);
+    });
+
+    it("routes ESCALATE to the assistant", async () => {
+      const agent = { answer: vi.fn().mockResolvedValue(assistantAnswer) };
+      aiParser.parseText.mockResolvedValue({
+        transactions: [{ intent: "ESCALATE", confidence: 0.9 }],
+      });
+
+      const out = await withAssistant(agent).execute({
+        platformUserId: "123",
+        textMessage: "am I spending more than last month?",
+      });
+
+      expect(agent.answer).toHaveBeenCalled();
+      expect(out.response).toBe(assistantAnswer.text);
+    });
+
+    it("records the assistant's model and latency on the turn", async () => {
+      aiParser.parseText.mockResolvedValue({
+        transactions: [{ intent: "ESCALATE", confidence: 0.9 }],
+      });
+      await withAssistant({
+        answer: vi.fn().mockResolvedValue(assistantAnswer),
+      }).execute({ platformUserId: "123", textMessage: "q" });
+
+      expect(
+        conversationRepository.appendExchange.mock.calls[0]![3],
+      ).toMatchObject({
+        provider: "anthropic",
+        model: "claude-sonnet-5",
+      });
+    });
+
+    it("still logs a clear spend on the fast path, without the assistant", async () => {
+      const agent = { answer: vi.fn() };
+      aiParser.parseText.mockResolvedValue({
+        transactions: [
+          {
+            intent: "EXPENSE",
+            amount: 220,
+            category: "Food",
+            bucket: "WANTS",
+            confidence: 0.9,
+          },
+        ],
+      });
+
+      await withAssistant(agent).execute({
+        platformUserId: "123",
+        textMessage: "lunch 220",
+      });
+
+      expect(agent.answer).not.toHaveBeenCalled();
+      expect(expenseRepository.create).toHaveBeenCalled();
+    });
   });
 
   it("hands a brand-new unlinked user off to the dashboard (no row created)", async () => {
@@ -239,6 +344,41 @@ describe("ProcessIncomingMessage (budget flow)", () => {
     expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
       "This cycle — Day",
     );
+  });
+
+  it("records pre-parse turns so slash commands aren't missing from history", async () => {
+    await useCase.execute({ platformUserId: "123", textMessage: "status" });
+
+    // Previously only post-parse turns were saved, so the model read a
+    // transcript with every /status and button press silently missing.
+    expect(conversationRepository.appendExchange).toHaveBeenCalledTimes(1);
+    const [userId, userText, modelText] =
+      conversationRepository.appendExchange.mock.calls[0];
+    expect(userId).toBe("u1");
+    expect(userText).toBe("status");
+    // A marker, not the rendered reply: the full /status text is a money dump
+    // (income + per-bucket totals) that would otherwise be replayed into the
+    // parser's prompt — and to its provider — on every later message.
+    expect(modelText).toBe("[showed budget status]");
+    expect(modelText).not.toContain("Income:");
+  });
+
+  it("tags the recorded turn with the intent it resolved to", async () => {
+    aiParser.parseText.mockResolvedValue({
+      transactions: [
+        {
+          intent: "EXPENSE",
+          amount: 220,
+          category: "Food",
+          bucket: "WANTS",
+          confidence: 0.9,
+        },
+      ],
+    });
+    await useCase.execute({ platformUserId: "123", textMessage: "lunch 220" });
+
+    const meta = conversationRepository.appendExchange.mock.calls[0][3];
+    expect(meta).toMatchObject({ intent: "EXPENSE" });
   });
 
   it("applies the link token even when a Telegram user already exists (merge)", async () => {

--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -20,6 +20,7 @@ import { ParsedData, ParsedBucket } from "../../domain/entities/ParsedData";
 import {
   MessageProcessor,
   ProcessContext,
+  ProcessOutput,
 } from "./processors/MessageProcessor";
 import { ConfirmBucketProcessor } from "./processors/ConfirmBucketProcessor";
 import { RecurringConfirmProcessor } from "./processors/RecurringConfirmProcessor";
@@ -37,7 +38,14 @@ import { ExpenseProcessor } from "./processors/ExpenseProcessor";
 import { IncomeProcessor } from "./processors/IncomeProcessor";
 import { RecurringSetupProcessor } from "./processors/RecurringSetupProcessor";
 import { QueryProcessor } from "./processors/QueryProcessor";
+import { AssistantProcessor } from "./processors/AssistantProcessor";
+import { PendingActionProcessor } from "./processors/PendingActionProcessor";
+import { IAssistantAgent } from "../../domain/services/IAssistantAgent";
+import { IPendingActionRepository } from "../../domain/repositories/IPendingActionRepository";
 import { FallbackProcessor } from "./processors/FallbackProcessor";
+import { zonedYmd } from "../../utils/time";
+import { logger } from "../../utils/logger";
+import { describeError } from "../../utils/describeError";
 import { BoxProcessor } from "./processors/BoxProcessor";
 import { BoxCommandProcessor } from "./processors/BoxCommandProcessor";
 import { RecurringCommandProcessor } from "./processors/RecurringCommandProcessor";
@@ -85,8 +93,25 @@ export class ProcessIncomingMessageUseCase {
     private readonly queryAgent: IFinancialQueryAgent,
     private readonly runTransaction: RunInTransaction,
     private readonly webAppUrl: string,
+    // Null when the assistant lane is off — QueryProcessor then answers as before.
+    private readonly assistantAgent: IAssistantAgent | null = null,
+    private readonly pendingActionRepository: IPendingActionRepository | null = null,
   ) {
     this.preParseProcessors = [
+      // Confirmations for assistant-proposed writes. First, and before any AI:
+      // a button press is an answer to a question already asked.
+      ...(pendingActionRepository
+        ? [
+            new PendingActionProcessor(
+              pendingActionRepository,
+              expenseRepository,
+              categoryRepository,
+              boxRepository,
+              recurringRuleRepository,
+              messageService,
+            ),
+          ]
+        : []),
       new TransactionActionProcessor(
         expenseRepository,
         incomeRepository,
@@ -187,6 +212,9 @@ export class ProcessIncomingMessageUseCase {
         messageService,
       ),
       new BoxProcessor(boxRepository, messageService),
+      // Assistant lane first; it yields when unconfigured so QueryProcessor
+      // stays the answer path until the lane is switched on.
+      new AssistantProcessor(this.assistantAgent, messageService),
       new QueryProcessor(queryAgent, messageService),
       new FallbackProcessor(messageService),
     ];
@@ -258,7 +286,12 @@ export class ProcessIncomingMessageUseCase {
     // Pre-AI processors (button callbacks, onboarding).
     for (const processor of this.preParseProcessors) {
       if (processor.canHandle(context)) {
-        return processor.process(context);
+        const output = await processor.process(context);
+        // Record these too. Skipping them left /status, /report and every
+        // button press missing from the transcript the model reads back, so a
+        // follow-up referred to a conversation it could not see.
+        this.recordExchange(user.id, payload.textMessage, output);
+        return output;
       }
     }
 
@@ -267,6 +300,8 @@ export class ProcessIncomingMessageUseCase {
     const batch = await this.aiParser.parseText(payload.textMessage, {
       categories,
       history,
+      today: zonedYmd(new Date(), user.timezone),
+      assistantMode: this.assistantAgent !== null,
     });
 
     if (batch.transactions.length >= 2) {
@@ -283,13 +318,7 @@ export class ProcessIncomingMessageUseCase {
     for (const processor of this.postParseProcessors) {
       if (processor.canHandle(context)) {
         const output = await processor.process(context);
-        // Save conversation turns (fire-and-forget — don't block the reply).
-        this.conversationRepository
-          .append(user.id, "user", payload.textMessage)
-          .catch(console.error);
-        this.conversationRepository
-          .append(user.id, "model", output.response)
-          .catch(console.error);
+        this.recordExchange(user.id, payload.textMessage, output);
         return output;
       }
     }
@@ -298,6 +327,28 @@ export class ProcessIncomingMessageUseCase {
     throw new Error(
       `No processor handled intent: ${context.parsed?.intent ?? "BATCH"}`,
     );
+  }
+
+  // Fire-and-forget: history is context, not correctness, so a failed write
+  // must never cost the user their reply. Ordering within the pair is handled
+  // by the repository, not by the order these two lines happen to resolve in.
+  private recordExchange(
+    userId: string,
+    userText: string,
+    output: ProcessOutput,
+  ): void {
+    this.conversationRepository
+      .appendExchange(userId, userText, output.historyText ?? output.response, {
+        intent: output.parsed?.intent,
+        ...output.turnMeta,
+      })
+      .catch((err) =>
+        logger.error("Failed to record conversation turn", {
+          component: "conversation",
+          userId,
+          err: describeError(err),
+        }),
+      );
   }
 
   private async loadCategoryHints(userId: string): Promise<CategoryHint[]> {

--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -139,7 +139,7 @@ export class ProcessIncomingMessageUseCase {
       ),
       new ConnectAccountProcessor(messageService, webAppUrl),
       new SettingsProcessor(userRepository, messageService),
-      new HelpProcessor(messageService),
+      new HelpProcessor(messageService, webAppUrl),
       new StatusProcessor(
         expenseRepository,
         budgetConfigRepository,
@@ -214,8 +214,8 @@ export class ProcessIncomingMessageUseCase {
       new BoxProcessor(boxRepository, messageService),
       // Assistant lane first; it yields when unconfigured so QueryProcessor
       // stays the answer path until the lane is switched on.
-      new AssistantProcessor(this.assistantAgent, messageService),
-      new QueryProcessor(queryAgent, messageService),
+      new AssistantProcessor(this.assistantAgent, messageService, webAppUrl),
+      new QueryProcessor(queryAgent, messageService, webAppUrl),
       new FallbackProcessor(messageService),
     ];
   }

--- a/src/application/use-cases/actCallback.ts
+++ b/src/application/use-cases/actCallback.ts
@@ -1,0 +1,24 @@
+// callback_data grammar for assistant-proposed actions (namespace "act:").
+//
+//   act:<pendingActionId>:<y|n>
+//
+// Kept dependency-free so the processor and the button builder can share it
+// without a cycle, matching the txn: grammar next door. cuids never contain ":".
+
+export interface ActCallback {
+  pendingId: string;
+  yes: boolean;
+}
+
+export const actCb = {
+  confirm: (pendingId: string) => `act:${pendingId}:y`,
+  cancel: (pendingId: string) => `act:${pendingId}:n`,
+};
+
+export function parseActCallback(data: string): ActCallback | null {
+  const parts = data.split(":");
+  if (parts.length !== 3 || parts[0] !== "act") return null;
+  const [, pendingId, verdict] = parts;
+  if (!pendingId || (verdict !== "y" && verdict !== "n")) return null;
+  return { pendingId, yes: verdict === "y" };
+}

--- a/src/application/use-cases/processors/AssistantProcessor.spec.ts
+++ b/src/application/use-cases/processors/AssistantProcessor.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AssistantProcessor } from "./AssistantProcessor";
+
+const user: any = {
+  id: "u1",
+  payday: 1,
+  currency: "INR",
+  timezone: "Asia/Kolkata",
+  monthlyIncome: 50000,
+};
+
+const answer = {
+  text: "You spent *₹1,200* on Food.",
+  toolCalls: [{ name: "get_spend_by_category", args: {}, result: {} }],
+  model: "claude-sonnet-5",
+  provider: "anthropic",
+  latencyMs: 1830,
+  inputTokens: 900,
+  outputTokens: 40,
+  ungroundedAmounts: [],
+};
+
+function ctx(overrides: object = {}): any {
+  return {
+    user,
+    platformUserId: "123",
+    textMessage: "how much on food?",
+    parsed: { intent: "QUERY", confidence: 0.9 },
+    ...overrides,
+  };
+}
+
+describe("AssistantProcessor", () => {
+  let agent: any;
+  let messageService: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agent = { answer: vi.fn().mockResolvedValue(answer) };
+    messageService = {
+      sendMessage: vi.fn().mockResolvedValue("m1"),
+      sendInteractiveMessage: vi.fn().mockResolvedValue("m2"),
+      sendTypingIndicator: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  describe("gating", () => {
+    it("handles QUERY when an agent is configured", () => {
+      const p = new AssistantProcessor(agent, messageService);
+      expect(p.canHandle(ctx())).toBe(true);
+    });
+
+    it("yields when no agent is configured, leaving QueryProcessor to answer", () => {
+      const p = new AssistantProcessor(null, messageService);
+      expect(p.canHandle(ctx())).toBe(false);
+    });
+
+    it("ignores non-QUERY intents", () => {
+      const p = new AssistantProcessor(agent, messageService);
+      expect(
+        p.canHandle(ctx({ parsed: { intent: "EXPENSE", confidence: 1 } })),
+      ).toBe(false);
+    });
+  });
+
+  it("sends the answer and returns the tool trace for the turn log", async () => {
+    const p = new AssistantProcessor(agent, messageService);
+    const out = await p.process(ctx());
+
+    expect(messageService.sendMessage).toHaveBeenCalledWith({
+      to: "123",
+      body: answer.text,
+    });
+    expect(out.turnMeta).toMatchObject({
+      intent: "QUERY",
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      latencyMs: 1830,
+      inputTokens: 900,
+      outputTokens: 40,
+      toolCalls: answer.toolCalls,
+    });
+  });
+
+  describe("proposed writes", () => {
+    const proposal = {
+      ...answer,
+      text: "Ready to add ₹2,000 to your Goa trip box — tap confirm.",
+      pendingAction: { id: "p1", summary: "Add ₹2,000 to Goa trip" },
+    };
+
+    it("shows the server-verified summary, not just the model's prose", async () => {
+      // The summary is built from the rows the write will actually touch. The
+      // prose is not. Confirming a button whose payload was never shown is a
+      // rubber stamp, not a confirmation.
+      agent.answer.mockResolvedValue(proposal);
+      const p = new AssistantProcessor(agent, messageService);
+      await p.process(ctx());
+
+      const [, body] = messageService.sendInteractiveMessage.mock.calls[0]!;
+      expect(body).toContain("Add ₹2,000 to Goa trip");
+    });
+
+    it("renders confirm/cancel buttons bound to the proposal id", async () => {
+      agent.answer.mockResolvedValue(proposal);
+      const p = new AssistantProcessor(agent, messageService);
+      await p.process(ctx());
+
+      const [, , rows] = messageService.sendInteractiveMessage.mock.calls[0]!;
+      expect(rows[0].map((b: any) => b.id)).toEqual(["act:p1:y", "act:p1:n"]);
+    });
+
+    it("strips Markdown control chars from the summary", async () => {
+      // The summary embeds a user-authored expense note, and the send path uses
+      // legacy Markdown — a stray underscore would break the whole message.
+      agent.answer.mockResolvedValue({
+        ...proposal,
+        pendingAction: { id: "p1", summary: "Delete ₹220 (lunch_with *boss*)" },
+      });
+      const p = new AssistantProcessor(agent, messageService);
+      await p.process(ctx());
+
+      const [, body] = messageService.sendInteractiveMessage.mock.calls[0]!;
+      expect(body).toContain("lunchwith boss");
+    });
+
+    it("records the confirmed body, so history matches what the user saw", async () => {
+      agent.answer.mockResolvedValue(proposal);
+      const p = new AssistantProcessor(agent, messageService);
+      const out = await p.process(ctx());
+      expect(out.response).toContain("Add ₹2,000 to Goa trip");
+    });
+
+    it("sends a plain message when there is nothing to confirm", async () => {
+      const p = new AssistantProcessor(agent, messageService);
+      await p.process(ctx());
+      expect(messageService.sendMessage).toHaveBeenCalled();
+      expect(messageService.sendInteractiveMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  it("shows a typing indicator before the slow call", async () => {
+    const p = new AssistantProcessor(agent, messageService);
+    await p.process(ctx());
+    expect(messageService.sendTypingIndicator).toHaveBeenCalledWith("123");
+  });
+
+  it("passes the user's local date and cycle, not the server's", async () => {
+    vi.setSystemTime(new Date("2026-08-11T20:00:00Z")); // 01:30 IST on Aug 12
+    const p = new AssistantProcessor(agent, messageService);
+    await p.process(ctx());
+
+    // A UTC date here would tell the assistant it is still Aug 11.
+    expect(agent.answer.mock.calls[0]![1].today).toBe("2026-08-12");
+    expect(agent.answer.mock.calls[0]![1].period.end).toBe("2026-08-31");
+    vi.useRealTimers();
+  });
+
+  it("gives the agent an abort signal so a hung call is cancelled, not just ignored", async () => {
+    const p = new AssistantProcessor(agent, messageService);
+    await p.process(ctx());
+    expect(agent.answer.mock.calls[0]![1].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("degrades to a friendly nudge when the agent fails", async () => {
+    agent.answer.mockRejectedValue(new Error("provider down"));
+    const p = new AssistantProcessor(agent, messageService);
+    const out = await p.process(ctx());
+
+    expect(out.response).toContain("/status");
+    expect(out.turnMeta).toBeUndefined();
+    expect(messageService.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("still answers when the typing indicator fails", async () => {
+    messageService.sendTypingIndicator.mockRejectedValue(new Error("429"));
+    const p = new AssistantProcessor(agent, messageService);
+    const out = await p.process(ctx());
+    expect(out.response).toBe(answer.text);
+  });
+});

--- a/src/application/use-cases/processors/AssistantProcessor.spec.ts
+++ b/src/application/use-cases/processors/AssistantProcessor.spec.ts
@@ -46,17 +46,29 @@ describe("AssistantProcessor", () => {
 
   describe("gating", () => {
     it("handles QUERY when an agent is configured", () => {
-      const p = new AssistantProcessor(agent, messageService);
+      const p = new AssistantProcessor(
+        agent,
+        messageService,
+        "https://blipko.lol",
+      );
       expect(p.canHandle(ctx())).toBe(true);
     });
 
     it("yields when no agent is configured, leaving QueryProcessor to answer", () => {
-      const p = new AssistantProcessor(null, messageService);
+      const p = new AssistantProcessor(
+        null,
+        messageService,
+        "https://blipko.lol",
+      );
       expect(p.canHandle(ctx())).toBe(false);
     });
 
     it("ignores non-QUERY intents", () => {
-      const p = new AssistantProcessor(agent, messageService);
+      const p = new AssistantProcessor(
+        agent,
+        messageService,
+        "https://blipko.lol",
+      );
       expect(
         p.canHandle(ctx({ parsed: { intent: "EXPENSE", confidence: 1 } })),
       ).toBe(false);
@@ -64,7 +76,11 @@ describe("AssistantProcessor", () => {
   });
 
   it("sends the answer and returns the tool trace for the turn log", async () => {
-    const p = new AssistantProcessor(agent, messageService);
+    const p = new AssistantProcessor(
+      agent,
+      messageService,
+      "https://blipko.lol",
+    );
     const out = await p.process(ctx());
 
     expect(messageService.sendMessage).toHaveBeenCalledWith({
@@ -94,7 +110,11 @@ describe("AssistantProcessor", () => {
       // prose is not. Confirming a button whose payload was never shown is a
       // rubber stamp, not a confirmation.
       agent.answer.mockResolvedValue(proposal);
-      const p = new AssistantProcessor(agent, messageService);
+      const p = new AssistantProcessor(
+        agent,
+        messageService,
+        "https://blipko.lol",
+      );
       await p.process(ctx());
 
       const [, body] = messageService.sendInteractiveMessage.mock.calls[0]!;
@@ -103,7 +123,11 @@ describe("AssistantProcessor", () => {
 
     it("renders confirm/cancel buttons bound to the proposal id", async () => {
       agent.answer.mockResolvedValue(proposal);
-      const p = new AssistantProcessor(agent, messageService);
+      const p = new AssistantProcessor(
+        agent,
+        messageService,
+        "https://blipko.lol",
+      );
       await p.process(ctx());
 
       const [, , rows] = messageService.sendInteractiveMessage.mock.calls[0]!;
@@ -117,7 +141,11 @@ describe("AssistantProcessor", () => {
         ...proposal,
         pendingAction: { id: "p1", summary: "Delete ₹220 (lunch_with *boss*)" },
       });
-      const p = new AssistantProcessor(agent, messageService);
+      const p = new AssistantProcessor(
+        agent,
+        messageService,
+        "https://blipko.lol",
+      );
       await p.process(ctx());
 
       const [, body] = messageService.sendInteractiveMessage.mock.calls[0]!;
@@ -126,13 +154,21 @@ describe("AssistantProcessor", () => {
 
     it("records the confirmed body, so history matches what the user saw", async () => {
       agent.answer.mockResolvedValue(proposal);
-      const p = new AssistantProcessor(agent, messageService);
+      const p = new AssistantProcessor(
+        agent,
+        messageService,
+        "https://blipko.lol",
+      );
       const out = await p.process(ctx());
       expect(out.response).toContain("Add ₹2,000 to Goa trip");
     });
 
     it("sends a plain message when there is nothing to confirm", async () => {
-      const p = new AssistantProcessor(agent, messageService);
+      const p = new AssistantProcessor(
+        agent,
+        messageService,
+        "https://blipko.lol",
+      );
       await p.process(ctx());
       expect(messageService.sendMessage).toHaveBeenCalled();
       expect(messageService.sendInteractiveMessage).not.toHaveBeenCalled();
@@ -140,14 +176,22 @@ describe("AssistantProcessor", () => {
   });
 
   it("shows a typing indicator before the slow call", async () => {
-    const p = new AssistantProcessor(agent, messageService);
+    const p = new AssistantProcessor(
+      agent,
+      messageService,
+      "https://blipko.lol",
+    );
     await p.process(ctx());
     expect(messageService.sendTypingIndicator).toHaveBeenCalledWith("123");
   });
 
   it("passes the user's local date and cycle, not the server's", async () => {
     vi.setSystemTime(new Date("2026-08-11T20:00:00Z")); // 01:30 IST on Aug 12
-    const p = new AssistantProcessor(agent, messageService);
+    const p = new AssistantProcessor(
+      agent,
+      messageService,
+      "https://blipko.lol",
+    );
     await p.process(ctx());
 
     // A UTC date here would tell the assistant it is still Aug 11.
@@ -157,14 +201,22 @@ describe("AssistantProcessor", () => {
   });
 
   it("gives the agent an abort signal so a hung call is cancelled, not just ignored", async () => {
-    const p = new AssistantProcessor(agent, messageService);
+    const p = new AssistantProcessor(
+      agent,
+      messageService,
+      "https://blipko.lol",
+    );
     await p.process(ctx());
     expect(agent.answer.mock.calls[0]![1].signal).toBeInstanceOf(AbortSignal);
   });
 
   it("degrades to a friendly nudge when the agent fails", async () => {
     agent.answer.mockRejectedValue(new Error("provider down"));
-    const p = new AssistantProcessor(agent, messageService);
+    const p = new AssistantProcessor(
+      agent,
+      messageService,
+      "https://blipko.lol",
+    );
     const out = await p.process(ctx());
 
     expect(out.response).toContain("/status");
@@ -174,7 +226,11 @@ describe("AssistantProcessor", () => {
 
   it("still answers when the typing indicator fails", async () => {
     messageService.sendTypingIndicator.mockRejectedValue(new Error("429"));
-    const p = new AssistantProcessor(agent, messageService);
+    const p = new AssistantProcessor(
+      agent,
+      messageService,
+      "https://blipko.lol",
+    );
     const out = await p.process(ctx());
     expect(out.response).toBe(answer.text);
   });

--- a/src/application/use-cases/processors/AssistantProcessor.ts
+++ b/src/application/use-cases/processors/AssistantProcessor.ts
@@ -1,0 +1,145 @@
+import {
+  MessageProcessor,
+  ProcessContext,
+  ProcessOutput,
+} from "./MessageProcessor";
+import { IAssistantAgent } from "../../../domain/services/IAssistantAgent";
+import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
+import {
+  currentBudgetPeriod,
+  formatMoney,
+  periodDayInfo,
+  sanitizeMd,
+} from "../budgetMath";
+import { zonedYmd } from "../../../utils/time";
+import { actCb } from "../actCallback";
+import { logger } from "../../../utils/logger";
+import { describeError } from "../../../utils/describeError";
+
+const FALLBACK =
+  "I couldn't work that out right now — try /status, or rephrase your question.";
+
+// Five rounds of a frontier model plus tool queries. Generous enough not to cut
+// off a real multi-step answer, bounded so a hung provider can't hold the
+// Telegram webhook open indefinitely.
+const ASSISTANT_TIMEOUT_MS = 25_000;
+
+// Handles free-form questions with a tool-calling assistant over the user's own
+// data. Every figure it states is fetched and pre-computed by the tool layer.
+//
+// Gated: when no agent is configured this yields, and QueryProcessor answers as
+// before. Enabling the lane is a config change, not a code change.
+export class AssistantProcessor implements MessageProcessor {
+  constructor(
+    private readonly agent: IAssistantAgent | null,
+    private readonly messageService: IMessagingPlatform,
+  ) {}
+
+  canHandle(context: ProcessContext): boolean {
+    if (this.agent === null) return false;
+    const intent = context.parsed?.intent;
+    // ESCALATE is what the log-or-escalate parser emits for everything that is
+    // not a clear spend; QUERY is the same thing from the legacy prompt.
+    return intent === "ESCALATE" || intent === "QUERY";
+  }
+
+  async process(context: ProcessContext): Promise<ProcessOutput> {
+    const { user, platformUserId, textMessage } = context;
+    const agent = this.agent!;
+    const now = new Date();
+    const tz = user.timezone;
+    const { start, end } = currentBudgetPeriod(user.payday, now, tz);
+    const { day, daysInPeriod, remainingDays } = periodDayInfo(
+      user.payday,
+      now,
+      tz,
+    );
+
+    // An agent turn takes seconds, not milliseconds — show the user something
+    // is happening rather than leaving the chat silent.
+    void this.messageService
+      .sendTypingIndicator(platformUserId)
+      .catch(() => {});
+
+    // A real abort, not just an unblocked promise: withTimeout races but leaves
+    // the underlying request running, so a hung provider call leaks.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ASSISTANT_TIMEOUT_MS);
+
+    try {
+      const answer = await agent.answer(textMessage, {
+        userId: user.id,
+        currency: user.currency,
+        payday: user.payday,
+        monthlyIncome: formatMoney(Number(user.monthlyIncome ?? 0)),
+        today: zonedYmd(now, tz),
+        period: {
+          start: zonedYmd(start, tz),
+          end: zonedYmd(new Date(end.getTime() - 1), tz),
+          day,
+          daysInPeriod,
+          remainingDays,
+        },
+        history: context.conversationHistory,
+        signal: controller.signal,
+      });
+
+      // A proposed write is shown with its confirm buttons; nothing has been
+      // changed yet, so the user's tap is what commits it.
+      //
+      // The body carries `summary`, NOT just the model's prose. The summary is
+      // built from the rows the write will actually touch (resolved box name,
+      // the expense's real amount), so the user is confirming what will happen
+      // rather than what the model said would happen. Showing only the prose
+      // would make this a confirmation in name and a rubber stamp in fact.
+      const body = answer.pendingAction
+        ? `${answer.text}\n\n➡️ *${sanitizeMd(answer.pendingAction.summary)}*`
+        : answer.text;
+
+      if (answer.pendingAction) {
+        await this.messageService.sendInteractiveMessage(platformUserId, body, [
+          [
+            { id: actCb.confirm(answer.pendingAction.id), title: "✅ Confirm" },
+            { id: actCb.cancel(answer.pendingAction.id), title: "✖️ Cancel" },
+          ],
+        ]);
+      } else {
+        await this.messageService.sendMessage({
+          to: platformUserId,
+          body,
+        });
+      }
+
+      return {
+        response: body,
+        parsed: { intent: "QUERY", confidence: 1 },
+        turnMeta: {
+          intent: "QUERY",
+          toolCalls: answer.toolCalls,
+          provider: answer.provider,
+          model: answer.model,
+          latencyMs: answer.latencyMs,
+          inputTokens: answer.inputTokens,
+          outputTokens: answer.outputTokens,
+        },
+      };
+    } catch (error) {
+      logger.error("Assistant failed", {
+        component: "assistant",
+        userId: user.id,
+        question: textMessage,
+        err: describeError(error),
+      });
+      await this.messageService.sendMessage({
+        to: platformUserId,
+        body: FALLBACK,
+      });
+      return {
+        response: FALLBACK,
+        parsed: { intent: "QUERY", confidence: 1 },
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/application/use-cases/processors/AssistantProcessor.ts
+++ b/src/application/use-cases/processors/AssistantProcessor.ts
@@ -33,6 +33,7 @@ export class AssistantProcessor implements MessageProcessor {
   constructor(
     private readonly agent: IAssistantAgent | null,
     private readonly messageService: IMessagingPlatform,
+    private readonly webAppUrl: string,
   ) {}
 
   canHandle(context: ProcessContext): boolean {
@@ -73,6 +74,7 @@ export class AssistantProcessor implements MessageProcessor {
         payday: user.payday,
         monthlyIncome: formatMoney(Number(user.monthlyIncome ?? 0)),
         today: zonedYmd(now, tz),
+        dashboardUrl: this.webAppUrl,
         period: {
           start: zonedYmd(start, tz),
           end: zonedYmd(new Date(end.getTime() - 1), tz),
@@ -101,6 +103,18 @@ export class AssistantProcessor implements MessageProcessor {
           [
             { id: actCb.confirm(answer.pendingAction.id), title: "✅ Confirm" },
             { id: actCb.cancel(answer.pendingAction.id), title: "✖️ Cancel" },
+          ],
+        ]);
+      } else if (answer.dashboardUrl) {
+        // A pending write takes precedence: an unanswered "confirm?" must not
+        // be buried under a link to somewhere else.
+        await this.messageService.sendInteractiveMessage(platformUserId, body, [
+          [
+            {
+              id: "dashboard",
+              title: "🔗 Open dashboard",
+              url: answer.dashboardUrl,
+            },
           ],
         ]);
       } else {

--- a/src/application/use-cases/processors/HelpProcessor.spec.ts
+++ b/src/application/use-cases/processors/HelpProcessor.spec.ts
@@ -8,7 +8,7 @@ describe("HelpProcessor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
-    processor = new HelpProcessor(messageService);
+    processor = new HelpProcessor(messageService, "https://blipko.lol");
   });
 
   it("matches 'help' and '/help' only", () => {

--- a/src/application/use-cases/processors/HelpProcessor.ts
+++ b/src/application/use-cases/processors/HelpProcessor.ts
@@ -5,7 +5,8 @@ import {
 } from "./MessageProcessor";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 
-const HELP_BODY = `🧭 *How to use Blipko*
+function helpBody(webAppUrl: string): string {
+  return `🧭 *How to use Blipko*
 
 *Log a spend* — just say what you spent, in English, Hindi, Manglish, or Malayalam:
 • \`chai 30\`
@@ -26,11 +27,17 @@ Or send a *voice note* — I'll transcribe and log it.
 • /start — connect your dashboard
 • \`undo\` — remove the last entry
 
-*Set up & fine-tune everything* on the web dashboard — sign in, then tap *Connect Telegram* to link this chat. Categories, per-category limits, income split, and reminders all live there: blipko.lol`;
+*Set up & fine-tune everything* on the web dashboard — sign in, then tap *Connect Telegram* to link this chat. Categories, per-category limits, income split, and reminders all live there: ${webAppUrl}`;
+}
 
 // Replies to "help"/"/help" with a detailed guide. Pre-parse (no AI needed).
 export class HelpProcessor implements MessageProcessor {
-  constructor(private readonly messageService: IMessagingPlatform) {}
+  constructor(
+    private readonly messageService: IMessagingPlatform,
+    // From env, not hardcoded — the help text used to name blipko.lol
+    // literally, so any other deployment sent its users to the wrong app.
+    private readonly webAppUrl: string,
+  ) {}
 
   canHandle(context: ProcessContext): boolean {
     const normalized = context.textMessage
@@ -41,12 +48,13 @@ export class HelpProcessor implements MessageProcessor {
   }
 
   async process(context: ProcessContext): Promise<ProcessOutput> {
+    const body = helpBody(this.webAppUrl);
     await this.messageService.sendMessage({
       to: context.platformUserId,
-      body: HELP_BODY,
+      body,
     });
     return {
-      response: HELP_BODY,
+      response: body,
       parsed: { intent: "UNKNOWN", confidence: 1 },
     };
   }

--- a/src/application/use-cases/processors/MessageProcessor.ts
+++ b/src/application/use-cases/processors/MessageProcessor.ts
@@ -2,6 +2,7 @@ import { User } from "@prisma/client";
 import { ParsedData, ParsedBatch } from "../../../domain/entities/ParsedData";
 import { ConversationTurn } from "../../../domain/services/IAiParser";
 import { TransactionRef } from "../transactionActions";
+import { TurnMeta } from "../../../domain/repositories/IConversationRepository";
 
 export interface ProcessContext {
   user: User;
@@ -26,6 +27,14 @@ export interface ProcessOutput {
   parsed: ParsedData;
   // Optional short toast shown on the tapped inline button.
   toast?: string | undefined;
+  // Extra detail to persist with this turn (tool trace, model, latency, cost).
+  // Set by the assistant lane; deterministic processors leave it unset.
+  turnMeta?: TurnMeta | undefined;
+  // Short stand-in stored in the transcript instead of `response`. For replies
+  // that are a pure rendering of data the AI can fetch on demand (/status,
+  // /report), the full text is a money dump with no follow-up value — and it
+  // would otherwise be replayed into the parser's prompt on every later message.
+  historyText?: string | undefined;
 }
 
 export interface MessageProcessor {

--- a/src/application/use-cases/processors/PendingActionProcessor.spec.ts
+++ b/src/application/use-cases/processors/PendingActionProcessor.spec.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PendingActionProcessor } from "./PendingActionProcessor";
+
+const user: any = { id: "u1", payday: 1, timezone: "Asia/Kolkata" };
+
+function ctx(textMessage: string): any {
+  return { user, platformUserId: "123", textMessage };
+}
+
+function pending(overrides: object = {}): any {
+  return {
+    id: "p1",
+    userId: "u1",
+    kind: "BOX_MOVE",
+    payload: { boxName: "Goa trip", amount: 5000, direction: "IN" },
+    summary: "Add ₹5,000 to Goa trip",
+    ...overrides,
+  };
+}
+
+describe("PendingActionProcessor", () => {
+  let pendingActionRepository: any;
+  let expenseRepository: any;
+  let categoryRepository: any;
+  let boxRepository: any;
+  let recurringRuleRepository: any;
+  let messageService: any;
+  let p: PendingActionProcessor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pendingActionRepository = {
+      findLiveForUser: vi.fn().mockResolvedValue(pending()),
+      consume: vi.fn().mockResolvedValue(true),
+    };
+    expenseRepository = {
+      findById: vi.fn(),
+      softDelete: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    categoryRepository = { findByNameForUser: vi.fn().mockResolvedValue(null) };
+    boxRepository = {
+      findByNameForUser: vi
+        .fn()
+        .mockResolvedValue({ id: "b1", name: "Goa trip", targetAmount: null }),
+      addEntry: vi.fn().mockResolvedValue({}),
+      balanceFor: vi.fn().mockResolvedValue(5000),
+      markTargetReached: vi.fn().mockResolvedValue(false),
+    };
+    recurringRuleRepository = {
+      create: vi.fn().mockResolvedValue({ id: "r1" }),
+    };
+    messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+
+    p = new PendingActionProcessor(
+      pendingActionRepository,
+      expenseRepository,
+      categoryRepository,
+      boxRepository,
+      recurringRuleRepository,
+      messageService,
+    );
+  });
+
+  describe("routing", () => {
+    it("handles act: callbacks", () => {
+      expect(p.canHandle(ctx("act:p1:y"))).toBe(true);
+      expect(p.canHandle(ctx("act:p1:n"))).toBe(true);
+    });
+
+    it("ignores anything else", () => {
+      expect(p.canHandle(ctx("chai 30"))).toBe(false);
+      expect(p.canHandle(ctx("txn:askdel:e:x1"))).toBe(false);
+      expect(p.canHandle(ctx("act:p1"))).toBe(false);
+      expect(p.canHandle(ctx("act:p1:maybe"))).toBe(false);
+    });
+  });
+
+  it("applies the action on confirm", async () => {
+    const out = await p.process(ctx("act:p1:y"));
+    expect(boxRepository.addEntry).toHaveBeenCalled();
+    expect(out.response).toContain("Goa trip");
+  });
+
+  it("changes nothing on cancel", async () => {
+    const out = await p.process(ctx("act:p1:n"));
+    expect(boxRepository.addEntry).not.toHaveBeenCalled();
+    expect(recurringRuleRepository.create).not.toHaveBeenCalled();
+    expect(out.response).toBe("Cancelled — nothing changed.");
+  });
+
+  describe("authorization and single-use", () => {
+    it("refuses another user's pending id", async () => {
+      // The repository scopes by userId, so a foreign id resolves to nothing.
+      pendingActionRepository.findLiveForUser.mockResolvedValue(null);
+      const out = await p.process(ctx("act:someone-elses-id:y"));
+
+      expect(out.response).toContain("expired");
+      expect(boxRepository.addEntry).not.toHaveBeenCalled();
+      expect(pendingActionRepository.findLiveForUser).toHaveBeenCalledWith(
+        "someone-elses-id",
+        "u1",
+      );
+    });
+
+    it("refuses an expired or already-used action", async () => {
+      pendingActionRepository.findLiveForUser.mockResolvedValue(null);
+      const out = await p.process(ctx("act:p1:y"));
+      expect(out.response).toContain("expired");
+    });
+
+    it("does not apply twice when the claim is lost to a double tap", async () => {
+      pendingActionRepository.consume.mockResolvedValue(false);
+      const out = await p.process(ctx("act:p1:y"));
+
+      expect(boxRepository.addEntry).not.toHaveBeenCalled();
+      expect(out.response).toContain("expired");
+    });
+
+    it("claims the action before writing, not after", async () => {
+      const order: string[] = [];
+      pendingActionRepository.consume.mockImplementation(async () => {
+        order.push("consume");
+        return true;
+      });
+      boxRepository.addEntry.mockImplementation(async () => {
+        order.push("write");
+        return {};
+      });
+
+      await p.process(ctx("act:p1:y"));
+      expect(order).toEqual(["consume", "write"]);
+    });
+  });
+
+  describe("payload validation", () => {
+    it("rejects a payload that no longer matches its schema", async () => {
+      pendingActionRepository.findLiveForUser.mockResolvedValue(
+        pending({
+          payload: { boxName: "Goa trip", amount: -5, direction: "IN" },
+        }),
+      );
+      const out = await p.process(ctx("act:p1:y"));
+
+      expect(out.response).toContain("expired");
+      expect(boxRepository.addEntry).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown action kind", async () => {
+      pendingActionRepository.findLiveForUser.mockResolvedValue(
+        pending({ kind: "DROP_DATABASE", payload: {} }),
+      );
+      const out = await p.process(ctx("act:p1:y"));
+      expect(out.response).toContain("expired");
+    });
+  });
+
+  describe("apply-time re-checks", () => {
+    it("re-verifies expense ownership at apply time, not just at proposal", async () => {
+      pendingActionRepository.findLiveForUser.mockResolvedValue(
+        pending({ kind: "DELETE_EXPENSE", payload: { expenseId: "e1" } }),
+      );
+      // Proposal was made 30 minutes ago; the row now belongs to someone else.
+      expenseRepository.findById.mockResolvedValue({
+        id: "e1",
+        userId: "someone-else",
+        amount: 220,
+        isDeleted: false,
+      });
+
+      const out = await p.process(ctx("act:p1:y"));
+      expect(expenseRepository.softDelete).not.toHaveBeenCalled();
+      expect(out.response).toContain("expired");
+    });
+
+    it("will not delete an already-deleted expense", async () => {
+      pendingActionRepository.findLiveForUser.mockResolvedValue(
+        pending({ kind: "DELETE_EXPENSE", payload: { expenseId: "e1" } }),
+      );
+      expenseRepository.findById.mockResolvedValue({
+        id: "e1",
+        userId: "u1",
+        amount: 220,
+        isDeleted: true,
+      });
+
+      const out = await p.process(ctx("act:p1:y"));
+      expect(expenseRepository.softDelete).not.toHaveBeenCalled();
+      expect(out.response).toContain("expired");
+    });
+
+    it("deletes a valid expense", async () => {
+      pendingActionRepository.findLiveForUser.mockResolvedValue(
+        pending({ kind: "DELETE_EXPENSE", payload: { expenseId: "e1" } }),
+      );
+      expenseRepository.findById.mockResolvedValue({
+        id: "e1",
+        userId: "u1",
+        amount: 220,
+        note: "chai",
+        isDeleted: false,
+      });
+
+      const out = await p.process(ctx("act:p1:y"));
+      expect(expenseRepository.softDelete).toHaveBeenCalledWith("e1");
+      expect(out.response).toContain("₹220");
+    });
+  });
+
+  describe("recurring", () => {
+    it("lets a named category's bucket override the model's guess", async () => {
+      pendingActionRepository.findLiveForUser.mockResolvedValue(
+        pending({
+          kind: "SET_RECURRING",
+          payload: {
+            kind: "EXPENSE",
+            amount: 8000,
+            dayOfMonth: 1,
+            bucket: "WANTS", // model guessed wrong
+            categoryName: "Rent",
+            note: "rent",
+          },
+        }),
+      );
+      categoryRepository.findByNameForUser.mockResolvedValue({
+        id: "c1",
+        name: "Rent",
+        bucket: "NEEDS",
+      });
+
+      await p.process(ctx("act:p1:y"));
+      expect(recurringRuleRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ bucket: "NEEDS", categoryId: "c1" }),
+      );
+    });
+  });
+
+  it("reports a failed write without claiming success", async () => {
+    boxRepository.addEntry.mockRejectedValue(new Error("db down"));
+    const out = await p.process(ctx("act:p1:y"));
+    expect(out.response).toContain("nothing was changed");
+  });
+});

--- a/src/application/use-cases/processors/PendingActionProcessor.ts
+++ b/src/application/use-cases/processors/PendingActionProcessor.ts
@@ -1,0 +1,214 @@
+import {
+  MessageProcessor,
+  ProcessContext,
+  ProcessOutput,
+} from "./MessageProcessor";
+import { IPendingActionRepository } from "../../../domain/repositories/IPendingActionRepository";
+import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
+import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
+import { IBoxRepository } from "../../../domain/repositories/IBoxRepository";
+import { IRecurringRuleRepository } from "../../../domain/repositories/IRecurringRuleRepository";
+import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
+import { parseActCallback } from "../actCallback";
+import { parsePendingPayload } from "../../../domain/entities/PendingAction";
+import { recordBoxEntry } from "../boxFlow";
+import { BUCKET_META, formatMoney } from "../budgetMath";
+import { logger } from "../../../utils/logger";
+import { describeError } from "../../../utils/describeError";
+
+const EXPIRED =
+  "That request expired or was already handled — ask me again and I'll set it up.";
+const CANCELLED = "Cancelled — nothing changed.";
+
+// Performs a write the assistant proposed, once the user taps Confirm.
+//
+// The split matters: the model decides WHAT to propose, this decides whether it
+// is allowed and then does it. Ownership, expiry, single-use and payload shape
+// are all re-checked here — the callback id being unguessable is not an
+// authorization check.
+export class PendingActionProcessor implements MessageProcessor {
+  constructor(
+    private readonly pendingActionRepository: IPendingActionRepository,
+    private readonly expenseRepository: IExpenseRepository,
+    private readonly categoryRepository: ICategoryRepository,
+    private readonly boxRepository: IBoxRepository,
+    private readonly recurringRuleRepository: IRecurringRuleRepository,
+    private readonly messageService: IMessagingPlatform,
+  ) {}
+
+  canHandle(context: ProcessContext): boolean {
+    return parseActCallback(context.textMessage ?? "") !== null;
+  }
+
+  async process(context: ProcessContext): Promise<ProcessOutput> {
+    const { user, platformUserId } = context;
+    const callback = parseActCallback(context.textMessage)!;
+
+    if (!callback.yes) {
+      // Nothing was ever written, so cancelling is just consuming the row.
+      await this.pendingActionRepository.consume(callback.pendingId, user.id);
+      return this.reply(platformUserId, CANCELLED, context);
+    }
+
+    // Scoped to this user: another user's pending id must not resolve.
+    const pending = await this.pendingActionRepository.findLiveForUser(
+      callback.pendingId,
+      user.id,
+    );
+    if (!pending) return this.reply(platformUserId, EXPIRED, context);
+
+    const parsed = parsePendingPayload(pending.kind, pending.payload);
+    if (!parsed) {
+      logger.error("Pending action payload failed validation", {
+        component: "assistant",
+        userId: user.id,
+        pendingActionId: pending.id,
+        kind: pending.kind,
+      });
+      return this.reply(platformUserId, EXPIRED, context);
+    }
+
+    // Claim it BEFORE writing: a double-tap must not apply the same change
+    // twice, and losing the race means someone else already did the work.
+    const claimed = await this.pendingActionRepository.consume(
+      pending.id,
+      user.id,
+    );
+    if (!claimed) return this.reply(platformUserId, EXPIRED, context);
+
+    try {
+      const body = await this.apply(parsed, user.id);
+      return this.reply(platformUserId, body, context);
+    } catch (error) {
+      logger.error("Failed to apply pending action", {
+        component: "assistant",
+        userId: user.id,
+        pendingActionId: pending.id,
+        kind: pending.kind,
+        err: describeError(error),
+      });
+      return this.reply(
+        platformUserId,
+        "Something went wrong applying that — nothing was changed.",
+        context,
+      );
+    }
+  }
+
+  private async apply(
+    parsed: NonNullable<ReturnType<typeof parsePendingPayload>>,
+    userId: string,
+  ): Promise<string> {
+    switch (parsed.kind) {
+      case "SET_RECURRING": {
+        const p = parsed.data as {
+          kind: "INCOME" | "EXPENSE";
+          amount: number;
+          dayOfMonth: number;
+          bucket?: "NEEDS" | "WANTS" | "SAVINGS";
+          categoryName?: string;
+          note?: string;
+        };
+        const category = p.categoryName
+          ? await this.categoryRepository.findByNameForUser(
+              userId,
+              p.categoryName,
+            )
+          : null;
+        await this.recurringRuleRepository.create({
+          userId,
+          kind: p.kind,
+          amount: p.amount,
+          dayOfMonth: p.dayOfMonth,
+          // A named category's own bucket is authoritative, exactly as when
+          // logging an expense.
+          bucket: category?.bucket ?? p.bucket,
+          categoryId: category?.id,
+          note: p.note,
+        });
+        return `🔁 Set up: ${formatMoney(p.amount)} ${p.kind === "INCOME" ? "income" : "expense"} on day ${p.dayOfMonth} every month.`;
+      }
+
+      case "BOX_MOVE": {
+        const p = parsed.data as {
+          boxName: string;
+          amount: number;
+          direction: "IN" | "OUT";
+          note?: string;
+        };
+        const box = await this.boxRepository.findByNameForUser(
+          userId,
+          p.boxName,
+        );
+        if (!box) return EXPIRED;
+        const { balance } = await recordBoxEntry(this.boxRepository, {
+          box,
+          userId,
+          amount: p.amount,
+          direction: p.direction,
+          note: p.note,
+        });
+        const verb = p.direction === "IN" ? "Added" : "Withdrew";
+        return `📦 ${verb} ${formatMoney(p.amount)} ${p.direction === "IN" ? "to" : "from"} ${box.name}. Balance: ${formatMoney(balance)}.`;
+      }
+
+      case "DELETE_EXPENSE": {
+        const p = parsed.data as { expenseId: string };
+        const expense = await this.expenseRepository.findById(p.expenseId);
+        // Re-check ownership at apply time: the proposal may be 30 minutes old.
+        if (!expense || expense.userId !== userId || expense.isDeleted) {
+          return EXPIRED;
+        }
+        await this.expenseRepository.softDelete(expense.id);
+        return `🗑 Deleted ${formatMoney(Number(expense.amount))}${expense.note ? ` (${expense.note})` : ""}.`;
+      }
+
+      case "EDIT_EXPENSE": {
+        const p = parsed.data as {
+          expenseId: string;
+          amount?: number;
+          bucket?: "NEEDS" | "WANTS" | "SAVINGS";
+          categoryName?: string;
+          note?: string;
+        };
+        const expense = await this.expenseRepository.findById(p.expenseId);
+        if (!expense || expense.userId !== userId || expense.isDeleted) {
+          return EXPIRED;
+        }
+        const category = p.categoryName
+          ? await this.categoryRepository.findByNameForUser(
+              userId,
+              p.categoryName,
+            )
+          : null;
+        await this.expenseRepository.update(expense.id, {
+          amount: p.amount,
+          bucket: category?.bucket ?? p.bucket,
+          categoryId: category?.id,
+          note: p.note,
+        });
+
+        const bits = [
+          p.amount !== undefined ? formatMoney(p.amount) : null,
+          category ? category.name : null,
+          (category?.bucket ?? p.bucket)
+            ? BUCKET_META[(category?.bucket ?? p.bucket)!].label
+            : null,
+        ].filter(Boolean);
+        return `✏️ Updated${bits.length ? `: ${bits.join(" · ")}` : ""}.`;
+      }
+    }
+  }
+
+  private async reply(
+    to: string,
+    body: string,
+    context: ProcessContext,
+  ): Promise<ProcessOutput> {
+    if (context.callbackQueryId && this.messageService.acknowledgeInteraction) {
+      await this.messageService.acknowledgeInteraction(context.callbackQueryId);
+    }
+    await this.messageService.sendMessage({ to, body });
+    return { response: body, parsed: { intent: "UNKNOWN", confidence: 1 } };
+  }
+}

--- a/src/application/use-cases/processors/QueryProcessor.spec.ts
+++ b/src/application/use-cases/processors/QueryProcessor.spec.ts
@@ -19,7 +19,11 @@ describe("QueryProcessor", () => {
     vi.clearAllMocks();
     queryAgent = { answer: vi.fn() };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
-    processor = new QueryProcessor(queryAgent, messageService);
+    processor = new QueryProcessor(
+      queryAgent,
+      messageService,
+      "https://blipko.lol",
+    );
   });
 
   it("handles only the QUERY intent", () => {

--- a/src/application/use-cases/processors/QueryProcessor.ts
+++ b/src/application/use-cases/processors/QueryProcessor.ts
@@ -5,9 +5,11 @@ import {
 } from "./MessageProcessor";
 import { IFinancialQueryAgent } from "../../../domain/services/IFinancialQueryAgent";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
-import { currentBudgetPeriod, periodDayInfo } from "../budgetMath";
+import { currentBudgetPeriod, formatMoney, periodDayInfo } from "../budgetMath";
+import { zonedYmd } from "../../../utils/time";
 import { withTimeout } from "../../../utils/withTimeout";
 import { logger } from "../../../utils/logger";
+import { describeError } from "../../../utils/describeError";
 
 const FALLBACK =
   "I couldn't work that out right now — try /status, or rephrase your question.";
@@ -32,10 +34,12 @@ export class QueryProcessor implements MessageProcessor {
   async process(context: ProcessContext): Promise<ProcessOutput> {
     const { user, platformUserId, textMessage } = context;
     const now = new Date();
-    const { start, end } = currentBudgetPeriod(user.payday, now);
+    const tz = user.timezone;
+    const { start, end } = currentBudgetPeriod(user.payday, now, tz);
     const { day, daysInPeriod, remainingDays } = periodDayInfo(
       user.payday,
       now,
+      tz,
     );
 
     let body: string;
@@ -46,11 +50,13 @@ export class QueryProcessor implements MessageProcessor {
           currency: user.currency,
           locale: user.locale,
           payday: user.payday,
-          monthlyIncome: Number(user.monthlyIncome ?? 0),
-          now,
+          monthlyIncome: formatMoney(Number(user.monthlyIncome ?? 0)),
+          today: zonedYmd(now, tz),
           period: {
-            start: start.toISOString(),
-            end: end.toISOString(),
+            start: zonedYmd(start, tz),
+            // `end` is exclusive internally; the agent is told the inclusive
+            // last day so it never reports a cycle as one day longer.
+            end: zonedYmd(new Date(end.getTime() - 1), tz),
             day,
             daysInPeriod,
             remainingDays,
@@ -65,7 +71,7 @@ export class QueryProcessor implements MessageProcessor {
         component: "query",
         userId: user.id,
         question: textMessage,
-        err: error,
+        err: describeError(error),
       });
       body = FALLBACK;
     }

--- a/src/application/use-cases/processors/QueryProcessor.ts
+++ b/src/application/use-cases/processors/QueryProcessor.ts
@@ -25,6 +25,7 @@ export class QueryProcessor implements MessageProcessor {
   constructor(
     private readonly queryAgent: IFinancialQueryAgent,
     private readonly messageService: IMessagingPlatform,
+    private readonly webAppUrl: string,
   ) {}
 
   canHandle(context: ProcessContext): boolean {
@@ -52,6 +53,7 @@ export class QueryProcessor implements MessageProcessor {
           payday: user.payday,
           monthlyIncome: formatMoney(Number(user.monthlyIncome ?? 0)),
           today: zonedYmd(now, tz),
+          dashboardUrl: this.webAppUrl,
           period: {
             start: zonedYmd(start, tz),
             // `end` is exclusive internally; the agent is told the inclusive

--- a/src/application/use-cases/processors/ReportProcessor.ts
+++ b/src/application/use-cases/processors/ReportProcessor.ts
@@ -104,7 +104,11 @@ export class ReportProcessor implements MessageProcessor {
     }
 
     await this.messageService.sendMessage({ to: platformUserId, body });
-    return { response: body, parsed: { intent: "UNKNOWN", confidence: 1 } };
+    return {
+      response: body,
+      parsed: { intent: "UNKNOWN", confidence: 1 },
+      historyText: "[showed monthly report]",
+    };
   }
 
   private bucketLine(

--- a/src/application/use-cases/processors/StatusProcessor.ts
+++ b/src/application/use-cases/processors/StatusProcessor.ts
@@ -100,6 +100,13 @@ export class StatusProcessor implements MessageProcessor {
     }
 
     await this.messageService.sendMessage({ to: platformUserId, body });
-    return { response: body, parsed: { intent: "STATUS", confidence: 1 } };
+    // Stored as a marker, not the rendered income + per-bucket totals: this
+    // is a pure projection the assistant can re-fetch, and the full text would
+    // otherwise be replayed into the parser's prompt on every later message.
+    return {
+      response: body,
+      parsed: { intent: "STATUS", confidence: 1 },
+      historyText: "[showed budget status]",
+    };
   }
 }

--- a/src/application/use-cases/query/AssistantWriteTools.spec.ts
+++ b/src/application/use-cases/query/AssistantWriteTools.spec.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AssistantWriteTools } from "./AssistantWriteTools";
+
+describe("AssistantWriteTools", () => {
+  let pendingActionRepository: any;
+  let expenseRepository: any;
+  let categoryRepository: any;
+  let boxRepository: any;
+  let writes: AssistantWriteTools;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pendingActionRepository = {
+      create: vi.fn().mockResolvedValue({ id: "p1" }),
+    };
+    expenseRepository = {
+      findById: vi.fn().mockResolvedValue({
+        id: "e1",
+        userId: "u1",
+        amount: 220,
+        note: "chai",
+        isDeleted: false,
+      }),
+    };
+    categoryRepository = {
+      findByNameForUser: vi.fn().mockResolvedValue(null),
+      findAllForUser: vi
+        .fn()
+        .mockResolvedValue([{ name: "Food", bucket: "WANTS", isGroup: false }]),
+    };
+    boxRepository = {
+      findByNameForUser: vi
+        .fn()
+        .mockResolvedValue({ id: "b1", name: "Goa trip" }),
+      listWithBalances: vi.fn().mockResolvedValue([{ name: "Goa trip" }]),
+    };
+
+    writes = new AssistantWriteTools(
+      pendingActionRepository,
+      expenseRepository,
+      categoryRepository,
+      boxRepository,
+    );
+  });
+
+  it("never mutates — it only stages a proposal", async () => {
+    const res = await writes.proposeBoxMove("u1", {
+      box: "Goa trip",
+      amount: 5000,
+      direction: "IN",
+    });
+
+    expect(res).toMatchObject({ ok: true, pendingId: "p1" });
+    expect(pendingActionRepository.create).toHaveBeenCalledTimes(1);
+    // No ledger repository has a write method called here at all.
+    expect(boxRepository).not.toHaveProperty("addEntry.mock.calls.0");
+  });
+
+  it("stages a proposal with an expiry", async () => {
+    await writes.proposeBoxMove("u1", {
+      box: "Goa trip",
+      amount: 5000,
+      direction: "IN",
+    });
+    expect(pendingActionRepository.create.mock.calls[0]![0].ttlMinutes).toBe(
+      30,
+    );
+  });
+
+  describe("references are resolved against real rows", () => {
+    it("rejects an unknown box and hands back the real names", async () => {
+      boxRepository.findByNameForUser.mockResolvedValue(null);
+      const res = await writes.proposeBoxMove("u1", {
+        box: "Bali trip",
+        amount: 5000,
+        direction: "IN",
+      });
+
+      expect(res).toMatchObject({
+        ok: false,
+        error: "unknown_box",
+        available_boxes: ["Goa trip"],
+      });
+      expect(pendingActionRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("stores the box's canonical name, not the model's spelling", async () => {
+      boxRepository.findByNameForUser.mockResolvedValue({
+        id: "b1",
+        name: "Goa trip",
+      });
+      await writes.proposeBoxMove("u1", {
+        box: "goa TRIP",
+        amount: 100,
+        direction: "IN",
+      });
+      expect(
+        pendingActionRepository.create.mock.calls[0]![0].payload.boxName,
+      ).toBe("Goa trip");
+    });
+
+    it("rejects another user's expense", async () => {
+      expenseRepository.findById.mockResolvedValue({
+        id: "e1",
+        userId: "someone-else",
+        amount: 220,
+        isDeleted: false,
+      });
+      const res = await writes.proposeDeleteExpense("u1", { expenseId: "e1" });
+
+      expect(res).toMatchObject({ ok: false, error: "expense_not_found" });
+      expect(pendingActionRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown category and lists the valid ones", async () => {
+      const res = await writes.proposeRecurring("u1", {
+        kind: "EXPENSE",
+        amount: 8000,
+        dayOfMonth: 1,
+        category: "Groceries",
+      });
+
+      expect(res).toMatchObject({
+        ok: false,
+        error: "unknown_category",
+        available_categories: ["Food"],
+      });
+    });
+
+    it("takes the bucket from the named category, not the model", async () => {
+      categoryRepository.findByNameForUser.mockResolvedValue({
+        id: "c1",
+        name: "Rent",
+        bucket: "NEEDS",
+      });
+      await writes.proposeRecurring("u1", {
+        kind: "EXPENSE",
+        amount: 8000,
+        dayOfMonth: 1,
+        bucket: "SAVINGS", // wrong guess
+        category: "Rent",
+      });
+
+      expect(
+        pendingActionRepository.create.mock.calls[0]![0].payload.bucket,
+      ).toBe("NEEDS");
+    });
+  });
+
+  describe("payload validation happens before staging", () => {
+    it("rejects a day of month outside 1-28", async () => {
+      const res = await writes.proposeRecurring("u1", {
+        kind: "EXPENSE",
+        amount: 8000,
+        dayOfMonth: 31,
+      });
+      expect(res).toMatchObject({ ok: false, error: "invalid_proposal" });
+      expect(pendingActionRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects an absurd amount", async () => {
+      const res = await writes.proposeBoxMove("u1", {
+        box: "Goa trip",
+        amount: 9_999_999_999,
+        direction: "IN",
+      });
+      expect(res).toMatchObject({ ok: false, error: "invalid_proposal" });
+    });
+  });
+
+  it("rejects an edit that changes nothing", async () => {
+    const res = await writes.proposeExpenseEdit("u1", { expenseId: "e1" });
+    expect(res).toMatchObject({ ok: false, error: "no_changes" });
+  });
+
+  it("summarises an edit as a before → after the user can check", async () => {
+    const res = await writes.proposeExpenseEdit("u1", {
+      expenseId: "e1",
+      amount: 50,
+    });
+    expect(res).toMatchObject({ ok: true });
+    expect((res as any).summary).toContain("₹220");
+    expect((res as any).summary).toContain("₹50");
+  });
+});

--- a/src/application/use-cases/query/AssistantWriteTools.ts
+++ b/src/application/use-cases/query/AssistantWriteTools.ts
@@ -1,0 +1,264 @@
+import { Bucket } from "@prisma/client";
+import {
+  IAssistantWriteTools,
+  ProposalResult,
+} from "../../../domain/services/IAssistantWriteTools";
+import { IPendingActionRepository } from "../../../domain/repositories/IPendingActionRepository";
+import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
+import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
+import { IBoxRepository } from "../../../domain/repositories/IBoxRepository";
+import { BUCKET_META, formatMoney } from "../budgetMath";
+import { PENDING_ACTION_SCHEMAS } from "../../../domain/entities/PendingAction";
+
+// Long enough to read the message and tap; short enough that a stale proposal
+// can't be confirmed days later against a budget that has since moved on. The
+// existing bkt: confirmations have no expiry at all.
+const TTL_MINUTES = 30;
+
+const BUCKETS: Bucket[] = ["NEEDS", "WANTS", "SAVINGS"];
+
+// Explicit tag rather than an `"error" in x` check: the success arm of
+// ProposalResult has no `error` key either, so `in` cannot discriminate it.
+type ResolvedBucket =
+  | { resolved: true; bucket: Bucket | undefined }
+  | { resolved: false; failure: ProposalResult };
+
+// Turns a model's intent to write into a PendingAction. Every reference it
+// makes (box name, expense id, category, bucket) is resolved against real rows
+// HERE — so a confirmed action can never apply to something invented, and an
+// unresolvable reference comes back as a soft error with the valid options.
+export class AssistantWriteTools implements IAssistantWriteTools {
+  constructor(
+    private readonly pendingActionRepository: IPendingActionRepository,
+    private readonly expenseRepository: IExpenseRepository,
+    private readonly categoryRepository: ICategoryRepository,
+    private readonly boxRepository: IBoxRepository,
+  ) {}
+
+  async proposeRecurring(
+    userId: string,
+    input: {
+      kind: "INCOME" | "EXPENSE";
+      amount: number;
+      dayOfMonth: number;
+      bucket?: string | undefined;
+      category?: string | undefined;
+      note?: string | undefined;
+    },
+  ): Promise<ProposalResult> {
+    const bucket = await this.resolveBucket(
+      userId,
+      input.bucket,
+      input.category,
+    );
+    if (!bucket.resolved) return bucket.failure;
+
+    const payload = {
+      kind: input.kind,
+      amount: input.amount,
+      dayOfMonth: input.dayOfMonth,
+      ...(bucket.bucket ? { bucket: bucket.bucket } : {}),
+      ...(input.category ? { categoryName: input.category } : {}),
+      ...(input.note ? { note: input.note } : {}),
+    };
+
+    const label = input.note ?? input.category ?? input.kind.toLowerCase();
+    const summary =
+      input.kind === "INCOME"
+        ? `${formatMoney(input.amount)} income (${label}) on day ${input.dayOfMonth} every month`
+        : `${formatMoney(input.amount)} for ${label} on day ${input.dayOfMonth} every month`;
+
+    return this.stage(userId, "SET_RECURRING", payload, summary);
+  }
+
+  async proposeBoxMove(
+    userId: string,
+    input: {
+      box: string;
+      amount: number;
+      direction: "IN" | "OUT";
+      note?: string | undefined;
+    },
+  ): Promise<ProposalResult> {
+    const box = await this.boxRepository.findByNameForUser(userId, input.box);
+    if (!box) {
+      const boxes = await this.boxRepository.listWithBalances(userId);
+      return {
+        ok: false,
+        error: "unknown_box",
+        message: `"${input.box}" is not one of the user's boxes.`,
+        available_boxes: boxes.map((b) => b.name),
+      };
+    }
+
+    const summary =
+      input.direction === "IN"
+        ? `Add ${formatMoney(input.amount)} to ${box.name}`
+        : `Take ${formatMoney(input.amount)} out of ${box.name}`;
+
+    return this.stage(
+      userId,
+      "BOX_MOVE",
+      {
+        boxName: box.name,
+        amount: input.amount,
+        direction: input.direction,
+        ...(input.note ? { note: input.note } : {}),
+      },
+      summary,
+    );
+  }
+
+  async proposeDeleteExpense(
+    userId: string,
+    input: { expenseId: string },
+  ): Promise<ProposalResult> {
+    const expense = await this.expenseRepository.findById(input.expenseId);
+    if (!expense || expense.userId !== userId || expense.isDeleted) {
+      return {
+        ok: false,
+        error: "expense_not_found",
+        message:
+          "No such expense. Call get_recent_expenses and use an id from its rows.",
+      };
+    }
+
+    return this.stage(
+      userId,
+      "DELETE_EXPENSE",
+      { expenseId: expense.id },
+      `Delete ${formatMoney(Number(expense.amount))}${expense.note ? ` (${expense.note})` : ""}`,
+    );
+  }
+
+  async proposeExpenseEdit(
+    userId: string,
+    input: {
+      expenseId: string;
+      amount?: number | undefined;
+      bucket?: string | undefined;
+      category?: string | undefined;
+      note?: string | undefined;
+    },
+  ): Promise<ProposalResult> {
+    const expense = await this.expenseRepository.findById(input.expenseId);
+    if (!expense || expense.userId !== userId || expense.isDeleted) {
+      return {
+        ok: false,
+        error: "expense_not_found",
+        message:
+          "No such expense. Call get_recent_expenses and use an id from its rows.",
+      };
+    }
+
+    const bucket = await this.resolveBucket(
+      userId,
+      input.bucket,
+      input.category,
+    );
+    if (!bucket.resolved) return bucket.failure;
+
+    const changes: string[] = [];
+    if (input.amount !== undefined) {
+      changes.push(
+        `amount ${formatMoney(Number(expense.amount))} → ${formatMoney(input.amount)}`,
+      );
+    }
+    if (input.category) changes.push(`category → ${input.category}`);
+    if (bucket.bucket)
+      changes.push(`bucket → ${BUCKET_META[bucket.bucket].label}`);
+    if (input.note) changes.push(`note → "${input.note}"`);
+
+    if (changes.length === 0) {
+      return {
+        ok: false,
+        error: "no_changes",
+        message: "Nothing to change — send at least one new value.",
+      };
+    }
+
+    return this.stage(
+      userId,
+      "EDIT_EXPENSE",
+      {
+        expenseId: expense.id,
+        ...(input.amount !== undefined ? { amount: input.amount } : {}),
+        ...(bucket.bucket ? { bucket: bucket.bucket } : {}),
+        ...(input.category ? { categoryName: input.category } : {}),
+        ...(input.note ? { note: input.note } : {}),
+      },
+      changes.join(", "),
+    );
+  }
+
+  // A named category's own bucket wins over whatever the model guessed — the
+  // same rule ExpenseProcessor applies when logging.
+  private async resolveBucket(
+    userId: string,
+    bucket: string | undefined,
+    category: string | undefined,
+  ): Promise<ResolvedBucket> {
+    if (category) {
+      const row = await this.categoryRepository.findByNameForUser(
+        userId,
+        category,
+      );
+      if (!row) {
+        const all = await this.categoryRepository.findAllForUser(userId);
+        return {
+          resolved: false,
+          failure: {
+            ok: false,
+            error: "unknown_category",
+            message: `"${category}" is not one of the user's categories.`,
+            available_categories: all
+              .filter((c) => !c.isGroup)
+              .map((c) => c.name),
+          },
+        };
+      }
+      return { resolved: true, bucket: row.bucket };
+    }
+
+    if (bucket === undefined) return { resolved: true, bucket: undefined };
+    if (!BUCKETS.includes(bucket as Bucket)) {
+      return {
+        resolved: false,
+        failure: {
+          ok: false,
+          error: "invalid_bucket",
+          message: `Bucket must be one of ${BUCKETS.join(", ")}.`,
+        },
+      };
+    }
+    return { resolved: true, bucket: bucket as Bucket };
+  }
+
+  private async stage(
+    userId: string,
+    kind: keyof typeof PENDING_ACTION_SCHEMAS,
+    payload: unknown,
+    summary: string,
+  ): Promise<ProposalResult> {
+    // Validate before storing as well as on read: a malformed proposal should
+    // fail now, where the model can fix it, not at confirmation time.
+    const parsed = PENDING_ACTION_SCHEMAS[kind].safeParse(payload);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: "invalid_proposal",
+        message: parsed.error.issues.map((i) => i.message).join("; "),
+      };
+    }
+
+    const row = await this.pendingActionRepository.create({
+      userId,
+      kind,
+      payload: parsed.data,
+      summary,
+      ttlMinutes: TTL_MINUTES,
+    });
+
+    return { ok: true, pendingId: row.id, summary };
+  }
+}

--- a/src/application/use-cases/query/FinancialDataTools.spec.ts
+++ b/src/application/use-cases/query/FinancialDataTools.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { FinancialDataTools } from "./FinancialDataTools";
 
 const user = {
@@ -7,6 +7,13 @@ const user = {
   payday: 1,
   currency: "INR",
   locale: "en-IN",
+  timezone: "Asia/Kolkata",
+};
+
+const SPEND: Record<string, number> = {
+  NEEDS: 10000,
+  WANTS: 6000,
+  SAVINGS: 2000,
 };
 
 describe("FinancialDataTools", () => {
@@ -16,21 +23,18 @@ describe("FinancialDataTools", () => {
   let budgetConfigRepository: any;
   let recurringRuleRepository: any;
   let categoryRepository: any;
+  let boxRepository: any;
   let tools: FinancialDataTools;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Mid-cycle so `remainingDays` is stable across runs (payday 1, August).
+    vi.setSystemTime(new Date("2026-08-11T06:00:00Z"));
+
     userRepository = { findById: vi.fn().mockResolvedValue(user) };
     expenseRepository = {
       sumByBucketForMonth: vi.fn((_u, bucket) =>
-        Promise.resolve(
-          (
-            { NEEDS: 10000, WANTS: 6000, SAVINGS: 2000 } as Record<
-              string,
-              number
-            >
-          )[bucket] ?? 0,
-        ),
+        Promise.resolve(SPEND[bucket] ?? 0),
       ),
       categoryTotals: vi
         .fn()
@@ -52,7 +56,26 @@ describe("FinancialDataTools", () => {
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
     recurringRuleRepository = { findByUserId: vi.fn().mockResolvedValue([]) };
-    categoryRepository = { findById: vi.fn().mockResolvedValue(null) };
+    categoryRepository = {
+      findById: vi.fn().mockResolvedValue(null),
+      findAllForUser: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          name: "Food",
+          bucket: "WANTS",
+          isGroup: false,
+          monthlyBudget: 5000,
+        },
+        {
+          id: "g1",
+          name: "Living",
+          bucket: "NEEDS",
+          isGroup: true,
+          monthlyBudget: null,
+        },
+      ]),
+    };
+    boxRepository = { listWithBalances: vi.fn().mockResolvedValue([]) };
 
     tools = new FinancialDataTools(
       userRepository,
@@ -61,42 +84,238 @@ describe("FinancialDataTools", () => {
       budgetConfigRepository,
       recurringRuleRepository,
       categoryRepository,
+      boxRepository,
     );
   });
 
-  it("computes per-bucket budget/spent/remaining from the 50/30/20 split", async () => {
-    const status = await tools.getPeriodStatus("u1");
-    const needs = status.buckets.find((b) => b.bucket === "NEEDS")!;
-    expect(needs.budget).toBe(25000); // 50% of 50000
-    expect(needs.spent).toBe(10000);
-    expect(needs.remaining).toBe(15000);
-    expect(needs.pct).toBe(40);
-    expect(status.currency).toBe("INR");
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
-  it("returns all buckets when none specified, one when scoped", async () => {
-    const all = await tools.getSpendByBucket("u1", {});
-    expect(all).toHaveLength(3);
-    const wants = await tools.getSpendByBucket("u1", {}, "WANTS");
-    expect(wants).toEqual([{ bucket: "WANTS", total: 6000 }]);
+  describe("getPeriodStatus", () => {
+    it("computes per-bucket budget/spent/remaining from the 50/30/20 split", async () => {
+      const status = await tools.getPeriodStatus("u1");
+      const needs = status.buckets.find((b) => b.bucket === "NEEDS")!;
+      expect(needs.budget).toBe("₹25,000"); // 50% of 50000
+      expect(needs.spent).toBe("₹10,000");
+      expect(needs.remaining).toBe("₹15,000");
+      expect(needs.pct).toBe(40);
+      expect(status.currency).toBe("INR");
+    });
+
+    it("decides the bucket status server-side so the model never compares", async () => {
+      expenseRepository.sumByBucketForMonth = vi.fn((_u, bucket) =>
+        Promise.resolve(
+          { NEEDS: 24000, WANTS: 20000, SAVINGS: 0 }[bucket as string] ?? 0,
+        ),
+      );
+      const status = await tools.getPeriodStatus("u1");
+      const by = (b: string) => status.buckets.find((x) => x.bucket === b)!;
+
+      expect(by("NEEDS").status).toBe("NEAR_LIMIT"); // 24000/25000 = 96%
+      expect(by("WANTS").status).toBe("OVER"); // 20000/15000 = 133%
+      expect(by("SAVINGS").status).toBe("NO_ACTIVITY");
+    });
+
+    it("frames over-target SAVINGS as good, unlike an over-budget WANTS", async () => {
+      expenseRepository.sumByBucketForMonth = vi.fn((_u, bucket) =>
+        Promise.resolve(
+          { NEEDS: 0, WANTS: 20000, SAVINGS: 12000 }[bucket as string] ?? 0,
+        ),
+      );
+      const status = await tools.getPeriodStatus("u1");
+      const by = (b: string) => status.buckets.find((x) => x.bucket === b)!;
+
+      expect(by("SAVINGS").status).toBe("OVER");
+      expect(by("SAVINGS").interpretation).toMatch(/good/i);
+      expect(by("WANTS").interpretation).toMatch(/over budget/i);
+    });
+  });
+
+  describe("date ranges", () => {
+    it("anchors a model-supplied date to the user's timezone, not UTC", async () => {
+      await tools.getSpendByBucket("u1", {
+        from: "2026-08-01",
+        to: "2026-08-01",
+      });
+      const [, , from, to] =
+        expenseRepository.sumByBucketForMonth.mock.calls[0];
+
+      // IST midnight on Aug 1 is 18:30 UTC on Jul 31 — a bare new Date() would
+      // have started the window 5.5h early and swept in Jul 31 evening spends.
+      expect(from.toISOString()).toBe("2026-07-31T18:30:00.000Z");
+      // `to` is inclusive on the wire, so the window covers all of Aug 1.
+      expect(to.toISOString()).toBe("2026-08-01T18:30:00.000Z");
+    });
+
+    it("echoes back the inclusive range it actually used", async () => {
+      const res = await tools.getSpendByBucket("u1", {
+        from: "2026-08-01",
+        to: "2026-08-07",
+      });
+      expect(res.range).toEqual({ from: "2026-08-01", to: "2026-08-07" });
+    });
+
+    it("defaults to the current cycle when no range is given", async () => {
+      const res = await tools.getSpendByBucket("u1", {});
+      expect(res.range).toEqual({ from: "2026-08-01", to: "2026-08-31" });
+    });
+  });
+
+  describe("absence is not zero", () => {
+    it("notes an empty spend result instead of implying ₹0 was spent", async () => {
+      expenseRepository.sumByBucketForMonth = vi.fn().mockResolvedValue(0);
+      const res = await tools.getSpendByBucket("u1", {});
+      expect(res.note).toMatch(/NOT the same as/i);
+    });
+
+    it("notes an empty category result", async () => {
+      expenseRepository.categoryTotals = vi.fn().mockResolvedValue([]);
+      const res = await tools.getSpendByCategory("u1", {});
+      expect(res.note).toMatch(/NOT the same as/i);
+    });
+
+    it("does not add a note when there is real data", async () => {
+      const res = await tools.getSpendByBucket("u1", {});
+      expect(res.note).toBeUndefined();
+    });
+  });
+
+  describe("checkAffordability", () => {
+    // WANTS: 15000 budget − 6000 spent = 9000 remaining.
+    it("returns YES with a decided verdict, not raw operands", async () => {
+      const res = await tools.checkAffordability("u1", 1000, "WANTS");
+      expect(res.verdict).toBe("YES");
+      expect(res.remainingBefore).toBe("₹9,000");
+      expect(res.remainingAfter).toBe("₹8,000");
+      expect(res.reason).toMatch(/fits comfortably/i);
+    });
+
+    it("returns TIGHT when the purchase eats more than half of what's left", async () => {
+      const res = await tools.checkAffordability("u1", 5000, "WANTS");
+      expect(res.verdict).toBe("TIGHT");
+    });
+
+    it("returns NO and a negative remainder when it overshoots", async () => {
+      const res = await tools.checkAffordability("u1", 12000, "WANTS");
+      expect(res.verdict).toBe("NO");
+      expect(res.remainingAfter).toBe("-₹3,000");
+      expect(res.reason).toMatch(/over budget by ₹3,000/i);
+    });
+
+    it("defaults to the WANTS bucket for a discretionary purchase", async () => {
+      const res = await tools.checkAffordability("u1", 100);
+      expect(res.bucket).toBe("WANTS");
+    });
+
+    it("says NO when there is no budget at all rather than inventing one", async () => {
+      userRepository.findById.mockResolvedValue({ ...user, monthlyIncome: 0 });
+      incomeRepository.sumForMonth.mockResolvedValue(0);
+      const res = await tools.checkAffordability("u1", 100, "WANTS");
+      expect(res.verdict).toBe("NO");
+      expect(res.reason).toMatch(/no income recorded/i);
+    });
+  });
+
+  describe("compareCycles", () => {
+    it("computes the direction and delta itself", async () => {
+      // Current cycle spends 18000 total; the previous one 9000.
+      let call = 0;
+      expenseRepository.sumByBucketForMonth = vi.fn(() =>
+        Promise.resolve(call++ < 3 ? 6000 : 3000),
+      );
+      const res = await tools.compareCycles("u1", 1);
+
+      expect(res.cycles[0]!.label).toBe("current");
+      expect(res.cycles[1]!.label).toBe("previous");
+      expect(res.vsPrevious).toMatchObject({
+        direction: "UP",
+        deltaPct: 100,
+        delta: "+₹9,000",
+      });
+    });
+
+    it("warns that the current cycle is partial", async () => {
+      const res = await tools.compareCycles("u1", 1);
+      expect(res.vsPrevious!.note).toMatch(/day 11 of 31/);
+      expect(res.vsPrevious!.note).toMatch(/partial cycle/i);
+    });
+
+    it("reports a sub-5% swing as FLAT rather than a trend", async () => {
+      let call = 0;
+      expenseRepository.sumByBucketForMonth = vi.fn(() =>
+        Promise.resolve(call++ < 3 ? 3400 : 3333),
+      );
+      const res = await tools.compareCycles("u1", 1);
+      expect(res.vsPrevious!.direction).toBe("FLAT");
+    });
+  });
+
+  describe("categories and boxes", () => {
+    it("exposes leaves only — a group can never hold an expense", async () => {
+      const res = await tools.getCategories("u1");
+      expect(res.categories).toEqual([
+        { name: "Food", bucket: "WANTS", monthlyBudget: "₹5,000" },
+      ]);
+    });
+
+    it("reports box progress toward target", async () => {
+      boxRepository.listWithBalances.mockResolvedValue([
+        { name: "New York trip", balance: 5000, targetAmount: 20000 },
+      ]);
+      const res = await tools.getBoxes("u1");
+      expect(res.boxes[0]).toEqual({
+        name: "New York trip",
+        balance: "₹5,000",
+        target: "₹20,000",
+        pctOfTarget: 25,
+      });
+    });
   });
 
   it("passes a bucket filter and limit to categoryTotals", async () => {
     const cats = await tools.getSpendByCategory("u1", {}, "WANTS", 3);
-    expect(cats).toEqual([{ name: "Food", total: 1200 }]);
+    expect(cats.categories).toEqual([{ name: "Food", total: "₹1,200" }]);
     const call = expenseRepository.categoryTotals.mock.calls[0];
     expect(call[3]).toBe("WANTS"); // bucket
     expect(call[4]).toBe(3); // limit
   });
 
-  it("maps recent expenses to ISO dates", async () => {
+  it("formats recent expenses as local dates and formatted amounts", async () => {
     const recent = await tools.getRecentExpenses("u1", { limit: 5 });
-    expect(recent[0]).toMatchObject({
-      amount: 220,
+    expect(recent.rows[0]).toEqual({
+      date: "2026-06-10",
+      amount: "₹220",
       bucket: "WANTS",
       category: "Food",
       note: "lunch",
     });
-    expect(recent[0].date).toBe("2026-06-10T00:00:00.000Z");
+  });
+
+  it("resolves recurring category names in one lookup, not one per rule", async () => {
+    recurringRuleRepository.findByUserId.mockResolvedValue([
+      {
+        kind: "EXPENSE",
+        amount: 8000,
+        dayOfMonth: 1,
+        bucket: "NEEDS",
+        categoryId: "c1",
+        note: "rent",
+      },
+      {
+        kind: "EXPENSE",
+        amount: 199,
+        dayOfMonth: 5,
+        bucket: "WANTS",
+        categoryId: "c1",
+        note: "netflix",
+      },
+    ]);
+    const res = await tools.getRecurringRules("u1");
+
+    expect(res.rules.map((r) => r.category)).toEqual(["Food", "Food"]);
+    expect(res.rules[0]!.amount).toBe("₹8,000");
+    expect(categoryRepository.findAllForUser).toHaveBeenCalledTimes(1);
+    expect(categoryRepository.findById).not.toHaveBeenCalled();
   });
 });

--- a/src/application/use-cases/query/FinancialDataTools.spec.ts
+++ b/src/application/use-cases/query/FinancialDataTools.spec.ts
@@ -259,6 +259,61 @@ describe("FinancialDataTools", () => {
       ]);
     });
 
+    it("collapses the system template and the user's own copy into one entry", async () => {
+      // findAllForUser returns both rows. Left alone, most names appear twice —
+      // duplicated in the tool schema's enum and in what the model reads back.
+      categoryRepository.findAllForUser.mockResolvedValue([
+        {
+          id: "sys",
+          name: "Fuel",
+          bucket: "NEEDS",
+          isGroup: false,
+          monthlyBudget: null,
+          userId: null,
+        },
+        {
+          id: "own",
+          name: "Fuel",
+          bucket: "NEEDS",
+          isGroup: false,
+          monthlyBudget: 2000,
+          userId: "u1",
+        },
+      ]);
+      const res = await tools.getCategories("u1");
+
+      expect(res.categories).toHaveLength(1);
+      // The user's own row wins, so their budget shows rather than the blank template.
+      expect(res.categories[0]).toEqual({
+        name: "Fuel",
+        bucket: "NEEDS",
+        monthlyBudget: "₹2,000",
+      });
+    });
+
+    it("keeps the user's row regardless of which order they come back in", async () => {
+      categoryRepository.findAllForUser.mockResolvedValue([
+        {
+          id: "own",
+          name: "Fuel",
+          bucket: "NEEDS",
+          isGroup: false,
+          monthlyBudget: 2000,
+          userId: "u1",
+        },
+        {
+          id: "sys",
+          name: "Fuel",
+          bucket: "NEEDS",
+          isGroup: false,
+          monthlyBudget: null,
+          userId: null,
+        },
+      ]);
+      const res = await tools.getCategories("u1");
+      expect(res.categories[0]!.monthlyBudget).toBe("₹2,000");
+    });
+
     it("reports box progress toward target", async () => {
       boxRepository.listWithBalances.mockResolvedValue([
         { name: "New York trip", balance: 5000, targetAmount: 20000 },

--- a/src/application/use-cases/query/FinancialDataTools.ts
+++ b/src/application/use-cases/query/FinancialDataTools.ts
@@ -216,8 +216,21 @@ export class FinancialDataTools implements IFinancialDataTools {
     // so offering them to the model just invites uncategorized spends.
     const leaves = all.filter((c) => !c.isGroup);
 
+    // One entry per NAME, preferring the user's own row over the shared system
+    // template. findAllForUser returns both, so without this most names appear
+    // twice — duplicated in the tool schema's enum and in the list the model
+    // reads back to the user.
+    const byName = new Map<string, (typeof leaves)[number]>();
+    for (const c of leaves) {
+      const existing = byName.get(c.name);
+      if (!existing || (existing.userId === null && c.userId === userId)) {
+        byName.set(c.name, c);
+      }
+    }
+    const unique = [...byName.values()];
+
     const result: Categories = {
-      categories: leaves.map((c) => ({
+      categories: unique.map((c) => ({
         name: c.name,
         bucket: c.bucket,
         monthlyBudget:
@@ -226,7 +239,7 @@ export class FinancialDataTools implements IFinancialDataTools {
             : formatMoney(Number(c.monthlyBudget)),
       })),
     };
-    if (leaves.length === 0) result.note = "The user has no categories yet.";
+    if (unique.length === 0) result.note = "The user has no categories yet.";
     return result;
   }
 

--- a/src/application/use-cases/query/FinancialDataTools.ts
+++ b/src/application/use-cases/query/FinancialDataTools.ts
@@ -1,32 +1,61 @@
-import { Bucket } from "@prisma/client";
+import { Bucket, User } from "@prisma/client";
 import {
+  Affordability,
+  Boxes,
+  BucketBudgetStatus,
+  BucketStatus,
+  Categories,
+  CycleComparison,
+  CycleSummary,
   DateRange,
   IFinancialDataTools,
+  IncomeTotal,
   PeriodStatus,
-  CategoryTotal,
-  RecentExpense,
-  RecurringRuleSummary,
+  RecentExpenses,
+  RecurringRules,
+  ResolvedRange,
+  SpendByBucket,
+  SpendByCategory,
 } from "../../../domain/services/IFinancialDataTools";
 import { IExpenseRepository } from "../../../domain/repositories/IExpenseRepository";
 import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
 import { IRecurringRuleRepository } from "../../../domain/repositories/IRecurringRuleRepository";
 import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
+import { IBoxRepository } from "../../../domain/repositories/IBoxRepository";
 import { IUserRepository } from "../../../domain/repositories/IUserRepository";
 import {
+  BUCKET_META,
   bucketBudget,
   currentBudgetPeriod,
   effectiveMonthlyIncome,
+  formatMoney,
   pctSpent,
   periodDayInfo,
+  previousCycles,
 } from "../budgetMath";
+import { zonedParts, zonedStartOfDayUtc, zonedYmd } from "../../../utils/time";
 
 const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
 const ORDER: Bucket[] = ["NEEDS", "WANTS", "SAVINGS"];
 
+// A spend swing smaller than this reads as noise, not a trend.
+const FLAT_DELTA_PCT = 5;
+// Above this share of the bucket budget, a bucket is "near limit".
+const NEAR_LIMIT_PCT = 80;
+
+const NO_SPEND_NOTE =
+  "No expenses are recorded for this range. That means nothing was logged — it is NOT the same as the user having spent ₹0.";
+const NO_INCOME_NOTE =
+  "No income is recorded for this range. That means nothing was logged — it is NOT proof the user earned nothing.";
+
 // Read-only data tools for the conversational query agent. Reuses the same
 // repositories + budgetMath as the deterministic processors, so answers match
 // what /status and /report would show. No method ever writes.
+//
+// Everything monetary leaves this class already formatted, and every comparison
+// the answer depends on (bucket status, affordability verdict, cycle direction)
+// is decided here. See the grounding contract on IFinancialDataTools.
 export class FinancialDataTools implements IFinancialDataTools {
   constructor(
     private readonly userRepository: IUserRepository,
@@ -35,52 +64,26 @@ export class FinancialDataTools implements IFinancialDataTools {
     private readonly budgetConfigRepository: IBudgetConfigRepository,
     private readonly recurringRuleRepository: IRecurringRuleRepository,
     private readonly categoryRepository: ICategoryRepository,
+    private readonly boxRepository: IBoxRepository,
   ) {}
 
   async getPeriodStatus(userId: string): Promise<PeriodStatus> {
     const user = await this.requireUser(userId);
-    const config =
-      (await this.budgetConfigRepository.findByUserId(userId)) ?? DEFAULT_SPLIT;
-    const { start, end } = currentBudgetPeriod(user.payday);
-    const { day, daysInPeriod, remainingDays } = periodDayInfo(user.payday);
-    const incomeLogged = await this.incomeRepository.sumForMonth(
-      userId,
-      start,
-      end,
-    );
-    const monthlyIncome = effectiveMonthlyIncome(
-      Number(user.monthlyIncome ?? 0),
-      incomeLogged,
-    );
+    const cycle = await this.cycleFigures(user);
 
     const buckets = await Promise.all(
-      ORDER.map(async (bucket) => {
-        const budget = bucketBudget(monthlyIncome, config, bucket);
-        const spent = await this.expenseRepository.sumByBucketForMonth(
-          userId,
-          bucket,
-          start,
-          end,
-        );
-        return {
-          bucket,
-          budget,
-          spent,
-          remaining: budget - spent,
-          pct: pctSpent(spent, budget),
-        };
-      }),
+      ORDER.map((bucket) => this.bucketStatus(user.id, bucket, cycle)),
     );
 
     return {
       currency: user.currency,
-      periodStart: start.toISOString(),
-      periodEnd: end.toISOString(),
-      day,
-      daysInPeriod,
-      remainingDays,
-      monthlyIncome,
-      incomeLogged,
+      periodStart: zonedYmd(cycle.start, cycle.tz),
+      periodEnd: lastDayOf(cycle.end, cycle.tz),
+      day: cycle.day,
+      daysInPeriod: cycle.daysInPeriod,
+      remainingDays: cycle.remainingDays,
+      monthlyIncome: formatMoney(cycle.monthlyIncome),
+      incomeLogged: formatMoney(cycle.incomeLogged),
       buckets,
     };
   }
@@ -89,13 +92,14 @@ export class FinancialDataTools implements IFinancialDataTools {
     userId: string,
     range: DateRange,
     bucket?: Bucket,
-  ): Promise<Array<{ bucket: Bucket; total: number }>> {
-    const { from, to } = await this.resolveRange(userId, range);
-    const buckets = bucket ? [bucket] : ORDER;
-    return Promise.all(
-      buckets.map(async (b) => ({
+  ): Promise<SpendByBucket> {
+    const user = await this.requireUser(userId);
+    const { from, to, resolved } = this.resolveRange(user, range);
+    const wanted = bucket ? [bucket] : ORDER;
+    const totals = await Promise.all(
+      wanted.map(async (b) => ({
         bucket: b,
-        total: await this.expenseRepository.sumByBucketForMonth(
+        raw: await this.expenseRepository.sumByBucketForMonth(
           userId,
           b,
           from,
@@ -103,6 +107,16 @@ export class FinancialDataTools implements IFinancialDataTools {
         ),
       })),
     );
+
+    const result: SpendByBucket = {
+      range: resolved,
+      buckets: totals.map((t) => ({
+        bucket: t.bucket,
+        total: formatMoney(t.raw),
+      })),
+    };
+    if (totals.every((t) => t.raw === 0)) result.note = NO_SPEND_NOTE;
+    return result;
   }
 
   async getSpendByCategory(
@@ -110,24 +124,36 @@ export class FinancialDataTools implements IFinancialDataTools {
     range: DateRange,
     bucket?: Bucket,
     limit = 5,
-  ): Promise<CategoryTotal[]> {
-    const { from, to } = await this.resolveRange(userId, range);
-    return this.expenseRepository.categoryTotals(
+  ): Promise<SpendByCategory> {
+    const user = await this.requireUser(userId);
+    const { from, to, resolved } = this.resolveRange(user, range);
+    const rows = await this.expenseRepository.categoryTotals(
       userId,
       from,
       to,
       bucket ?? null,
       clamp(limit, 1, 20),
     );
+
+    const result: SpendByCategory = {
+      range: resolved,
+      categories: rows.map((r) => ({
+        name: r.name,
+        total: formatMoney(r.total),
+      })),
+    };
+    if (rows.length === 0) result.note = NO_SPEND_NOTE;
+    return result;
   }
 
-  async getIncome(
-    userId: string,
-    range: DateRange,
-  ): Promise<{ total: number }> {
-    const { from, to } = await this.resolveRange(userId, range);
+  async getIncome(userId: string, range: DateRange): Promise<IncomeTotal> {
+    const user = await this.requireUser(userId);
+    const { from, to, resolved } = this.resolveRange(user, range);
     const total = await this.incomeRepository.sumForMonth(userId, from, to);
-    return { total };
+
+    const result: IncomeTotal = { range: resolved, total: formatMoney(total) };
+    if (total === 0) result.note = NO_INCOME_NOTE;
+    return result;
   }
 
   async getRecentExpenses(
@@ -137,70 +163,453 @@ export class FinancialDataTools implements IFinancialDataTools {
       category?: string | undefined;
       range?: DateRange | undefined;
     },
-  ): Promise<RecentExpense[]> {
+  ): Promise<RecentExpenses> {
+    const user = await this.requireUser(userId);
     // No default range here — "recent" spans all time unless the user narrows it.
-    const range = opts.range
-      ? await this.resolveRange(userId, opts.range)
-      : undefined;
+    const resolved = opts.range ? this.resolveRange(user, opts.range) : null;
     const rows = await this.expenseRepository.findRecent(userId, {
       limit: clamp(opts.limit ?? 10, 1, 50),
       categoryName: opts.category,
-      from: range?.from,
-      to: range?.to,
+      from: resolved?.from,
+      to: resolved?.to,
     });
-    return rows.map((r) => ({
-      date: r.date.toISOString(),
-      amount: r.amount,
-      bucket: r.bucket,
-      category: r.categoryName,
-      note: r.note,
-    }));
+
+    const result: RecentExpenses = {
+      rows: rows.map((r) => ({
+        id: r.id,
+        date: zonedYmd(r.date, user.timezone),
+        amount: formatMoney(r.amount),
+        bucket: r.bucket,
+        category: r.categoryName,
+        note: r.note,
+      })),
+    };
+    if (rows.length === 0) result.note = NO_SPEND_NOTE;
+    return result;
   }
 
-  async getRecurringRules(userId: string): Promise<RecurringRuleSummary[]> {
+  async getRecurringRules(userId: string): Promise<RecurringRules> {
     const rules = await this.recurringRuleRepository.findByUserId(userId);
-    return Promise.all(
-      rules.map(async (r) => {
-        let category: string | null = null;
-        if (r.categoryId) {
-          const c = await this.categoryRepository.findById(r.categoryId);
-          category = c?.name ?? null;
-        }
+    // One lookup for the whole taxonomy instead of one per rule.
+    const categories = await this.categoryRepository.findAllForUser(userId);
+    const nameById = new Map(categories.map((c) => [c.id, c.name]));
+
+    const result: RecurringRules = {
+      rules: rules.map((r) => ({
+        kind: r.kind,
+        amount: formatMoney(Number(r.amount)),
+        dayOfMonth: r.dayOfMonth,
+        bucket: r.bucket ?? null,
+        category: r.categoryId ? (nameById.get(r.categoryId) ?? null) : null,
+        note: r.note ?? null,
+      })),
+    };
+    if (rules.length === 0) {
+      result.note = "The user has no recurring rules set up.";
+    }
+    return result;
+  }
+
+  async getCategories(userId: string): Promise<Categories> {
+    const all = await this.categoryRepository.findAllForUser(userId);
+    // Leaves only. Groups are containers — an expense can never attach to one,
+    // so offering them to the model just invites uncategorized spends.
+    const leaves = all.filter((c) => !c.isGroup);
+
+    const result: Categories = {
+      categories: leaves.map((c) => ({
+        name: c.name,
+        bucket: c.bucket,
+        monthlyBudget:
+          c.monthlyBudget === null
+            ? null
+            : formatMoney(Number(c.monthlyBudget)),
+      })),
+    };
+    if (leaves.length === 0) result.note = "The user has no categories yet.";
+    return result;
+  }
+
+  async getBoxes(userId: string): Promise<Boxes> {
+    const boxes = await this.boxRepository.listWithBalances(userId);
+
+    const result: Boxes = {
+      boxes: boxes.map((b) => {
+        const target = b.targetAmount === null ? null : Number(b.targetAmount);
         return {
-          kind: r.kind,
-          amount: Number(r.amount),
-          dayOfMonth: r.dayOfMonth,
-          bucket: r.bucket ?? null,
-          category,
-          note: r.note ?? null,
+          name: b.name,
+          balance: formatMoney(b.balance),
+          target: target === null ? null : formatMoney(target),
+          pctOfTarget:
+            target === null || target <= 0
+              ? null
+              : Math.round((b.balance / target) * 100),
         };
       }),
-    );
+    };
+    if (boxes.length === 0) result.note = "The user has no boxes yet.";
+    return result;
   }
 
-  private async requireUser(userId: string) {
+  async compareCycles(userId: string, cycles = 1): Promise<CycleComparison> {
+    const user = await this.requireUser(userId);
+    const tz = user.timezone;
+    const now = new Date();
+    const n = clamp(cycles, 1, 6);
+
+    const current = currentBudgetPeriod(user.payday, now, tz);
+    const windows = [current, ...previousCycles(user.payday, n, now, tz)];
+    const scored = await Promise.all(
+      windows.map((w, i) => this.cycleSummary(userId, w, cycleLabel(i), tz)),
+    );
+
+    const { day, daysInPeriod } = periodDayInfo(user.payday, now, tz);
+    return {
+      cycles: scored.map((s) => s.summary),
+      vsPrevious: cycleDelta(scored, day, daysInPeriod),
+    };
+  }
+
+  async checkAffordability(
+    userId: string,
+    amount: number,
+    bucket: Bucket = "WANTS",
+  ): Promise<Affordability> {
+    const user = await this.requireUser(userId);
+    const cycle = await this.cycleFigures(user);
+    const { budget, remaining: remainingBefore } = await this.bucketFigures(
+      user.id,
+      bucket,
+      cycle,
+    );
+
+    const remainingAfter = remainingBefore - amount;
+    const days = cycle.remainingDays;
+    const verdict: Affordability["verdict"] =
+      budget <= 0 || remainingBefore <= 0 || remainingAfter < 0
+        ? "NO"
+        : remainingAfter < remainingBefore / 2
+          ? "TIGHT"
+          : "YES";
+
+    return {
+      amount: formatMoney(amount),
+      bucket,
+      verdict,
+      remainingBefore: money(remainingBefore),
+      remainingAfter: money(remainingAfter),
+      daysLeft: days,
+      safeDailyBefore: formatMoney(safeDaily(remainingBefore, days)),
+      safeDailyAfter: formatMoney(safeDaily(remainingAfter, days)),
+      reason: affordabilityReason(
+        verdict,
+        bucket,
+        budget,
+        remainingBefore,
+        remainingAfter,
+        days,
+      ),
+    };
+  }
+
+  // The cycle-wide numbers every budget answer is derived from. Loaded once per
+  // tool call so payday/timezone/income are read exactly one way.
+  private async cycleFigures(user: User): Promise<CycleFigures> {
+    const tz = user.timezone;
+    const now = new Date();
+    const config =
+      (await this.budgetConfigRepository.findByUserId(user.id)) ??
+      DEFAULT_SPLIT;
+    const { start, end } = currentBudgetPeriod(user.payday, now, tz);
+    const { day, daysInPeriod, remainingDays } = periodDayInfo(
+      user.payday,
+      now,
+      tz,
+    );
+    const incomeLogged = await this.incomeRepository.sumForMonth(
+      user.id,
+      start,
+      end,
+    );
+    return {
+      tz,
+      config,
+      start,
+      end,
+      day,
+      daysInPeriod,
+      remainingDays,
+      incomeLogged,
+      monthlyIncome: effectiveMonthlyIncome(
+        Number(user.monthlyIncome ?? 0),
+        incomeLogged,
+      ),
+    };
+  }
+
+  private async bucketFigures(
+    userId: string,
+    bucket: Bucket,
+    cycle: CycleFigures,
+  ): Promise<{ budget: number; spent: number; remaining: number }> {
+    const budget = bucketBudget(cycle.monthlyIncome, cycle.config, bucket);
+    const spent = await this.expenseRepository.sumByBucketForMonth(
+      userId,
+      bucket,
+      cycle.start,
+      cycle.end,
+    );
+    return { budget, spent, remaining: budget - spent };
+  }
+
+  private async bucketStatus(
+    userId: string,
+    bucket: Bucket,
+    cycle: CycleFigures,
+  ): Promise<BucketStatus> {
+    const { budget, spent, remaining } = await this.bucketFigures(
+      userId,
+      bucket,
+      cycle,
+    );
+    const pct = pctSpent(spent, budget);
+    const status = bucketStatusOf(spent, budget, pct);
+    return {
+      bucket,
+      budget: formatMoney(budget),
+      spent: formatMoney(spent),
+      remaining: money(remaining),
+      pct,
+      safeDaily: formatMoney(safeDaily(remaining, cycle.remainingDays)),
+      status,
+      interpretation: interpretBucket(bucket, status, budget, remaining),
+    };
+  }
+
+  private async cycleSummary(
+    userId: string,
+    window: { start: Date; end: Date },
+    label: string,
+    tz: string,
+  ): Promise<ScoredCycle> {
+    const [buckets, income] = await Promise.all([
+      Promise.all(
+        ORDER.map(async (b) => ({
+          bucket: b,
+          raw: await this.expenseRepository.sumByBucketForMonth(
+            userId,
+            b,
+            window.start,
+            window.end,
+          ),
+        })),
+      ),
+      this.incomeRepository.sumForMonth(userId, window.start, window.end),
+    ]);
+
+    const rawTotal = buckets.reduce((s, b) => s + b.raw, 0);
+    return {
+      rawTotal,
+      summary: {
+        label,
+        start: zonedYmd(window.start, tz),
+        end: lastDayOf(window.end, tz),
+        total: formatMoney(rawTotal),
+        buckets: buckets.map((b) => ({
+          bucket: b.bucket,
+          total: formatMoney(b.raw),
+        })),
+        income: formatMoney(income),
+      },
+    };
+  }
+
+  private async requireUser(userId: string): Promise<User> {
     const user = await this.userRepository.findById(userId);
     if (!user) throw new Error(`FinancialDataTools: user ${userId} not found`);
     return user;
   }
 
-  // Resolve an ISO range to concrete Dates, defaulting to the current cycle.
-  private async resolveRange(
-    userId: string,
+  // Resolve a caller-facing range (YYYY-MM-DD in the user's timezone, `to`
+  // INCLUSIVE) to the half-open [from, to) the repositories expect. Defaults to
+  // the current budget cycle. Dates are anchored to the user's wall clock, not
+  // the server's — a 00:30 IST spend must land on the day the user calls it.
+  private resolveRange(
+    user: User,
     range: DateRange,
-  ): Promise<{ from: Date; to: Date }> {
-    const user = await this.requireUser(userId);
-    const period = currentBudgetPeriod(user.payday);
-    const from = parseDate(range.from) ?? period.start;
-    const to = parseDate(range.to) ?? period.end;
-    return { from, to };
+  ): { from: Date; to: Date; resolved: ResolvedRange } {
+    const tz = tzOf(user);
+    const period = currentBudgetPeriod(user.payday, new Date(), tz);
+    const from = parseZonedDate(range.from, tz) ?? period.start;
+    const toInclusive = parseZonedDate(range.to, tz);
+    const to = toInclusive ? addDaysZoned(toInclusive, 1, tz) : period.end;
+    return {
+      from,
+      to,
+      resolved: { from: zonedYmd(from, tz), to: lastDayOf(to, tz) },
+    };
   }
 }
 
-function parseDate(iso?: string): Date | null {
+// Cycle-wide numbers, loaded once and threaded through the per-bucket helpers.
+interface CycleFigures {
+  tz: string;
+  config: { needsPct: number; wantsPct: number; savingsPct: number };
+  start: Date;
+  end: Date; // exclusive
+  day: number;
+  daysInPeriod: number;
+  remainingDays: number;
+  incomeLogged: number;
+  monthlyIncome: number;
+}
+
+// A cycle summary plus the raw total behind it, so deltas are computed from
+// numbers rather than parsed back out of formatted strings.
+interface ScoredCycle {
+  summary: CycleSummary;
+  rawTotal: number;
+}
+
+function tzOf(user: User): string {
+  return user.timezone;
+}
+
+function cycleLabel(index: number): string {
+  if (index === 0) return "current";
+  if (index === 1) return "previous";
+  return `${index} cycles ago`;
+}
+
+// Direction and delta are decided here so the model never subtracts two totals
+// itself — and so a 3-days-in cycle can't be reported as a real drop.
+function cycleDelta(
+  scored: ScoredCycle[],
+  day: number,
+  daysInPeriod: number,
+): CycleComparison["vsPrevious"] {
+  const [current, previous] = scored;
+  if (!current || !previous) return null;
+
+  const delta = current.rawTotal - previous.rawTotal;
+  const deltaPct =
+    previous.rawTotal > 0 ? Math.round((delta / previous.rawTotal) * 100) : 0;
+  const direction =
+    previous.rawTotal === 0
+      ? current.rawTotal > 0
+        ? "UP"
+        : "FLAT"
+      : Math.abs(deltaPct) < FLAT_DELTA_PCT
+        ? "FLAT"
+        : delta > 0
+          ? "UP"
+          : "DOWN";
+
+  return {
+    direction,
+    deltaPct,
+    delta: signedMoney(delta),
+    note: `The current cycle is only day ${day} of ${daysInPeriod}, so this compares a partial cycle against a complete one. Say so when reporting it.`,
+  };
+}
+
+// Parse "YYYY-MM-DD" (or an ISO timestamp — the date part wins) as midnight in
+// the user's timezone. Bare `new Date(iso)` would give UTC midnight, which is
+// 5.5h off an IST cycle boundary.
+function parseZonedDate(iso: string | undefined, tz: string): Date | null {
   if (!iso) return null;
-  const d = new Date(iso);
-  return Number.isNaN(d.getTime()) ? null : d;
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso.trim());
+  if (!m) return null;
+  return zonedStartOfDayUtc(Number(m[1]), Number(m[2]), Number(m[3]), tz);
+}
+
+function addDaysZoned(date: Date, days: number, tz: string): Date {
+  const p = zonedParts(date, tz);
+  return zonedStartOfDayUtc(p.year, p.month, p.day + days, tz);
+}
+
+// The inclusive last day of a half-open range ending at `end`.
+function lastDayOf(end: Date, tz: string): string {
+  return zonedYmd(new Date(end.getTime() - 1), tz);
+}
+
+function safeDaily(remaining: number, days: number): number {
+  if (remaining <= 0 || days <= 0) return 0;
+  return remaining / days;
+}
+
+function bucketStatusOf(
+  spent: number,
+  budget: number,
+  pct: number,
+): BucketBudgetStatus {
+  if (spent <= 0) return "NO_ACTIVITY";
+  if (budget <= 0) return "OVER";
+  if (pct > 100) return "OVER";
+  if (pct >= NEAR_LIMIT_PCT) return "NEAR_LIMIT";
+  return "ON_TRACK";
+}
+
+// Over-spending WANTS is a problem; over-saving is the goal. The model should
+// never have to infer that difference, so we state it.
+function interpretBucket(
+  bucket: Bucket,
+  status: BucketBudgetStatus,
+  budget: number,
+  remaining: number,
+): string {
+  const label = BUCKET_META[bucket].label;
+  if (budget <= 0) {
+    return `No ${label} budget is set — the user has no income recorded this cycle.`;
+  }
+  if (bucket === "SAVINGS") {
+    return status === "OVER"
+      ? `${label} is above target by ${formatMoney(Math.abs(remaining))} — that is good.`
+      : `${label} is ${formatMoney(remaining)} short of target.`;
+  }
+  switch (status) {
+    case "OVER":
+      return `${label} is over budget by ${formatMoney(Math.abs(remaining))}.`;
+    case "NEAR_LIMIT":
+      return `${label} is close to its limit — ${formatMoney(remaining)} left.`;
+    case "NO_ACTIVITY":
+      return `Nothing has been logged in ${label} this cycle.`;
+    default:
+      return `${label} is on track — ${formatMoney(remaining)} left.`;
+  }
+}
+
+function affordabilityReason(
+  verdict: Affordability["verdict"],
+  bucket: Bucket,
+  budget: number,
+  remainingBefore: number,
+  remainingAfter: number,
+  days: number,
+): string {
+  const label = BUCKET_META[bucket].label;
+  if (verdict === "NO") {
+    if (budget <= 0) {
+      return `There is no ${label} budget to check against — the user has no income recorded this cycle.`;
+    }
+    return remainingBefore <= 0
+      ? `${label} is already out of budget this cycle.`
+      : `It would put ${label} over budget by ${formatMoney(Math.abs(remainingAfter))}.`;
+  }
+  const after = formatMoney(safeDaily(remainingAfter, days));
+  return verdict === "TIGHT"
+    ? `It fits, but takes more than half of what is left in ${label} — ${formatMoney(remainingAfter)} would remain, ${after}/day for ${days} days.`
+    : `It fits comfortably — ${formatMoney(remainingAfter)} would remain in ${label}, ${after}/day for ${days} days.`;
+}
+
+function money(n: number): string {
+  return n < 0 ? `-${formatMoney(Math.abs(n))}` : formatMoney(n);
+}
+
+function signedMoney(n: number): string {
+  const rounded = Math.round(n);
+  if (rounded === 0) return formatMoney(0);
+  return `${rounded > 0 ? "+" : "-"}${formatMoney(Math.abs(n))}`;
 }
 
 function clamp(n: number, min: number, max: number): number {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -10,7 +10,17 @@ const envSchema = z.object({
   GEMINI_API_KEY: z.string().min(1),
   GEMINI_MODEL: z.string().default("gemini-2.0-flash"),
   OPENAI_API_KEY: z.string().min(1),
+  OPENAI_PARSER_MODEL: z.string().default("gpt-4o-mini"),
   SARVAM_API_KEY: z.string().default(""),
+  // Assistant lane. Blank key / flag off keeps the bot on the existing
+  // deterministic path, so a missing key degrades instead of failing at boot
+  // the way the required keys above do.
+  ANTHROPIC_API_KEY: z.string().default(""),
+  ANTHROPIC_MODEL: z.string().default("claude-sonnet-5"),
+  ASSISTANT_ENABLED: z
+    .string()
+    .default("false")
+    .transform((v) => v === "true" || v === "1"),
   TELEGRAM_BOT_TOKEN: z.string(),
   TELEGRAM_WEBHOOK_SECRET: z.string().min(1),
   // Public URL of the web dashboard, used in the bot's onboarding hand-off.

--- a/src/data/ai/ClaudeAssistantAgent.spec.ts
+++ b/src/data/ai/ClaudeAssistantAgent.spec.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { create } = vi.hoisted(() => ({ create: vi.fn() }));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create };
+  },
+}));
+
+vi.mock("../../config/env", () => ({
+  env: { ANTHROPIC_API_KEY: "test-key", ANTHROPIC_MODEL: "claude-sonnet-5" },
+}));
+
+import { ClaudeAssistantAgent } from "./ClaudeAssistantAgent";
+
+const ctx = {
+  userId: "u1",
+  currency: "INR",
+  payday: 1,
+  monthlyIncome: "₹50,000",
+  today: "2026-08-11",
+  period: {
+    start: "2026-08-01",
+    end: "2026-08-31",
+    day: 11,
+    daysInPeriod: 31,
+    remainingDays: 21,
+  },
+};
+
+const usage = { input_tokens: 100, output_tokens: 20 };
+
+function says(text: string) {
+  return { content: [{ type: "text", text }], usage };
+}
+
+function callsTool(name: string, input: object = {}) {
+  return {
+    content: [{ type: "tool_use", id: "tu_1", name, input }],
+    usage,
+  };
+}
+
+describe("ClaudeAssistantAgent", () => {
+  let tools: any;
+  let writes: any;
+  let agent: ClaudeAssistantAgent;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tools = {
+      getCategories: vi.fn().mockResolvedValue({
+        categories: [
+          { name: "Food", bucket: "WANTS", monthlyBudget: "₹5,000" },
+        ],
+      }),
+      getPeriodStatus: vi.fn().mockResolvedValue({ buckets: [] }),
+      getSpendByCategory: vi.fn().mockResolvedValue({
+        range: { from: "2026-08-01", to: "2026-08-11" },
+        categories: [{ name: "Food", total: "₹1,200" }],
+      }),
+      getRecentExpenses: vi.fn().mockResolvedValue({ rows: [] }),
+      checkAffordability: vi.fn().mockResolvedValue({ verdict: "YES" }),
+      compareCycles: vi.fn().mockResolvedValue({ cycles: [] }),
+      getBoxes: vi.fn().mockResolvedValue({ boxes: [] }),
+      getIncome: vi.fn().mockResolvedValue({ total: "₹0" }),
+      getSpendByBucket: vi.fn().mockResolvedValue({ buckets: [] }),
+      getRecurringRules: vi.fn().mockResolvedValue({ rules: [] }),
+    };
+    writes = {
+      proposeBoxMove: vi.fn(),
+      proposeRecurring: vi.fn(),
+      proposeDeleteExpense: vi.fn(),
+      proposeExpenseEdit: vi.fn(),
+    };
+    agent = new ClaudeAssistantAgent(
+      tools,
+      writes,
+      "test-key",
+      "claude-sonnet-5",
+    );
+  });
+
+  it("returns the answer text with provider metadata for the turn log", async () => {
+    create.mockResolvedValueOnce(says("You spent *₹1,200* on Food."));
+    const answer = await agent.answer("how much on food?", ctx);
+
+    expect(answer.text).toBe("You spent *₹1,200* on Food.");
+    expect(answer.provider).toBe("anthropic");
+    expect(answer.model).toBe("claude-sonnet-5");
+    expect(answer.inputTokens).toBe(100);
+    expect(answer.outputTokens).toBe(20);
+    expect(answer.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("runs a tool round and records the trace", async () => {
+    create
+      .mockResolvedValueOnce(
+        callsTool("get_spend_by_category", { category: "Food" }),
+      )
+      .mockResolvedValueOnce(says("*₹1,200* on Food."));
+
+    const answer = await agent.answer("food spend?", ctx);
+
+    expect(tools.getSpendByCategory).toHaveBeenCalled();
+    expect(answer.toolCalls).toEqual([
+      {
+        name: "get_spend_by_category",
+        args: { category: "Food" },
+        result: expect.objectContaining({ ok: true }),
+      },
+    ]);
+  });
+
+  it("sums token usage across every round, not just the last", async () => {
+    create
+      .mockResolvedValueOnce(callsTool("get_period_status"))
+      .mockResolvedValueOnce(says("all good"));
+
+    const answer = await agent.answer("status?", ctx);
+    expect(answer.inputTokens).toBe(200);
+    expect(answer.outputTokens).toBe(40);
+  });
+
+  it("feeds a tool_result back paired to its tool_use id", async () => {
+    create
+      .mockResolvedValueOnce(callsTool("get_period_status"))
+      .mockResolvedValueOnce(says("done"));
+
+    await agent.answer("status?", ctx);
+
+    const secondCall = create.mock.calls[1]![0];
+    const resultMsg = secondCall.messages[secondCall.messages.length - 1];
+    expect(resultMsg.role).toBe("user");
+    expect(resultMsg.content[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tu_1",
+    });
+  });
+
+  it("hands a failing tool back as data so the model can recover", async () => {
+    tools.getPeriodStatus.mockRejectedValue(new Error("db down"));
+    create
+      .mockResolvedValueOnce(callsTool("get_period_status"))
+      .mockResolvedValueOnce(says("Sorry, I can't reach that right now."));
+
+    const answer = await agent.answer("status?", ctx);
+    expect(answer.text).toContain("can't reach");
+    expect(answer.toolCalls[0]!.result).toMatchObject({
+      ok: false,
+      error: "tool_failed",
+    });
+  });
+
+  it("constrains the category param to the user's real categories", async () => {
+    create.mockResolvedValueOnce(says("ok"));
+    await agent.answer("q", ctx);
+
+    const defs = create.mock.calls[0]![0].tools;
+    const recent = defs.find((t: any) => t.name === "get_recent_expenses");
+    expect(recent.input_schema.properties.category.enum).toEqual(["Food"]);
+  });
+
+  it("flags amounts that appear in no tool result", async () => {
+    create
+      .mockResolvedValueOnce(callsTool("get_spend_by_category", {}))
+      // ₹1,200 is real; ₹9,999 is invented.
+      .mockResolvedValueOnce(says("Food was ₹1,200, so you have ₹9,999 left."));
+
+    const answer = await agent.answer("food?", ctx);
+    expect(answer.ungroundedAmounts).toEqual(["₹9,999"]);
+  });
+
+  it("reports no ungrounded amounts when every figure came from a tool", async () => {
+    create
+      .mockResolvedValueOnce(callsTool("get_spend_by_category", {}))
+      .mockResolvedValueOnce(says("Food was ₹1,200."));
+
+    const answer = await agent.answer("food?", ctx);
+    expect(answer.ungroundedAmounts).toEqual([]);
+  });
+
+  describe("one proposal per turn", () => {
+    // Only one pair of confirm buttons is ever rendered, so a second staged
+    // proposal would leave the button applying one action while the prose
+    // describes another.
+    function twoProposals() {
+      return {
+        content: [
+          {
+            type: "tool_use",
+            id: "tu_1",
+            name: "propose_box_move",
+            input: { box: "Emergency", amount: 5000, direction: "OUT" },
+          },
+          {
+            type: "tool_use",
+            id: "tu_2",
+            name: "propose_box_move",
+            input: { box: "Vacation", amount: 1000, direction: "IN" },
+          },
+        ],
+        usage,
+      };
+    }
+
+    beforeEach(() => {
+      let n = 0;
+      writes.proposeBoxMove = vi.fn(async () => {
+        n += 1;
+        return { ok: true, pendingId: `p${n}`, summary: `proposal ${n}` };
+      });
+    });
+
+    it("stages only the first of two proposals in the same round", async () => {
+      create
+        .mockResolvedValueOnce(twoProposals())
+        .mockResolvedValueOnce(says("done"));
+
+      const a = await agent.answer("move money around", ctx);
+      expect(writes.proposeBoxMove).toHaveBeenCalledTimes(1);
+      expect(a.toolCalls[1]!.result).toMatchObject({
+        ok: false,
+        error: "proposal_already_pending",
+      });
+    });
+
+    it("surfaces the proposal that was actually staged", async () => {
+      create
+        .mockResolvedValueOnce(twoProposals())
+        .mockResolvedValueOnce(says("done"));
+
+      const a = await agent.answer("move money around", ctx);
+      expect(a.pendingAction).toEqual({ id: "p1", summary: "proposal 1" });
+    });
+
+    it("refuses a second proposal in a later round too", async () => {
+      create
+        .mockResolvedValueOnce(
+          callsTool("propose_box_move", {
+            box: "Goa trip",
+            amount: 1,
+            direction: "IN",
+          }),
+        )
+        .mockResolvedValueOnce(
+          callsTool("propose_box_move", {
+            box: "Goa trip",
+            amount: 2,
+            direction: "IN",
+          }),
+        )
+        .mockResolvedValueOnce(says("done"));
+
+      const a = await agent.answer("two things", ctx);
+      expect(writes.proposeBoxMove).toHaveBeenCalledTimes(1);
+      expect(a.pendingAction).toEqual({ id: "p1", summary: "proposal 1" });
+    });
+
+    it("does not count a failed proposal against the guard", async () => {
+      writes.proposeBoxMove = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, error: "unknown_box" })
+        .mockResolvedValueOnce({
+          ok: true,
+          pendingId: "p9",
+          summary: "retried",
+        });
+      create
+        .mockResolvedValueOnce(
+          callsTool("propose_box_move", {
+            box: "Bali",
+            amount: 100,
+            direction: "IN",
+          }),
+        )
+        .mockResolvedValueOnce(
+          callsTool("propose_box_move", {
+            box: "Goa trip",
+            amount: 100,
+            direction: "IN",
+          }),
+        )
+        .mockResolvedValueOnce(says("done"));
+
+      const a = await agent.answer("add to bali", ctx);
+      expect(a.pendingAction).toEqual({ id: "p9", summary: "retried" });
+    });
+
+    it("keeps the guard turn-local — the agent is shared across users", async () => {
+      create
+        .mockResolvedValueOnce(
+          callsTool("propose_box_move", {
+            box: "Goa trip",
+            amount: 100,
+            direction: "IN",
+          }),
+        )
+        .mockResolvedValueOnce(says("done"))
+        .mockResolvedValueOnce(
+          callsTool("propose_box_move", {
+            box: "Goa trip",
+            amount: 100,
+            direction: "IN",
+          }),
+        )
+        .mockResolvedValueOnce(says("done"));
+
+      await agent.answer("first user's turn", ctx);
+      const second = await agent.answer("another turn", ctx);
+
+      // A field on the agent would have blocked this one.
+      expect(second.pendingAction).toBeDefined();
+      expect(writes.proposeBoxMove).toHaveBeenCalledTimes(2);
+    });
+
+    it("still runs reads in the same round as a proposal", async () => {
+      create
+        .mockResolvedValueOnce({
+          content: [
+            { type: "tool_use", id: "tu_1", name: "get_boxes", input: {} },
+            {
+              type: "tool_use",
+              id: "tu_2",
+              name: "propose_box_move",
+              input: { box: "Goa trip", amount: 100, direction: "IN" },
+            },
+          ],
+          usage,
+        })
+        .mockResolvedValueOnce(says("done"));
+
+      const a = await agent.answer("add to goa", ctx);
+      expect(tools.getBoxes).toHaveBeenCalled();
+      expect(writes.proposeBoxMove).toHaveBeenCalledTimes(1);
+      // Trace stays in the model's request order, not completion order.
+      expect(a.toolCalls.map((c) => c.name)).toEqual([
+        "get_boxes",
+        "propose_box_move",
+      ]);
+    });
+  });
+
+  it("caches the system prompt to keep multi-round turns cheap", async () => {
+    create.mockResolvedValueOnce(says("ok"));
+    await agent.answer("q", ctx);
+
+    expect(create.mock.calls[0]![0].system[0]).toMatchObject({
+      cache_control: { type: "ephemeral" },
+    });
+  });
+
+  it("anchors the prompt to the user's local date and cycle", async () => {
+    create.mockResolvedValueOnce(says("ok"));
+    await agent.answer("q", ctx);
+
+    const system = create.mock.calls[0]![0].system[0].text;
+    expect(system).toContain("Today: 2026-08-11");
+    expect(system).toContain("2026-08-01 to 2026-08-31");
+  });
+
+  it("stops after MAX_ROUNDS instead of looping forever", async () => {
+    create.mockResolvedValue(callsTool("get_period_status"));
+    await expect(agent.answer("status?", ctx)).rejects.toThrow(
+      /exceeded tool-call rounds/,
+    );
+    expect(create).toHaveBeenCalledTimes(5);
+  });
+
+  it("throws rather than sending an empty reply", async () => {
+    create.mockResolvedValueOnce({ content: [], usage });
+    await expect(agent.answer("q", ctx)).rejects.toThrow(/no answer/);
+  });
+
+  it("replays prior turns as chat messages", async () => {
+    create.mockResolvedValueOnce(says("ok"));
+    await agent.answer("and last month?", {
+      ...ctx,
+      history: [
+        { role: "user", content: "food spend?", createdAt: new Date() },
+        { role: "model", content: "₹1,200", createdAt: new Date() },
+      ],
+    } as any);
+
+    const messages = create.mock.calls[0]![0].messages;
+    expect(messages.map((m: any) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect(messages[2].content).toBe("and last month?");
+  });
+
+  it("passes the abort signal through to the provider", async () => {
+    create.mockResolvedValueOnce(says("ok"));
+    const controller = new AbortController();
+    await agent.answer("q", { ...ctx, signal: controller.signal });
+
+    expect(create.mock.calls[0]![1]).toMatchObject({
+      signal: controller.signal,
+    });
+  });
+});

--- a/src/data/ai/ClaudeAssistantAgent.ts
+++ b/src/data/ai/ClaudeAssistantAgent.ts
@@ -163,12 +163,15 @@ export class ClaudeAssistantAgent implements IAssistantAgent {
     categoryNames: string[],
   ): Promise<unknown> {
     return runAssistantTool(
-      this.tools,
+      {
+        tools: this.tools,
+        writes: this.writes,
+        userId: ctx.userId,
+        categoryNames,
+        dashboardUrl: ctx.dashboardUrl,
+      },
       req.name,
       req.input,
-      ctx.userId,
-      categoryNames,
-      this.writes,
     );
   }
 
@@ -203,6 +206,7 @@ export class ClaudeAssistantAgent implements IAssistantAgent {
       outputTokens,
       ungroundedAmounts,
       pendingAction: latestProposal(toolCalls),
+      dashboardUrl: requestedDashboard(toolCalls),
     };
   }
 
@@ -228,13 +232,26 @@ How to answer:
 - Say which window your numbers cover; the tools echo back the range they used.
 - If the tools cannot answer the question, say so plainly rather than estimating.
 
-Style: short and skimmable for Telegram. *bold* for key numbers, no preamble, no sign-off. Only discuss the user's budget, spending and income; politely decline anything else.`,
+Questions about Blipko itself — what you can do, how something works, how it helps them, who built it, where the dashboard is — are in scope. Answer them with get_product_info, never from your own knowledge: a feature you invent sends the user looking for something that does not exist. Use open_dashboard when what they want genuinely lives there.
+
+Style: short and skimmable for Telegram. *bold* for key numbers, no preamble, no sign-off. Discuss the user's money and Blipko itself; politely decline anything else.`,
         // The system prompt and tool definitions are identical between turns;
         // caching them cuts input cost sharply on a multi-round conversation.
         cache_control: { type: "ephemeral" },
       },
     ];
   }
+}
+
+// The URL from a successful open_dashboard call, so the caller can render a
+// button. Explicit: the model asks for it, we do not infer it from the text.
+function requestedDashboard(toolCalls: ToolCallRecord[]): string | undefined {
+  for (let i = toolCalls.length - 1; i >= 0; i--) {
+    const call = toolCalls[i]!;
+    const r = call.result as { ok?: boolean; url?: string } | undefined;
+    if (call.name === "open_dashboard" && r?.ok === true && r.url) return r.url;
+  }
+  return undefined;
 }
 
 function isProposal(toolName: string): boolean {

--- a/src/data/ai/ClaudeAssistantAgent.ts
+++ b/src/data/ai/ClaudeAssistantAgent.ts
@@ -1,0 +1,277 @@
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  AssistantAnswer,
+  AssistantContext,
+  IAssistantAgent,
+  ToolCallRecord,
+} from "../../domain/services/IAssistantAgent";
+import { IFinancialDataTools } from "../../domain/services/IFinancialDataTools";
+import { IAssistantWriteTools } from "../../domain/services/IAssistantWriteTools";
+import { buildAssistantTools, runAssistantTool } from "./assistantTools";
+import { trimHistory } from "./historyTrimmer";
+import { findUngroundedAmounts } from "./groundingCheck";
+import { env } from "../../config/env";
+import { logger } from "../../utils/logger";
+
+const PROVIDER = "anthropic";
+const MAX_ROUNDS = 5;
+const MAX_OUTPUT_TOKENS = 1024;
+// Leaves room for the system prompt, tool definitions and this turn's results.
+const MAX_HISTORY_TOKENS = 4000;
+
+// Tool-calling assistant over the user's own financial data.
+//
+// Grounding is enforced by the tool layer, not by pleading in the prompt: every
+// amount arrives pre-formatted, every comparison arrives pre-decided, and the
+// tool schemas name the user's real categories. What is left here is replay
+// fidelity (tool_use/tool_result pairs survive trimming) and measurement
+// (ungroundedAmounts).
+export class ClaudeAssistantAgent implements IAssistantAgent {
+  private client: Anthropic;
+
+  constructor(
+    private readonly tools: IFinancialDataTools,
+    private readonly writes: IAssistantWriteTools | null = null,
+    apiKey: string = env.ANTHROPIC_API_KEY,
+    private readonly model: string = env.ANTHROPIC_MODEL,
+  ) {
+    if (!apiKey) throw new Error("ClaudeAssistantAgent: API key is missing.");
+    this.client = new Anthropic({ apiKey });
+  }
+
+  async answer(
+    question: string,
+    ctx: AssistantContext,
+  ): Promise<AssistantAnswer> {
+    const startedAt = Date.now();
+    const categories = await this.tools.getCategories(ctx.userId);
+    const categoryNames = categories.categories.map((c) => c.name);
+    const toolDefs = buildAssistantTools(categoryNames, this.writes !== null);
+
+    const messages: Anthropic.MessageParam[] = [
+      ...trimHistory(toMessages(ctx.history ?? []), MAX_HISTORY_TOKENS),
+      { role: "user", content: question },
+    ];
+
+    const toolCalls: ToolCallRecord[] = [];
+    let inputTokens = 0;
+    let outputTokens = 0;
+    // Turn-local, NOT instance state — this agent is a singleton shared by every
+    // user, so a field here would leak one user's proposal into another's turn.
+    let proposalMade = false;
+
+    for (let round = 0; round < MAX_ROUNDS; round++) {
+      const response = await this.client.messages.create(
+        {
+          model: this.model,
+          max_tokens: MAX_OUTPUT_TOKENS,
+          system: this.systemPrompt(ctx),
+          tools: toolDefs,
+          messages,
+        },
+        ctx.signal ? { signal: ctx.signal } : {},
+      );
+
+      inputTokens += response.usage.input_tokens;
+      outputTokens += response.usage.output_tokens;
+
+      const requests = response.content.filter(
+        (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+      );
+
+      if (requests.length === 0) {
+        const text = response.content
+          .filter((b): b is Anthropic.TextBlock => b.type === "text")
+          .map((b) => b.text)
+          .join("")
+          .trim();
+        if (!text) {
+          throw new Error("ClaudeAssistantAgent: model returned no answer.");
+        }
+        return this.finish(
+          text,
+          toolCalls,
+          startedAt,
+          inputTokens,
+          outputTokens,
+          ctx,
+        );
+      }
+
+      messages.push({ role: "assistant", content: response.content });
+
+      // Reads fan out; proposals are serialised behind a one-per-turn guard.
+      //
+      // Only ONE pending action can be surfaced (the user gets one pair of
+      // buttons), so allowing several to be staged means the button applies
+      // whichever result happened to resolve last while the prose describes
+      // another. Refusing the second keeps the confirmed action and the
+      // described action the same thing by construction.
+      const reads = requests.filter((r) => !isProposal(r.name));
+      const proposals = requests.filter((r) => isProposal(r.name));
+
+      const results = new Map<string, unknown>();
+      await Promise.all(
+        reads.map(async (req) => {
+          results.set(req.id, await this.callTool(req, ctx, categoryNames));
+        }),
+      );
+      for (const req of proposals) {
+        if (proposalMade) {
+          results.set(req.id, {
+            ok: false,
+            error: "proposal_already_pending",
+            message:
+              "You already proposed a change this turn, and the user can only confirm one at a time. Describe this one and wait for them to ask again.",
+          });
+          continue;
+        }
+        const result = await this.callTool(req, ctx, categoryNames);
+        // Latch immediately, not after the loop — two proposals in the SAME
+        // round would both see `false` otherwise, which is the exact case the
+        // guard exists for.
+        if (isSuccessfulProposal(result)) proposalMade = true;
+        results.set(req.id, result);
+      }
+
+      // Record in the model's original request order, so the trace reads the
+      // way the turn actually happened rather than in completion order.
+      for (const req of requests) {
+        toolCalls.push({
+          name: req.name,
+          args: req.input,
+          result: results.get(req.id),
+        });
+      }
+
+      messages.push({
+        role: "user",
+        content: requests.map((req) => ({
+          type: "tool_result" as const,
+          tool_use_id: req.id,
+          content: JSON.stringify(results.get(req.id)),
+        })),
+      });
+    }
+
+    throw new Error("ClaudeAssistantAgent: exceeded tool-call rounds.");
+  }
+
+  private callTool(
+    req: Anthropic.ToolUseBlock,
+    ctx: AssistantContext,
+    categoryNames: string[],
+  ): Promise<unknown> {
+    return runAssistantTool(
+      this.tools,
+      req.name,
+      req.input,
+      ctx.userId,
+      categoryNames,
+      this.writes,
+    );
+  }
+
+  private finish(
+    text: string,
+    toolCalls: ToolCallRecord[],
+    startedAt: number,
+    inputTokens: number,
+    outputTokens: number,
+    ctx: AssistantContext,
+  ): AssistantAnswer {
+    const ungroundedAmounts = findUngroundedAmounts(
+      text,
+      toolCalls.map((c) => c.result),
+    );
+    if (ungroundedAmounts.length > 0) {
+      logger.warn("Assistant stated amounts absent from every tool result", {
+        component: "assistant",
+        userId: ctx.userId,
+        amounts: ungroundedAmounts,
+        tools: toolCalls.map((c) => c.name),
+      });
+    }
+
+    return {
+      text,
+      toolCalls,
+      model: this.model,
+      provider: PROVIDER,
+      latencyMs: Date.now() - startedAt,
+      inputTokens,
+      outputTokens,
+      ungroundedAmounts,
+      pendingAction: latestProposal(toolCalls),
+    };
+  }
+
+  private systemPrompt(ctx: AssistantContext): Anthropic.TextBlockParam[] {
+    return [
+      {
+        type: "text",
+        text: `You are Blipko, a budgeting assistant in a Telegram chat. The user follows a 50/30/20 budget (NEEDS 50%, WANTS 30%, SAVINGS 20%) on a payday-based cycle.
+
+User context:
+- Currency: ${ctx.currency} (amounts are written with ₹)
+- Today: ${ctx.today}
+- Current cycle: ${ctx.period.start} to ${ctx.period.end} (day ${ctx.period.day} of ${ctx.period.daysInPeriod}, ${ctx.period.remainingDays} left)
+- Payday: day ${ctx.payday} of the month
+- Expected monthly income: ${ctx.monthlyIncome}
+
+How to answer:
+- Every figure you state must appear in a tool result from this conversation. Copy the tool's formatted amounts exactly — do not re-round, re-format, or combine them.
+- Do not calculate. Differences, totals, per-day figures and yes/no verdicts all have a tool that returns them already decided. If you find yourself about to do arithmetic, you are using the wrong tool.
+- Dates you send to tools are YYYY-MM-DD in the user's local time and the end date is INCLUSIVE. Resolve "yesterday"/"last week"/"this month" against today's date above.
+- Honour a "note" on a tool result. An empty result means nothing was logged — never report that as ₹0 spent.
+- On { "ok": false }, read the error and retry with corrected arguments. Never present a failed call as data.
+- Say which window your numbers cover; the tools echo back the range they used.
+- If the tools cannot answer the question, say so plainly rather than estimating.
+
+Style: short and skimmable for Telegram. *bold* for key numbers, no preamble, no sign-off. Only discuss the user's budget, spending and income; politely decline anything else.`,
+        // The system prompt and tool definitions are identical between turns;
+        // caching them cuts input cost sharply on a multi-round conversation.
+        cache_control: { type: "ephemeral" },
+      },
+    ];
+  }
+}
+
+function isProposal(toolName: string): boolean {
+  return toolName.startsWith("propose_");
+}
+
+function isSuccessfulProposal(result: unknown): boolean {
+  const r = result as { ok?: boolean; pendingId?: string; summary?: string };
+  return r?.ok === true && Boolean(r.pendingId) && Boolean(r.summary);
+}
+
+// The turn's proposal. The one-per-turn guard in `answer` means there is at most
+// one, so this is a lookup rather than a tie-break — a revised proposal after a
+// soft error is still the only successful one.
+function latestProposal(
+  toolCalls: ToolCallRecord[],
+): { id: string; summary: string } | undefined {
+  for (let i = toolCalls.length - 1; i >= 0; i--) {
+    const r = toolCalls[i]!.result as { pendingId: string; summary: string };
+    if (isSuccessfulProposal(r)) {
+      return { id: r.pendingId, summary: r.summary };
+    }
+  }
+  return undefined;
+}
+
+// Replay stored turns as real chat messages. Tool traces are NOT replayed as
+// tool_use/tool_result blocks: those would need the original provider block ids
+// to stay valid, and a stale id is rejected outright. The prior answer's text
+// carries the conclusions forward, which is what a follow-up actually needs.
+function toMessages(
+  history: { role: string; content: string }[],
+): Anthropic.MessageParam[] {
+  return history
+    .filter((h) => h.content.trim().length > 0)
+    .map((h) => ({
+      role: h.role === "model" ? ("assistant" as const) : ("user" as const),
+      content: h.content,
+    }));
+}

--- a/src/data/ai/FallbackAiParser.ts
+++ b/src/data/ai/FallbackAiParser.ts
@@ -2,14 +2,9 @@ import { IAiParser, ParseContext } from "../../domain/services/IAiParser";
 import { ParsedBatch } from "../../domain/entities/ParsedData";
 import { withTimeout } from "../../utils/withTimeout";
 import { logger } from "../../utils/logger";
+import { describeError } from "../../utils/describeError";
 
 const log = logger.child({ component: "ai" });
-
-// The logger JSON-stringifies its fields, and an Error serializes to `{}` —
-// which would hide the very Zod message that says what the provider got wrong.
-function describeError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 // A slow/hung provider call must not block the webhook indefinitely.
 const PARSE_TIMEOUT_MS = 12_000;

--- a/src/data/ai/GeminiParser.ts
+++ b/src/data/ai/GeminiParser.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI, Type, Schema } from "@google/genai";
 import { IAiParser, ParseContext } from "../../domain/services/IAiParser";
 import {
+  PARSED_INTENTS,
   ParsedBatch,
   ParsedBatchSchema,
 } from "../../domain/entities/ParsedData";
@@ -16,16 +17,9 @@ const transactionSchema: Schema = {
   properties: {
     intent: {
       type: Type.STRING,
-      enum: [
-        "EXPENSE",
-        "INCOME",
-        "UNDO",
-        "STATUS",
-        "RECURRING",
-        "QUERY",
-        "BOX",
-        "UNKNOWN",
-      ],
+      // Sourced from the domain enum so a new intent can't be valid in Zod but
+      // unreachable in the schema the model is actually given.
+      enum: [...PARSED_INTENTS],
       description:
         'EXPENSE if the user spent money. INCOME if they received money/declared salary. STATUS for a plain overall budget-health check ("status", "how much is left"). UNDO to remove the last entry. RECURRING to set up a repeating monthly income/expense ("every month", "monthly", "on the Nth"). QUERY when the user ASKS a data-backed question about their spending/income/budget ("how much did I spend on food?", "biggest expense?", "can I afford X?", trends/comparisons) — a question, never a statement that logs money. BOX to add money to / withdraw from a NAMED savings goal or fund ("add 5000 to New York", "take 2000 from house fund") — only with explicit box phrasing, never ordinary spending. UNKNOWN for social/non-financial messages.',
     },
@@ -108,8 +102,7 @@ export class GeminiParser implements IAiParser {
   }
 
   async parseText(text: string, ctx: ParseContext): Promise<ParsedBatch> {
-    const today = new Date().toISOString().split("T")[0];
-    const promptText = `[Today: ${today}]\n${text}`;
+    const promptText = `[Today: ${ctx.today}]\n${text}`;
 
     const response = await this.client.models.generateContent({
       model: this.modelName,
@@ -117,7 +110,11 @@ export class GeminiParser implements IAiParser {
       // not as real model turns — see historyBlock.ts.
       contents: [{ role: "user", parts: [{ text: promptText }] }],
       config: {
-        systemInstruction: buildBudgetSystemPrompt(ctx.categories, ctx.history),
+        systemInstruction: buildBudgetSystemPrompt(
+          ctx.categories,
+          ctx.history,
+          ctx.assistantMode,
+        ),
         responseMimeType: "application/json",
         responseSchema: budgetSchema,
         temperature: 0.1,

--- a/src/data/ai/OpenAIParser.ts
+++ b/src/data/ai/OpenAIParser.ts
@@ -22,17 +22,20 @@ export class OpenAIParser implements IAiParser {
   }
 
   async parseText(text: string, ctx: ParseContext): Promise<ParsedBatch> {
-    const today = new Date().toISOString().split("T")[0];
-    const promptText = `[Today: ${today}]\n${text}`;
+    const promptText = `[Today: ${ctx.today}]\n${text}`;
 
     const completion = await this.client.chat.completions.create({
-      model: "gpt-4o-mini",
+      model: env.OPENAI_PARSER_MODEL,
       // History lives inside the system prompt as a bounded data block, not as
       // real assistant turns — see historyBlock.ts.
       messages: [
         {
           role: "system",
-          content: buildBudgetSystemPrompt(ctx.categories, ctx.history),
+          content: buildBudgetSystemPrompt(
+            ctx.categories,
+            ctx.history,
+            ctx.assistantMode,
+          ),
         },
         { role: "user", content: promptText },
       ],

--- a/src/data/ai/OpenAiQueryAgent.spec.ts
+++ b/src/data/ai/OpenAiQueryAgent.spec.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const create = vi.fn();
+
+vi.mock("openai", () => ({
+  default: class {
+    chat = { completions: { create } };
+  },
+}));
+
+// The real module parses process.env at import time and would fail without a
+// full .env; the agent only reads OPENAI_API_KEY.
+vi.mock("../../config/env", () => ({ env: { OPENAI_API_KEY: "test-key" } }));
+
+import { OpenAiQueryAgent } from "./OpenAiQueryAgent";
+
+const ctx = {
+  userId: "u1",
+  currency: "INR",
+  locale: "en-IN",
+  payday: 1,
+  monthlyIncome: "₹50,000",
+  today: "2026-08-11",
+  period: {
+    start: "2026-08-01",
+    end: "2026-08-31",
+    day: 11,
+    daysInPeriod: 31,
+    remainingDays: 21,
+  },
+};
+
+// A completion that asks for one tool call.
+function toolCall(name: string, args: object) {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name, arguments: JSON.stringify(args) },
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function text(content: string) {
+  return { choices: [{ message: { role: "assistant", content } }] };
+}
+
+// The tool result the agent fed back to the model on the Nth round.
+function toolResultAt(round: number): any {
+  const messages = create.mock.calls[round]![0].messages;
+  const last = messages[messages.length - 1];
+  return JSON.parse(last.content);
+}
+
+describe("OpenAiQueryAgent", () => {
+  let tools: any;
+  let agent: OpenAiQueryAgent;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tools = {
+      getCategories: vi.fn().mockResolvedValue({
+        categories: [
+          { name: "Food", bucket: "WANTS", monthlyBudget: "₹5,000" },
+          { name: "Transport", bucket: "NEEDS", monthlyBudget: null },
+        ],
+      }),
+      getBoxes: vi.fn().mockResolvedValue({ boxes: [{ name: "Goa trip" }] }),
+      getPeriodStatus: vi.fn().mockResolvedValue({ buckets: [] }),
+      getSpendByCategory: vi
+        .fn()
+        .mockResolvedValue({ range: {}, categories: [] }),
+      getRecentExpenses: vi.fn().mockResolvedValue({ rows: [] }),
+      checkAffordability: vi.fn().mockResolvedValue({ verdict: "YES" }),
+      compareCycles: vi.fn().mockResolvedValue({ cycles: [] }),
+    };
+    agent = new OpenAiQueryAgent(tools, "test-key");
+  });
+
+  it("returns the model's text once it stops calling tools", async () => {
+    create.mockResolvedValueOnce(text("You spent *₹1,200* on Food."));
+    await expect(agent.answer("how much on food?", ctx)).resolves.toBe(
+      "You spent *₹1,200* on Food.",
+    );
+  });
+
+  describe("schemas are built from the user's real data", () => {
+    it("constrains the category param to categories the user actually has", async () => {
+      create.mockResolvedValueOnce(text("ok"));
+      await agent.answer("q", ctx);
+
+      const schemas = create.mock.calls[0]![0].tools;
+      const recent = schemas.find(
+        (t: any) => t.function.name === "get_recent_expenses",
+      );
+      expect(recent.function.parameters.properties.category.enum).toEqual([
+        "Food",
+        "Transport",
+      ]);
+    });
+
+    it("omits the category param entirely when the user has no categories", async () => {
+      tools.getCategories.mockResolvedValue({ categories: [] });
+      create.mockResolvedValueOnce(text("ok"));
+      await agent.answer("q", ctx);
+
+      const schemas = create.mock.calls[0]![0].tools;
+      const recent = schemas.find(
+        (t: any) => t.function.name === "get_recent_expenses",
+      );
+      expect(recent.function.parameters.properties.category).toBeUndefined();
+    });
+  });
+
+  describe("failures come back as data, not exceptions", () => {
+    it("rejects an unknown category with the valid list so the model can retry", async () => {
+      create
+        .mockResolvedValueOnce(
+          toolCall("get_recent_expenses", { category: "Groceries" }),
+        )
+        .mockResolvedValueOnce(text("done"));
+
+      await agent.answer("spend on groceries?", ctx);
+
+      expect(toolResultAt(1)).toMatchObject({
+        ok: false,
+        error: "unknown_category",
+        available_categories: ["Food", "Transport"],
+      });
+      // The bad filter never reached the data layer — a silent [] would have
+      // been reported to the user as "you spent nothing on groceries".
+      expect(tools.getRecentExpenses).not.toHaveBeenCalled();
+    });
+
+    it("converts a thrown tool error into a soft error instead of killing the turn", async () => {
+      tools.getPeriodStatus.mockRejectedValue(new Error("db is down"));
+      create
+        .mockResolvedValueOnce(toolCall("get_period_status", {}))
+        .mockResolvedValueOnce(text("recovered"));
+
+      await expect(agent.answer("status?", ctx)).resolves.toBe("recovered");
+      expect(toolResultAt(1)).toMatchObject({
+        ok: false,
+        error: "tool_failed",
+      });
+    });
+
+    it("does not leak internal error detail to the model", async () => {
+      // The message is sent to the provider AND persisted in the turn's
+      // toolCalls. Internal throws carry the user's internal id
+      // ("FinancialDataTools: user <cuid> not found") or, for a Prisma
+      // connection failure, the database host and username.
+      tools.getPeriodStatus.mockRejectedValue(
+        new Error("Can't reach database server at db-prod.internal:5432"),
+      );
+      create
+        .mockResolvedValueOnce(toolCall("get_period_status", {}))
+        .mockResolvedValueOnce(text("sorry"));
+
+      await agent.answer("status?", ctx);
+      const result = toolResultAt(1);
+
+      expect(JSON.stringify(result)).not.toContain("db-prod.internal");
+      expect(JSON.stringify(result)).not.toContain("5432");
+    });
+
+    it("reports an unknown tool name rather than silently returning nothing", async () => {
+      create
+        .mockResolvedValueOnce(toolCall("get_crypto_prices", {}))
+        .mockResolvedValueOnce(text("done"));
+
+      await agent.answer("btc?", ctx);
+      expect(toolResultAt(1)).toMatchObject({
+        ok: false,
+        error: "unknown_tool",
+      });
+    });
+
+    it("rejects a non-positive affordability amount", async () => {
+      create
+        .mockResolvedValueOnce(toolCall("check_affordability", { amount: 0 }))
+        .mockResolvedValueOnce(text("done"));
+
+      await agent.answer("can i afford it?", ctx);
+      expect(toolResultAt(1)).toMatchObject({ error: "invalid_amount" });
+      expect(tools.checkAffordability).not.toHaveBeenCalled();
+    });
+
+    it("handles malformed tool arguments", async () => {
+      create
+        .mockResolvedValueOnce({
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [
+                  {
+                    id: "call_1",
+                    type: "function",
+                    function: {
+                      name: "get_period_status",
+                      arguments: "{not json",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce(text("done"));
+
+      await agent.answer("status?", ctx);
+      expect(toolResultAt(1)).toMatchObject({ error: "invalid_arguments" });
+    });
+  });
+
+  it("passes a valid category through to the data layer", async () => {
+    create
+      .mockResolvedValueOnce(
+        toolCall("get_recent_expenses", { category: "Food", limit: 3 }),
+      )
+      .mockResolvedValueOnce(text("done"));
+
+    await agent.answer("last food spends", ctx);
+    expect(tools.getRecentExpenses).toHaveBeenCalledWith("u1", {
+      limit: 3,
+      category: "Food",
+      range: undefined,
+    });
+  });
+
+  it("binds userId server-side even if the model supplies one", async () => {
+    create
+      .mockResolvedValueOnce(
+        toolCall("get_period_status", { userId: "someone-else" }),
+      )
+      .mockResolvedValueOnce(text("done"));
+
+    await agent.answer("status?", ctx);
+    expect(tools.getPeriodStatus).toHaveBeenCalledWith("u1");
+  });
+
+  it("gives up after MAX_ROUNDS of tool calls instead of looping forever", async () => {
+    create.mockResolvedValue(toolCall("get_period_status", {}));
+    await expect(agent.answer("status?", ctx)).rejects.toThrow(
+      /exceeded tool-call rounds/,
+    );
+    expect(create).toHaveBeenCalledTimes(5);
+  });
+
+  it("puts today's date and the cycle window in the system prompt", async () => {
+    create.mockResolvedValueOnce(text("ok"));
+    await agent.answer("q", ctx);
+
+    const system = create.mock.calls[0]![0].messages[0].content;
+    expect(system).toContain("Today: 2026-08-11");
+    expect(system).toContain("2026-08-01 to 2026-08-31");
+  });
+});

--- a/src/data/ai/OpenAiQueryAgent.ts
+++ b/src/data/ai/OpenAiQueryAgent.ts
@@ -1,34 +1,37 @@
 import OpenAI from "openai";
-import { Bucket } from "@prisma/client";
 import {
   IFinancialQueryAgent,
   QueryAgentContext,
 } from "../../domain/services/IFinancialQueryAgent";
-import {
-  DateRange,
-  IFinancialDataTools,
-} from "../../domain/services/IFinancialDataTools";
+import { IFinancialDataTools } from "../../domain/services/IFinancialDataTools";
+import { buildOpenAiTools, runAssistantTool } from "./assistantTools";
 import { env } from "../../config/env";
 
-const BUCKETS = ["NEEDS", "WANTS", "SAVINGS"] as const;
 const MAX_ROUNDS = 5;
 
 // Read-only conversational agent. Given a question, it plans tool calls over the
-// user's real data (IFinancialDataTools) and composes a grounded answer. It can
-// only read — there are no write tools.
+// user's real data and composes a grounded answer. It can only read.
+//
+// The tool catalog, the per-request category enum and the soft-error contract
+// all live in assistantTools.ts, shared with the Claude assistant so the two
+// paths cannot drift. This one is the fallback when the assistant lane is off.
 export class OpenAiQueryAgent implements IFinancialQueryAgent {
   private client: OpenAI;
 
   constructor(
     private readonly tools: IFinancialDataTools,
     apiKey: string = env.OPENAI_API_KEY,
-    private readonly model: string = "gpt-4o-mini",
+    private readonly model: string = env.OPENAI_PARSER_MODEL,
   ) {
     if (!apiKey) throw new Error("OpenAiQueryAgent: API Key is missing.");
     this.client = new OpenAI({ apiKey });
   }
 
   async answer(question: string, ctx: QueryAgentContext): Promise<string> {
+    const categories = await this.tools.getCategories(ctx.userId);
+    const categoryNames = categories.categories.map((c) => c.name);
+    const toolSchemas = buildOpenAiTools(categoryNames);
+
     const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
       { role: "system", content: this.systemPrompt(ctx) },
       ...(ctx.history ?? []).map((h) => ({
@@ -44,7 +47,7 @@ export class OpenAiQueryAgent implements IFinancialQueryAgent {
       const completion = await this.client.chat.completions.create({
         model: this.model,
         messages,
-        tools: TOOL_SCHEMAS,
+        tools: toolSchemas,
         tool_choice: "auto",
         temperature: 0.2,
       });
@@ -54,17 +57,28 @@ export class OpenAiQueryAgent implements IFinancialQueryAgent {
 
       if (msg.tool_calls && msg.tool_calls.length > 0) {
         messages.push(msg);
-        for (const call of msg.tool_calls) {
-          if (call.type !== "function") continue;
-          const result = await this.runTool(
-            call.function.name,
-            call.function.arguments,
-            ctx.userId,
-          );
+        const results = await Promise.all(
+          msg.tool_calls.map(async (call) =>
+            call.type === "function"
+              ? {
+                  id: call.id,
+                  result: await runAssistantTool(
+                    this.tools,
+                    call.function.name,
+                    call.function.arguments,
+                    ctx.userId,
+                    categoryNames,
+                  ),
+                }
+              : null,
+          ),
+        );
+        for (const r of results) {
+          if (!r) continue;
           messages.push({
             role: "tool",
-            tool_call_id: call.id,
-            content: JSON.stringify(result),
+            tool_call_id: r.id,
+            content: JSON.stringify(r.result),
           });
         }
         continue;
@@ -79,173 +93,23 @@ export class OpenAiQueryAgent implements IFinancialQueryAgent {
   }
 
   private systemPrompt(ctx: QueryAgentContext): string {
-    const today = ctx.now.toISOString().split("T")[0];
-    return `You are Blipko's budgeting assistant. The user follows a 50/30/20 budget (NEEDS 50%, WANTS 30%, SAVINGS 20%) on a payday-based cycle. Answer the user's question about THEIR money using the tools — never invent numbers.
+    return `You are Blipko's budgeting assistant. The user follows a 50/30/20 budget (NEEDS 50%, WANTS 30%, SAVINGS 20%) on a payday-based cycle.
 
 User context:
 - Currency: ${ctx.currency} (format amounts with ₹)
-- Today: ${today}
-- Current budget cycle: ${ctx.period.start.split("T")[0]} to ${ctx.period.end.split("T")[0]} (day ${ctx.period.day} of ${ctx.period.daysInPeriod}, ${ctx.period.remainingDays} left)
+- Today: ${ctx.today}
+- Current budget cycle: ${ctx.period.start} to ${ctx.period.end} (day ${ctx.period.day} of ${ctx.period.daysInPeriod}, ${ctx.period.remainingDays} left)
 - Payday: day ${ctx.payday} of the month
 - Expected monthly income: ${ctx.monthlyIncome}
 
 Rules:
-- ALWAYS call tools to get real figures before stating any number. If a tool returns nothing, say there's no data for that — don't guess.
-- Resolve relative dates ("last week", "this month", "yesterday") to explicit ISO from/to using today's date, and pass them to the tools. Omit the range to use the current cycle.
-- For "can I afford X?" use get_period_status: compare the amount to the remaining budget in the relevant bucket and the days left, then give a clear yes/no with the numbers.
-- Keep replies short and skimmable for Telegram. Use Markdown sparingly (*bold* for key numbers). Use ₹ for money. No preamble.
+- Every figure you state must come from a tool result in this conversation. Quote the tool's formatted amounts exactly as given — do not re-format, re-round, or recompute them.
+- Do not do arithmetic. If a question needs a difference, a total, a per-day figure or a yes/no verdict, there is a tool that returns it already computed. Use that tool.
+- Dates you pass to tools are YYYY-MM-DD in the user's local time, and the end date is INCLUSIVE. Resolve "last week"/"yesterday"/"this month" against today's date above. Omit both to use the current cycle.
+- If a tool result carries a "note", honour it — an empty result means nothing was logged, which is NOT the same as the user having spent ₹0.
+- If a tool returns { "ok": false }, read the error and try a corrected call. Never present a failed call as data.
+- State the window you are talking about (the tools echo back the range they used).
+- Keep replies short and skimmable for Telegram. Use Markdown sparingly (*bold* for key numbers). No preamble.
 - Only answer questions about the user's budget/spending/income. Politely decline anything else.`;
   }
-
-  private async runTool(
-    name: string,
-    rawArgs: string,
-    userId: string,
-  ): Promise<unknown> {
-    let args: Record<string, unknown> = {};
-    try {
-      args = rawArgs ? JSON.parse(rawArgs) : {};
-    } catch {
-      return { error: "invalid tool arguments" };
-    }
-    const range: DateRange = {
-      from: asString(args.from),
-      to: asString(args.to),
-    };
-    const bucket = asBucket(args.bucket);
-
-    switch (name) {
-      case "get_period_status":
-        return this.tools.getPeriodStatus(userId);
-      case "get_spend_by_bucket":
-        return this.tools.getSpendByBucket(userId, range, bucket);
-      case "get_spend_by_category":
-        return this.tools.getSpendByCategory(
-          userId,
-          range,
-          bucket,
-          asNumber(args.limit),
-        );
-      case "get_income":
-        return this.tools.getIncome(userId, range);
-      case "get_recent_expenses":
-        return this.tools.getRecentExpenses(userId, {
-          limit: asNumber(args.limit),
-          category: asString(args.category),
-          range: args.from || args.to ? range : undefined,
-        });
-      case "get_recurring_rules":
-        return this.tools.getRecurringRules(userId);
-      default:
-        return { error: `unknown tool: ${name}` };
-    }
-  }
 }
-
-function asString(v: unknown): string | undefined {
-  return typeof v === "string" && v.length > 0 ? v : undefined;
-}
-function asNumber(v: unknown): number | undefined {
-  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
-}
-function asBucket(v: unknown): Bucket | undefined {
-  return typeof v === "string" && (BUCKETS as readonly string[]).includes(v)
-    ? (v as Bucket)
-    : undefined;
-}
-
-const RANGE_PROPS = {
-  from: {
-    type: "string",
-    description: "ISO start date (inclusive). Omit for the current cycle.",
-  },
-  to: {
-    type: "string",
-    description: "ISO end date (exclusive). Omit for the current cycle.",
-  },
-} as const;
-
-const BUCKET_PROP = {
-  bucket: {
-    type: "string",
-    enum: ["NEEDS", "WANTS", "SAVINGS"],
-    description: "Optional 50/30/20 bucket filter.",
-  },
-} as const;
-
-const TOOL_SCHEMAS: OpenAI.Chat.Completions.ChatCompletionTool[] = [
-  {
-    type: "function",
-    function: {
-      name: "get_period_status",
-      description:
-        "Current-cycle budget health: per-bucket budget/spent/remaining/percent, days left, and effective income. Use for overall status and affordability checks.",
-      parameters: { type: "object", properties: {} },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "get_spend_by_bucket",
-      description:
-        "Total spend per bucket over a date range (defaults to the current cycle). Pass a bucket to scope to one.",
-      parameters: {
-        type: "object",
-        properties: { ...RANGE_PROPS, ...BUCKET_PROP },
-      },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "get_spend_by_category",
-      description:
-        "Top spending categories over a date range (defaults to the current cycle), highest first. Optional bucket filter and limit.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...RANGE_PROPS,
-          ...BUCKET_PROP,
-          limit: { type: "number", description: "Max categories (default 5)." },
-        },
-      },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "get_income",
-      description:
-        "Total income logged over a date range (defaults to the current cycle).",
-      parameters: { type: "object", properties: { ...RANGE_PROPS } },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "get_recent_expenses",
-      description:
-        "Most recent expenses, newest first. Optional category name and date range. Use for 'last few spends' or 'when did I last spend on X'.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...RANGE_PROPS,
-          category: {
-            type: "string",
-            description: "Optional category name to filter by.",
-          },
-          limit: { type: "number", description: "Max rows (default 10)." },
-        },
-      },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "get_recurring_rules",
-      description:
-        "The user's active recurring income/expense rules (amount, day of month, bucket, category).",
-      parameters: { type: "object", properties: {} },
-    },
-  },
-];

--- a/src/data/ai/OpenAiQueryAgent.ts
+++ b/src/data/ai/OpenAiQueryAgent.ts
@@ -63,11 +63,14 @@ export class OpenAiQueryAgent implements IFinancialQueryAgent {
               ? {
                   id: call.id,
                   result: await runAssistantTool(
-                    this.tools,
+                    {
+                      tools: this.tools,
+                      userId: ctx.userId,
+                      categoryNames,
+                      dashboardUrl: ctx.dashboardUrl,
+                    },
                     call.function.name,
                     call.function.arguments,
-                    ctx.userId,
-                    categoryNames,
                   ),
                 }
               : null,
@@ -110,6 +113,7 @@ Rules:
 - If a tool returns { "ok": false }, read the error and try a corrected call. Never present a failed call as data.
 - State the window you are talking about (the tools echo back the range they used).
 - Keep replies short and skimmable for Telegram. Use Markdown sparingly (*bold* for key numbers). No preamble.
-- Only answer questions about the user's budget/spending/income. Politely decline anything else.`;
+- Questions about Blipko itself (what you can do, how it works, who built it, the dashboard) are in scope — answer them with get_product_info rather than from your own knowledge. Use open_dashboard when what they want lives there.
+- Politely decline anything outside the user's money and Blipko itself.`;
   }
 }

--- a/src/data/ai/assistantTools.ts
+++ b/src/data/ai/assistantTools.ts
@@ -1,0 +1,504 @@
+import { Bucket } from "@prisma/client";
+import {
+  DateRange,
+  IFinancialDataTools,
+} from "../../domain/services/IFinancialDataTools";
+import { IAssistantWriteTools } from "../../domain/services/IAssistantWriteTools";
+import { logger } from "../../utils/logger";
+import { describeError } from "../../utils/describeError";
+
+// The single source of truth for what the assistant can do. Provider-neutral:
+// each agent renders these into its own schema dialect, so a description or a
+// dispatch rule can never drift between the OpenAI and Anthropic paths.
+//
+// The descriptions carry the anti-hallucination rules. That placement is
+// deliberate — a rule attached to the tool the model is about to pick lands
+// better than the same sentence buried in a system prompt.
+
+const BUCKETS = ["NEEDS", "WANTS", "SAVINGS"] as const;
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  properties: Record<string, unknown>;
+  required: string[];
+}
+
+const RANGE_PROPS = {
+  from: {
+    type: "string",
+    description:
+      "Start date YYYY-MM-DD in the user's local time (inclusive). Omit for the current cycle.",
+  },
+  to: {
+    type: "string",
+    description:
+      "End date YYYY-MM-DD in the user's local time, INCLUSIVE — the whole of this day is counted. Omit for the current cycle.",
+  },
+} as const;
+
+const BUCKET_PROP = {
+  bucket: {
+    type: "string",
+    enum: BUCKETS,
+    description: "Optional 50/30/20 bucket filter.",
+  },
+} as const;
+
+// `categoryNames` become an enum, which is the strongest grounding lever here:
+// the model cannot filter on a category the user does not have, so it cannot
+// invent one to explain a number.
+//
+// `includeWrites` gates the propose_* tools. The read-only query agent omits
+// them entirely rather than exposing tools it has no way to fulfil.
+export function buildToolCatalog(
+  categoryNames: string[],
+  includeWrites = false,
+): ToolDef[] {
+  const categoryProp =
+    categoryNames.length > 0
+      ? {
+          category: {
+            type: "string",
+            enum: categoryNames,
+            description:
+              "Optional category filter. Must be one of the user's own categories.",
+          },
+        }
+      : {};
+
+  return [
+    {
+      name: "get_period_status",
+      description:
+        "Current-cycle budget health per bucket: budget, spent, remaining, percent, safe daily spend, plus a precomputed `status` and a plain-English `interpretation`. Use for overall status. Do not compare the numbers yourself — `status` already says whether a bucket is over, near its limit, or on track.",
+      properties: {},
+      required: [],
+    },
+    {
+      name: "check_affordability",
+      description:
+        "Whether a specific purchase fits the remaining budget. Returns a decided `verdict` (YES / TIGHT / NO) with the figures behind it. ALWAYS use this for 'can I afford X?' — never subtract the amount from a balance yourself.",
+      properties: {
+        amount: {
+          type: "number",
+          description: "The purchase amount to test, in rupees.",
+        },
+        ...BUCKET_PROP,
+      },
+      required: ["amount"],
+    },
+    {
+      name: "compare_cycles",
+      description:
+        "The current budget cycle against recent COMPLETE cycles, with the change already computed (`vsPrevious.direction`, `deltaPct`, `delta`). Use for 'am I spending more than last month?'. The result carries a note about the current cycle being partial — repeat that caveat in your answer.",
+      properties: {
+        cycles: {
+          type: "number",
+          description:
+            "How many previous complete cycles to include (1-6, default 1).",
+        },
+      },
+      required: [],
+    },
+    {
+      name: "get_spend_by_bucket",
+      description:
+        "Total spend per bucket over a date range (defaults to the current cycle). Pass a bucket to scope to one.",
+      properties: { ...RANGE_PROPS, ...BUCKET_PROP },
+      required: [],
+    },
+    {
+      name: "get_spend_by_category",
+      description:
+        "Top spending categories over a date range (defaults to the current cycle), highest first. Use this for category totals rather than adding up individual expenses.",
+      properties: {
+        ...RANGE_PROPS,
+        ...BUCKET_PROP,
+        limit: { type: "number", description: "Max categories (default 5)." },
+      },
+      required: [],
+    },
+    {
+      name: "get_income",
+      description:
+        "Total income logged over a date range (defaults to the current cycle). An empty result means no income was LOGGED, not that the user earned nothing.",
+      properties: { ...RANGE_PROPS },
+      required: [],
+    },
+    {
+      name: "get_recent_expenses",
+      description:
+        "Individual recent expenses, newest first. Use for 'my last few spends' or 'when did I last spend on X'. For a total, use get_spend_by_category — do not add these rows up yourself.",
+      properties: {
+        ...RANGE_PROPS,
+        ...categoryProp,
+        limit: { type: "number", description: "Max rows (default 10)." },
+      },
+      required: [],
+    },
+    {
+      name: "get_categories",
+      description:
+        "The user's categories with their bucket and monthly budget cap, if set.",
+      properties: {},
+      required: [],
+    },
+    {
+      name: "get_boxes",
+      description:
+        "The user's savings boxes (named goals/funds) with balance and progress toward target.",
+      properties: {},
+      required: [],
+    },
+    {
+      name: "get_recurring_rules",
+      description:
+        "The user's active recurring income/expense rules (amount, day of month, bucket, category).",
+      properties: {},
+      required: [],
+    },
+    ...(includeWrites ? writeTools(categoryProp) : []),
+  ];
+}
+
+function writeTools(categoryProp: Record<string, unknown>): ToolDef[] {
+  return [
+    // ── Writes ───────────────────────────────────────────────────────────────
+    // None of these change anything. Each records a proposal and returns a
+    // summary; the user taps a button and a deterministic handler performs the
+    // write. Before calling one, paraphrase back what you are about to do.
+    {
+      name: "propose_recurring",
+      description:
+        "Propose a repeating monthly income or expense (rent, salary, a subscription). Does NOT create it — the user confirms with a button. Confirm the amount, the day of the month and what it is for before calling.",
+      properties: {
+        kind: {
+          type: "string",
+          enum: ["INCOME", "EXPENSE"],
+          description:
+            "INCOME for money coming in, EXPENSE for money going out.",
+        },
+        amount: { type: "number", description: "Amount in rupees." },
+        dayOfMonth: {
+          type: "number",
+          description: "Day of the month it repeats, 1-28.",
+        },
+        ...BUCKET_PROP,
+        category: {
+          type: "string",
+          description: "Category name for an expense rule.",
+        },
+        note: { type: "string", description: "Short label, e.g. 'rent'." },
+      },
+      required: ["kind", "amount", "dayOfMonth"],
+    },
+    {
+      name: "propose_box_move",
+      description:
+        "Propose moving money into or out of one of the user's savings boxes. Does NOT move it — the user confirms with a button. Use get_boxes first if you are unsure which box they mean; never guess between two similar names.",
+      properties: {
+        box: {
+          type: "string",
+          description: "The box name, exactly as listed by get_boxes.",
+        },
+        amount: { type: "number", description: "Amount in rupees." },
+        direction: {
+          type: "string",
+          enum: ["IN", "OUT"],
+          description: "IN adds money to the box, OUT withdraws from it.",
+        },
+        note: { type: "string", description: "Optional short note." },
+      },
+      required: ["box", "amount", "direction"],
+    },
+    {
+      name: "propose_delete_expense",
+      description:
+        "Propose deleting one of the user's expenses. Does NOT delete it — the user confirms with a button. Find the expense with get_recent_expenses first and quote it back so they know which one you mean.",
+      properties: {
+        expenseId: {
+          type: "string",
+          description: "The id from get_recent_expenses.",
+        },
+      },
+      required: ["expenseId"],
+    },
+    {
+      name: "propose_expense_edit",
+      description:
+        "Propose changing an existing expense's amount, bucket, category or note. Does NOT change it — the user confirms with a button. Send only the fields that change.",
+      properties: {
+        expenseId: {
+          type: "string",
+          description: "The id from get_recent_expenses.",
+        },
+        amount: { type: "number", description: "New amount in rupees." },
+        ...BUCKET_PROP,
+        ...categoryProp,
+        note: { type: "string", description: "New note." },
+      },
+      required: ["expenseId"],
+    },
+  ];
+}
+
+// Runs a tool and ALWAYS resolves. A throw would kill the whole turn with no
+// model-visible recovery; a soft error lets it correct itself in-loop.
+export async function runAssistantTool(
+  tools: IFinancialDataTools,
+  name: string,
+  rawArgs: unknown,
+  userId: string,
+  categoryNames: string[],
+  writes: IAssistantWriteTools | null = null,
+): Promise<unknown> {
+  const args = normalizeArgs(rawArgs);
+  if (!args) {
+    return {
+      ok: false,
+      error: "invalid_arguments",
+      message: "Tool arguments were not valid JSON. Retry the call.",
+    };
+  }
+
+  // Reject an unknown category here rather than letting it filter to zero rows
+  // — a silent [] reads to the model as "you spent nothing on that".
+  const category = asString(args.category);
+  if (category && !categoryNames.includes(category)) {
+    return {
+      ok: false,
+      error: "unknown_category",
+      message: `"${category}" is not one of the user's categories.`,
+      available_categories: categoryNames,
+    };
+  }
+
+  const range: DateRange = { from: asString(args.from), to: asString(args.to) };
+  const bucket = asBucket(args.bucket);
+
+  try {
+    const proposal = await dispatchWrite(writes, name, args, userId);
+    if (proposal !== undefined) return proposal;
+
+    const result = await dispatch(tools, name, args, range, bucket, userId);
+    if (result === undefined) {
+      return {
+        ok: false,
+        error: "unknown_tool",
+        message: `No tool named ${name}.`,
+      };
+    }
+    // A dispatch-level validation failure already carries its own ok:false.
+    return "ok" in (result as object) ? result : { ok: true, ...result };
+  } catch (error) {
+    // The message must NOT carry internal detail: it is returned to the model,
+    // sent to the provider, and persisted in ConversationMessage.toolCalls.
+    // `requireUser` throws with the internal user id; a Prisma connection error
+    // embeds the database host and username. Log those, don't publish them.
+    logger.error("Assistant tool failed", {
+      component: "assistant",
+      tool: name,
+      userId,
+      err: describeError(error),
+    });
+    return {
+      ok: false,
+      error: "tool_failed",
+      message:
+        "That lookup failed. Try a different tool, or tell the user you cannot answer right now.",
+    };
+  }
+}
+
+// Returns undefined when `name` is not a write tool, so the caller falls
+// through to the read dispatch.
+async function dispatchWrite(
+  writes: IAssistantWriteTools | null,
+  name: string,
+  args: Record<string, unknown>,
+  userId: string,
+): Promise<unknown | undefined> {
+  if (!name.startsWith("propose_")) return undefined;
+  if (!writes) {
+    return {
+      ok: false,
+      error: "writes_unavailable",
+      message: "This assistant cannot make changes. Answer with data instead.",
+    };
+  }
+
+  const amount = asNumber(args.amount);
+
+  switch (name) {
+    case "propose_recurring": {
+      const kind = args.kind === "INCOME" ? "INCOME" : "EXPENSE";
+      const dayOfMonth = asNumber(args.dayOfMonth);
+      if (amount === undefined || amount <= 0) {
+        return invalid("propose_recurring needs a positive `amount`.");
+      }
+      if (dayOfMonth === undefined || dayOfMonth < 1 || dayOfMonth > 28) {
+        return invalid("`dayOfMonth` must be between 1 and 28.");
+      }
+      return writes.proposeRecurring(userId, {
+        kind,
+        amount,
+        dayOfMonth,
+        bucket: asString(args.bucket),
+        category: asString(args.category),
+        note: asString(args.note),
+      });
+    }
+    case "propose_box_move": {
+      const box = asString(args.box);
+      const direction = args.direction === "OUT" ? "OUT" : "IN";
+      if (!box) return invalid("propose_box_move needs a `box` name.");
+      if (amount === undefined || amount <= 0) {
+        return invalid("propose_box_move needs a positive `amount`.");
+      }
+      return writes.proposeBoxMove(userId, {
+        box,
+        amount,
+        direction,
+        note: asString(args.note),
+      });
+    }
+    case "propose_delete_expense": {
+      const expenseId = asString(args.expenseId);
+      if (!expenseId)
+        return invalid("propose_delete_expense needs `expenseId`.");
+      return writes.proposeDeleteExpense(userId, { expenseId });
+    }
+    case "propose_expense_edit": {
+      const expenseId = asString(args.expenseId);
+      if (!expenseId) return invalid("propose_expense_edit needs `expenseId`.");
+      return writes.proposeExpenseEdit(userId, {
+        expenseId,
+        amount,
+        bucket: asString(args.bucket),
+        category: asString(args.category),
+        note: asString(args.note),
+      });
+    }
+    default:
+      return {
+        ok: false,
+        error: "unknown_tool",
+        message: `No tool named ${name}.`,
+      };
+  }
+}
+
+function invalid(message: string) {
+  return { ok: false, error: "invalid_arguments", message };
+}
+
+async function dispatch(
+  tools: IFinancialDataTools,
+  name: string,
+  args: Record<string, unknown>,
+  range: DateRange,
+  bucket: Bucket | undefined,
+  userId: string,
+): Promise<object | undefined> {
+  switch (name) {
+    case "get_period_status":
+      return tools.getPeriodStatus(userId);
+    case "get_spend_by_bucket":
+      return tools.getSpendByBucket(userId, range, bucket);
+    case "get_spend_by_category":
+      return tools.getSpendByCategory(
+        userId,
+        range,
+        bucket,
+        asNumber(args.limit),
+      );
+    case "get_income":
+      return tools.getIncome(userId, range);
+    case "get_recent_expenses":
+      return tools.getRecentExpenses(userId, {
+        limit: asNumber(args.limit),
+        category: asString(args.category),
+        range: args.from || args.to ? range : undefined,
+      });
+    case "get_recurring_rules":
+      return tools.getRecurringRules(userId);
+    case "get_categories":
+      return tools.getCategories(userId);
+    case "get_boxes":
+      return tools.getBoxes(userId);
+    case "compare_cycles":
+      return tools.compareCycles(userId, asNumber(args.cycles));
+    case "check_affordability": {
+      const amount = asNumber(args.amount);
+      if (amount === undefined || amount <= 0) {
+        return {
+          ok: false,
+          error: "invalid_amount",
+          message: "check_affordability needs a positive `amount`.",
+        };
+      }
+      return tools.checkAffordability(userId, amount, bucket);
+    }
+    default:
+      return undefined;
+  }
+}
+
+// OpenAI hands arguments over as a JSON string; Anthropic as a parsed object.
+function normalizeArgs(raw: unknown): Record<string, unknown> | null {
+  if (raw && typeof raw === "object") return raw as Record<string, unknown>;
+  if (typeof raw !== "string") return {};
+  if (raw.trim() === "") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return null;
+  }
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+function asNumber(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+function asBucket(v: unknown): Bucket | undefined {
+  return typeof v === "string" && (BUCKETS as readonly string[]).includes(v)
+    ? (v as Bucket)
+    : undefined;
+}
+
+// ── Provider renderers ───────────────────────────────────────────────────────
+
+export function buildAssistantTools(
+  categoryNames: string[],
+  includeWrites = false,
+) {
+  return buildToolCatalog(categoryNames, includeWrites).map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: {
+      type: "object" as const,
+      properties: t.properties,
+      required: t.required,
+    },
+  }));
+}
+
+export function buildOpenAiTools(categoryNames: string[]) {
+  return buildToolCatalog(categoryNames).map((t) => ({
+    type: "function" as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: {
+        type: "object",
+        properties: t.properties,
+        required: t.required,
+        additionalProperties: false,
+      },
+    },
+  }));
+}

--- a/src/data/ai/assistantTools.ts
+++ b/src/data/ai/assistantTools.ts
@@ -4,6 +4,7 @@ import {
   IFinancialDataTools,
 } from "../../domain/services/IFinancialDataTools";
 import { IAssistantWriteTools } from "../../domain/services/IAssistantWriteTools";
+import { buildProductFacts } from "../../domain/productFacts";
 import { logger } from "../../utils/logger";
 import { describeError } from "../../utils/describeError";
 
@@ -158,6 +159,40 @@ export function buildToolCatalog(
       properties: {},
       required: [],
     },
+    {
+      name: "get_product_info",
+      description:
+        "Facts about Blipko itself: what it is, what it can do, the commands, the dashboard, how your data is handled, and who built it. Use this for ANY question about the product — 'what can you do?', 'how does this work?', 'who made you?', 'how does this help me?'. Never answer those from your own knowledge: this returns the truth for THIS build, and anything you invent will send the user looking for a feature that does not exist.",
+      properties: {
+        topic: {
+          type: "string",
+          enum: [
+            "overview",
+            "features",
+            "commands",
+            "dashboard",
+            "privacy",
+            "creator",
+          ],
+          description:
+            "Omit for the overview. 'features' includes what each one is for, which is what to use when asked how Blipko helps them.",
+        },
+      },
+      required: [],
+    },
+    {
+      name: "open_dashboard",
+      description:
+        "Show the user a tappable button to their dashboard. Use when they ask for it, and when what they want genuinely lives there — charts and trends, editing categories or their limits, changing income, CSV export, or connecting an account. Do not use it to dodge a question you can answer from their data.",
+      properties: {
+        reason: {
+          type: "string",
+          description:
+            "What they should do there, e.g. 'edit category limits'.",
+        },
+      },
+      required: ["reason"],
+    },
     ...(includeWrites ? writeTools(categoryProp) : []),
   ];
 }
@@ -245,14 +280,25 @@ function writeTools(categoryProp: Record<string, unknown>): ToolDef[] {
 
 // Runs a tool and ALWAYS resolves. A throw would kill the whole turn with no
 // model-visible recovery; a soft error lets it correct itself in-loop.
+// Everything a tool call needs that does not come from the model.
+export interface ToolRunContext {
+  tools: IFinancialDataTools;
+  userId: string;
+  categoryNames: string[];
+  // Null for the read-only lane, which has no propose_* tools.
+  writes?: IAssistantWriteTools | null | undefined;
+  // From env.WEB_APP_URL, never hardcoded — a link the bot hands out must not
+  // be able to disagree with where the app is actually deployed.
+  dashboardUrl: string;
+}
+
 export async function runAssistantTool(
-  tools: IFinancialDataTools,
+  ctx: ToolRunContext,
   name: string,
   rawArgs: unknown,
-  userId: string,
-  categoryNames: string[],
-  writes: IAssistantWriteTools | null = null,
 ): Promise<unknown> {
+  const { tools, userId, categoryNames, dashboardUrl } = ctx;
+  const writes = ctx.writes ?? null;
   const args = normalizeArgs(rawArgs);
   if (!args) {
     return {
@@ -278,6 +324,9 @@ export async function runAssistantTool(
   const bucket = asBucket(args.bucket);
 
   try {
+    const product = dispatchProduct(name, args, dashboardUrl);
+    if (product !== undefined) return product;
+
     const proposal = await dispatchWrite(writes, name, args, userId);
     if (proposal !== undefined) return proposal;
 
@@ -308,6 +357,54 @@ export async function runAssistantTool(
       message:
         "That lookup failed. Try a different tool, or tell the user you cannot answer right now.",
     };
+  }
+}
+
+// Questions about Blipko itself. Answered from a curated file for the same
+// reason financial figures are: the model's own impression of what a budgeting
+// app does would be plausible, confident and occasionally invented.
+function dispatchProduct(
+  name: string,
+  args: Record<string, unknown>,
+  dashboardUrl: string,
+): unknown | undefined {
+  const facts = buildProductFacts(dashboardUrl);
+
+  if (name === "open_dashboard") {
+    return {
+      ok: true,
+      url: facts.dashboard.url,
+      // The caller renders this as a button; the model should not paste the
+      // raw URL into its reply as well.
+      instruction:
+        "A tappable dashboard button is being shown to the user. Tell them what to do there — do not repeat the URL.",
+    };
+  }
+
+  if (name !== "get_product_info") return undefined;
+
+  const topic = asString(args.topic);
+  switch (topic) {
+    case "features":
+      return { ok: true, features: facts.features };
+    case "commands":
+      return { ok: true, commands: facts.commands };
+    case "dashboard":
+      return { ok: true, dashboard: facts.dashboard };
+    case "privacy":
+      return { ok: true, dataHandling: facts.dataHandling };
+    case "creator":
+      return { ok: true, creator: facts.creator };
+    default:
+      return {
+        ok: true,
+        whatItIs: facts.whatItIs,
+        howLoggingWorks: facts.howLoggingWorks,
+        features: facts.features.map((f) => f.name),
+        commands: facts.commands,
+        dashboardUrl: facts.dashboard.url,
+        note: "This is the overview. Call get_product_info again with a topic for the detail behind any of it.",
+      };
   }
 }
 

--- a/src/data/ai/budgetParserPrompt.ts
+++ b/src/data/ai/budgetParserPrompt.ts
@@ -15,11 +15,16 @@ import { renderHistoryBlock } from "./historyBlock";
 export function buildBudgetSystemPrompt(
   categories: CategoryHint[],
   history?: ConversationTurn[],
+  assistantMode = false,
 ): string {
   const categoryList =
     categories.length > 0
       ? categories.map((c) => `- ${c.name} (${c.bucket})`).join("\n")
       : "- (none yet)";
+
+  if (assistantMode) {
+    return buildLogOrEscalatePrompt(categoryList, history);
+  }
 
   return `You are an expert budgeting assistant for Indian users. You read an informal money message in English, Hindi, Hinglish, Malayalam, or Manglish (often code-mixed) and return STRICT JSON describing it.
 
@@ -107,6 +112,83 @@ ones that don't apply.
 - BUCKET mapping (50/30/20): NEEDS = rent, groceries, utilities, transport, EMIs, essential bills. WANTS = eating out, entertainment, shopping, subscriptions, hobbies. SAVINGS = savings transfers, investments, debt prepayment.
 - Prefer a category from the USER'S CATEGORIES list. If none fits, propose a short new category name and your best-guess bucket.
 - CONFIDENCE: be honest. Set confidence BELOW 0.6 when the amount is unclear OR the bucket is genuinely ambiguous (e.g. a bare "paid 1500" with no hint of what for). The bot will ask the user to confirm in that case.
+- Ignore spelling mistakes. Default currency INR.
+- Output ONLY the JSON object.`;
+}
+
+// The assistant-lane prompt. The parser has exactly one decision to make here:
+// is this a clear spend or income to log, or is it something the assistant
+// should handle? Everything conversational — questions, commands, corrections,
+// ambiguity, chit-chat — is ESCALATE.
+//
+// This exists because classifying eight ways is where the mis-parses came from.
+// A message that is "sort of a question and sort of a spend" no longer has to
+// be resolved by the cheap model at all; it escalates, and the assistant works
+// it out with the user's real data in front of it.
+function buildLogOrEscalatePrompt(
+  categoryList: string,
+  history?: ConversationTurn[],
+): string {
+  return `You are the fast-path classifier for an Indian budgeting bot. You read an informal money message in English, Hindi, Hinglish, Malayalam, or Manglish (often code-mixed) and return STRICT JSON.
+
+### USER'S CATEGORIES (map to one of these when it fits):
+${categoryList}
+${renderHistoryBlock(history)}
+### YOUR ONLY DECISION
+Is this message a CLEAR record of money the user just spent or received?
+
+- YES → emit one transaction per distinct spend/income, intent "EXPENSE" or "INCOME".
+- NO, or you are not sure → emit exactly ONE transaction with intent "ESCALATE" and no amount. A colleague with full access to the user's data will handle it.
+
+ESCALATE is cheap and safe. Logging the wrong thing is not. When torn, ESCALATE.
+
+### OUTPUT (strict JSON, no prose):
+Always return an object with a "transactions" array — never a bare transaction
+object. Send EVERY key on every transaction; use null for the ones that don't apply.
+{
+  "transactions": [
+    {
+      "intent": "EXPENSE | INCOME | ESCALATE",
+      "amount": <number|null>,       // POSITIVE magnitude; null for ESCALATE. Ignore any minus sign
+      "currency": "INR",
+      "category": "<best category|null>", // prefer one from the list above; else propose a short new one
+      "bucket": "NEEDS | WANTS | SAVINGS | null",
+      "note": "<short free-text note, e.g. 'lunch', 'auto to office'|null>",
+      "dayOfMonth": null,
+      "recurringKind": null,
+      "boxName": null,
+      "boxDirection": null,
+      "confidence": <0..1>,          // your confidence in amount + category + bucket
+      "conversational_response": null
+    }
+  ]
+}
+
+### LOG (intent EXPENSE / INCOME)
+Only when the message states money that has ALREADY moved, with an amount.
+- "chai 30" → EXPENSE, amount 30, category Food, bucket WANTS, note "chai", confidence 0.9
+- "auto 80 office" → EXPENSE, amount 80, category Transport, bucket NEEDS, note "auto to office", confidence 0.9
+- "petrol 500 koduthu" → EXPENSE, amount 500, category Transport, bucket NEEDS, note "petrol", confidence 0.9
+- "got salary 50000" → INCOME, amount 50000, note "salary", confidence 0.9
+- "chai 30, auto 80, salary 50k" → three transactions (a genuine journal dump)
+
+### ESCALATE (everything else)
+One entry, intent "ESCALATE", amount null. Non-exhaustive:
+- Questions: "how much did I spend on food last week?", "am I spending more than last month?", "can I afford a 5000 phone?", "evide poyi ee maasathe panam?"
+- Budget health: "status", "how much wants left", "kitna bacha"
+- Corrections and deletions: "undo", "delete that", "make it 50", "that was actually groceries"
+- Repeating items: "rent 8000 on 1st every month", "netflix 199 monthly"
+- Savings goals: "add 5000 to New York trip", "take 1500 from house fund"
+- Social or unclear: "hi", "thanks", "what can you do", "paid 1500" with no hint of what for
+- ANY message where you cannot pin down an amount, or where you are unsure whether the user is logging or asking.
+
+### RULES
+- Amounts are ALWAYS positive. Ignore any minus sign ("chai -30" → amount 30). Direction comes from intent.
+- Never invent an amount to fill the field. If there is no clear amount, ESCALATE with amount null.
+- BUCKET mapping (50/30/20): NEEDS = rent, groceries, utilities, transport, EMIs, essential bills. WANTS = eating out, entertainment, shopping, subscriptions, hobbies. SAVINGS = savings transfers, investments, debt prepayment.
+- Prefer a category from the USER'S CATEGORIES list. If none fits, propose a short new category name and your best-guess bucket.
+- CONFIDENCE: be honest. Below 0.6 when the amount is unclear or the bucket is genuinely ambiguous — the bot will ask the user to confirm.
+- Do NOT split one transaction ("petrol 500" is ONE entry). ESCALATE is always a single-entry array.
 - Ignore spelling mistakes. Default currency INR.
 - Output ONLY the JSON object.`;
 }

--- a/src/data/ai/groundingCheck.spec.ts
+++ b/src/data/ai/groundingCheck.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { findUngroundedAmounts } from "./groundingCheck";
+
+describe("findUngroundedAmounts", () => {
+  it("passes an answer that quotes tool figures verbatim", () => {
+    const results = [{ categories: [{ name: "Food", total: "₹1,200" }] }];
+    expect(
+      findUngroundedAmounts("You spent *₹1,200* on Food.", results),
+    ).toEqual([]);
+  });
+
+  it("catches a total the model computed itself", () => {
+    // The classic failure: two real figures, one invented sum.
+    const results = [{ buckets: [{ total: "₹1,200" }, { total: "₹800" }] }];
+    expect(
+      findUngroundedAmounts(
+        "Food ₹1,200 and Transport ₹800, so ₹2,000 total.",
+        results,
+      ),
+    ).toEqual(["₹2,000"]);
+  });
+
+  it("ignores formatting differences rather than crying wolf", () => {
+    const results = [{ total: "₹1,200" }];
+    expect(findUngroundedAmounts("that's ₹ 1,200 so far", results)).toEqual([]);
+    expect(findUngroundedAmounts("that's ₹1200 so far", results)).toEqual([]);
+  });
+
+  it("treats a trailing .00 as the same amount", () => {
+    expect(findUngroundedAmounts("₹1,200.00", [{ t: "₹1,200" }])).toEqual([]);
+  });
+
+  it("reports each invented amount once", () => {
+    const out = findUngroundedAmounts("₹500 then ₹500 again", [{ t: "₹10" }]);
+    expect(out).toEqual(["₹500"]);
+  });
+
+  it("returns nothing when the answer states no amounts", () => {
+    expect(findUngroundedAmounts("No spending recorded yet.", [])).toEqual([]);
+  });
+
+  it("flags everything when there were no tool results at all", () => {
+    expect(findUngroundedAmounts("You have ₹9,000 left.", [])).toEqual([
+      "₹9,000",
+    ]);
+  });
+
+  it("matches a negative amount against the tool's negative figure", () => {
+    expect(
+      findUngroundedAmounts("over by -₹3,000", [{ remainingAfter: "-₹3,000" }]),
+    ).toEqual([]);
+  });
+});

--- a/src/data/ai/groundingCheck.ts
+++ b/src/data/ai/groundingCheck.ts
@@ -1,0 +1,29 @@
+// Post-hoc grounding check: every rupee figure the assistant states should have
+// come out of a tool result verbatim. Anything else was invented or recomputed,
+// which is exactly the failure this design exists to prevent.
+//
+// This does not block the reply — it measures. A silent hallucination is worse
+// than a logged one, and the rate is the number worth watching.
+
+const AMOUNT = /₹\s?-?[\d,]+(?:\.\d+)?/g;
+
+// "₹ 1,200.00" and "₹1200" are the same claim; compare on the digits alone.
+function canonical(amount: string): string {
+  const digits = amount.replace(/[^0-9.]/g, "").replace(/\.0+$/, "");
+  return digits.replace(/^0+(?=\d)/, "");
+}
+
+export function findUngroundedAmounts(
+  text: string,
+  toolResults: unknown[],
+): string[] {
+  const stated = text.match(AMOUNT);
+  if (!stated) return [];
+
+  const grounded = new Set(
+    (JSON.stringify(toolResults).match(AMOUNT) ?? []).map(canonical),
+  );
+
+  const missing = stated.filter((a) => !grounded.has(canonical(a)));
+  return [...new Set(missing)];
+}

--- a/src/data/ai/historyTrimmer.spec.ts
+++ b/src/data/ai/historyTrimmer.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { trimHistory, estimateTokens } from "./historyTrimmer";
+
+const user = (text: string): any => ({ role: "user", content: text });
+const assistant = (text: string): any => ({ role: "assistant", content: text });
+
+const toolUse = (id: string, name: string): any => ({
+  role: "assistant",
+  content: [{ type: "tool_use", id, name, input: {} }],
+});
+const toolResult = (id: string, out: string): any => ({
+  role: "user",
+  content: [{ type: "tool_result", tool_use_id: id, content: out }],
+});
+
+// Every tool_use block must have its tool_result in a LATER message, and every
+// tool_result must answer an EARLIER tool_use. An orphan is an API error.
+function pairsIntact(messages: any[]): boolean {
+  const uses = new Map<string, number>();
+  const results = new Map<string, number>();
+  messages.forEach((m, i) => {
+    if (!Array.isArray(m.content)) return;
+    for (const b of m.content) {
+      if (b.type === "tool_use") uses.set(b.id, i);
+      if (b.type === "tool_result") results.set(b.tool_use_id, i);
+    }
+  });
+  for (const [id, at] of uses) {
+    if (!results.has(id) || results.get(id)! <= at) return false;
+  }
+  for (const id of results.keys()) if (!uses.has(id)) return false;
+  return true;
+}
+
+describe("trimHistory", () => {
+  it("keeps everything when it already fits", () => {
+    const history = [user("hi"), assistant("hello")];
+    expect(trimHistory(history, 10_000)).toEqual(history);
+  });
+
+  it("drops from the oldest end, keeping the most recent turns", () => {
+    const history = [
+      user("oldest"),
+      assistant("a1"),
+      user("newest"),
+      assistant("a2"),
+    ];
+    const budget = estimateTokens([user("newest"), assistant("a2")]);
+    const kept = trimHistory(history, budget);
+
+    expect(kept).toEqual([user("newest"), assistant("a2")]);
+  });
+
+  it("never splits a tool_use from its tool_result", () => {
+    const history = [
+      user("q1"),
+      toolUse("t1", "get_period_status"),
+      toolResult("t1", "{}"),
+      assistant("a1"),
+      user("q2"),
+      toolUse("t2", "get_income"),
+      toolResult("t2", "{}"),
+      assistant("a2"),
+    ];
+
+    // Sweep every budget: no budget may ever produce an orphaned block.
+    for (let budget = 1; budget < estimateTokens(history) + 50; budget += 3) {
+      const kept = trimHistory(history, budget);
+      expect(pairsIntact(kept)).toBe(true);
+    }
+  });
+
+  it("keeps a multi-round tool exchange together", () => {
+    const history = [
+      user("q"),
+      toolUse("t1", "get_categories"),
+      toolResult("t1", "{}"),
+      toolUse("t2", "get_spend_by_category"),
+      toolResult("t2", "{}"),
+      assistant("done"),
+    ];
+    const kept = trimHistory(history, estimateTokens(history));
+    expect(pairsIntact(kept)).toBe(true);
+    expect(kept).toHaveLength(6);
+  });
+
+  it("never returns a history that opens on an assistant turn", () => {
+    const history = [user("q1"), assistant("a1"), user("q2"), assistant("a2")];
+    for (let budget = 1; budget < estimateTokens(history) + 20; budget += 2) {
+      const kept = trimHistory(history, budget);
+      if (kept.length > 0) expect(kept[0]!.role).toBe("user");
+    }
+  });
+
+  it("returns nothing for a zero or negative budget", () => {
+    expect(trimHistory([user("q")], 0)).toEqual([]);
+    expect(trimHistory([user("q")], -5)).toEqual([]);
+  });
+
+  it("drops the whole exchange when only part of it would fit", () => {
+    const history = [
+      user("q1"),
+      toolUse("t1", "big_tool"),
+      toolResult("t1", "x".repeat(2000)),
+      assistant("a1"),
+      user("q2"),
+      assistant("a2"),
+    ];
+    // Enough for the last plain exchange, nowhere near the tool round.
+    const kept = trimHistory(
+      history,
+      estimateTokens([user("q2"), assistant("a2")]),
+    );
+    expect(kept).toEqual([user("q2"), assistant("a2")]);
+  });
+});

--- a/src/data/ai/historyTrimmer.ts
+++ b/src/data/ai/historyTrimmer.ts
@@ -1,0 +1,90 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+type Message = Anthropic.MessageParam;
+
+// Rough token estimate: ~4 chars/token, then a safety factor because JSON tool
+// payloads tokenize worse than prose. Deliberately pessimistic — overshooting
+// the budget costs money and can hard-fail the request; undershooting only
+// drops an extra old turn.
+const CHARS_PER_TOKEN = 4;
+const SAFETY_FACTOR = 1.25;
+
+export function estimateTokens(messages: Message[]): number {
+  const chars = JSON.stringify(messages).length;
+  return Math.ceil((chars / CHARS_PER_TOKEN) * SAFETY_FACTOR);
+}
+
+// Drop whole exchanges from the OLDEST end until the history fits `maxTokens`.
+//
+// The invariant that matters: an assistant message containing `tool_use` blocks
+// and the user message carrying the matching `tool_result` blocks are one
+// indivisible unit. Splitting them leaves an orphan that the API rejects
+// outright, so the trimmer moves in groups, never individual messages.
+export function trimHistory(messages: Message[], maxTokens: number): Message[] {
+  if (maxTokens <= 0) return [];
+
+  const groups = groupIndivisible(messages);
+  const kept: Message[][] = [];
+
+  // Walk newest-first so the most recent context always survives.
+  for (let i = groups.length - 1; i >= 0; i--) {
+    const candidate = [groups[i]!, ...kept];
+    if (estimateTokens(candidate.flat()) > maxTokens) break;
+    kept.unshift(groups[i]!);
+  }
+
+  // A conversation must open on a user turn. Drop leading groups until it does
+  // — a whole group at a time, because slicing off just the first MESSAGE of a
+  // tool group decapitates it and leaves an orphaned tool_result behind.
+  while (kept.length > 0 && kept[0]![0]!.role === "assistant") kept.shift();
+
+  return kept.flat();
+}
+
+// Bundle each tool-using assistant message with the tool_result message that
+// answers it, so the two can only ever be dropped together.
+function groupIndivisible(messages: Message[]): Message[][] {
+  const groups: Message[][] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]!;
+    if (msg.role === "assistant" && hasBlock(msg, "tool_use")) {
+      const group = [msg];
+      // Consume every following message that is purely tool results.
+      while (i + 1 < messages.length && isToolResultMessage(messages[i + 1]!)) {
+        group.push(messages[++i]!);
+      }
+      // A follow-up assistant turn that also calls tools chains onto the same
+      // group — the whole multi-round exchange stands or falls together.
+      while (
+        i + 1 < messages.length &&
+        messages[i + 1]!.role === "assistant" &&
+        hasBlock(messages[i + 1]!, "tool_use")
+      ) {
+        group.push(messages[++i]!);
+        while (
+          i + 1 < messages.length &&
+          isToolResultMessage(messages[i + 1]!)
+        ) {
+          group.push(messages[++i]!);
+        }
+      }
+      groups.push(group);
+      continue;
+    }
+    groups.push([msg]);
+  }
+
+  return groups;
+}
+
+function hasBlock(msg: Message, type: "tool_use" | "tool_result"): boolean {
+  return (
+    Array.isArray(msg.content) &&
+    msg.content.some((b) => typeof b === "object" && b.type === type)
+  );
+}
+
+function isToolResultMessage(msg: Message): boolean {
+  return msg.role === "user" && hasBlock(msg, "tool_result");
+}

--- a/src/data/ai/productTools.spec.ts
+++ b/src/data/ai/productTools.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildToolCatalog, runAssistantTool } from "./assistantTools";
+import { buildProductFacts } from "../../domain/productFacts";
+
+const ctx = {
+  tools: {} as never,
+  userId: "u1",
+  categoryNames: ["Food"],
+  dashboardUrl: "https://example.test",
+};
+
+describe("product knowledge tools", () => {
+  it("exposes the product tools to the read-only lane too", () => {
+    // A user asking "what can you do?" gets the same answer whichever lane is
+    // serving them.
+    const names = buildToolCatalog([], false).map((t) => t.name);
+    expect(names).toContain("get_product_info");
+    expect(names).toContain("open_dashboard");
+  });
+
+  describe("get_product_info", () => {
+    it("returns an overview with no topic", async () => {
+      const res: any = await runAssistantTool(ctx, "get_product_info", {});
+      expect(res.ok).toBe(true);
+      expect(res.whatItIs).toContain("budget");
+      expect(res.commands.length).toBeGreaterThan(0);
+    });
+
+    it("answers 'how does this help me' with the why, not just the what", async () => {
+      const res: any = await runAssistantTool(ctx, "get_product_info", {
+        topic: "features",
+      });
+      // Every feature carries its own reason to exist, so the model never has
+      // to invent a benefit.
+      expect(res.features.every((f: any) => f.why?.length > 0)).toBe(true);
+    });
+
+    it("answers who built it", async () => {
+      const res: any = await runAssistantTool(ctx, "get_product_info", {
+        topic: "creator",
+      });
+      expect(res.creator.name).toBe("Mohammed Sadik");
+    });
+
+    it("is honest that messages are processed by an AI provider", async () => {
+      const res: any = await runAssistantTool(ctx, "get_product_info", {
+        topic: "privacy",
+      });
+      expect(res.dataHandling.join(" ")).toMatch(/AI provider/i);
+    });
+
+    it("takes the dashboard URL from context, never a hardcoded domain", async () => {
+      const res: any = await runAssistantTool(ctx, "get_product_info", {
+        topic: "dashboard",
+      });
+      expect(res.dashboard.url).toBe("https://example.test");
+    });
+
+    it("needs no user data, so it cannot fail on a broken DB", async () => {
+      const res: any = await runAssistantTool(
+        { ...ctx, tools: null as never },
+        "get_product_info",
+        {},
+      );
+      expect(res.ok).toBe(true);
+    });
+  });
+
+  describe("open_dashboard", () => {
+    it("returns the URL for the caller to render as a button", async () => {
+      const res: any = await runAssistantTool(ctx, "open_dashboard", {
+        reason: "edit category limits",
+      });
+      expect(res).toMatchObject({ ok: true, url: "https://example.test" });
+    });
+
+    it("tells the model not to repeat the URL in its text", async () => {
+      const res: any = await runAssistantTool(ctx, "open_dashboard", {
+        reason: "x",
+      });
+      expect(res.instruction).toMatch(/do not repeat the URL/i);
+    });
+  });
+
+  describe("the facts themselves", () => {
+    const facts = buildProductFacts("https://example.test");
+
+    it("describes /start as linking an account, not an in-chat wizard", () => {
+      // README still claims /start "runs the onboarding wizard"; that wizard was
+      // replaced by the dashboard hand-off. This file is the one the bot reads.
+      const start = facts.commands.find((c) => c.command === "/start")!;
+      expect(start.what).toMatch(/link/i);
+      expect(start.what).not.toMatch(/wizard/i);
+    });
+
+    it("lists every command the bot actually handles", () => {
+      const commands = facts.commands.map((c) => c.command);
+      // /boxes exists in the bot but is missing from the README's table.
+      expect(commands).toEqual(
+        expect.arrayContaining([
+          "/status",
+          "/report",
+          "/recurring",
+          "/boxes",
+          "/settings",
+          "/help",
+          "undo",
+          "/start",
+        ]),
+      );
+    });
+
+    it("hardcodes no domain anywhere", () => {
+      expect(JSON.stringify(buildProductFacts("https://x.test"))).not.toContain(
+        "blipko.lol",
+      );
+    });
+  });
+});

--- a/src/data/repositories/PrismaConversationRepository.spec.ts
+++ b/src/data/repositories/PrismaConversationRepository.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.hoisted: vi.mock is lifted above the file, so a plain top-level const
+// would not exist yet when the factory runs.
+const { createMany, findMany } = vi.hoisted(() => ({
+  createMany: vi.fn(),
+  findMany: vi.fn(),
+}));
+
+vi.mock("../prisma/client", () => ({
+  prisma: { conversationMessage: { createMany, findMany } },
+}));
+
+import { PrismaConversationRepository } from "./PrismaConversationRepository";
+
+describe("PrismaConversationRepository", () => {
+  let repo: PrismaConversationRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repo = new PrismaConversationRepository();
+  });
+
+  describe("appendExchange", () => {
+    it("writes both halves in one statement, user turn first", async () => {
+      await repo.appendExchange("u1", "chai 30", "✅ ₹30 → Wants");
+
+      // One createMany, not two creates: a single INSERT makes Postgres assign
+      // `seq` in array order, which is what getRecent sorts by. Two independent
+      // creates could land in either order.
+      expect(createMany).toHaveBeenCalledTimes(1);
+      const [userTurn, modelTurn] = createMany.mock.calls[0]![0].data;
+      expect(userTurn.role).toBe("user");
+      expect(modelTurn.role).toBe("model");
+    });
+
+    it("does not set createdAt, which is unsafe to order by", async () => {
+      await repo.appendExchange("u1", "q", "a");
+      for (const row of createMany.mock.calls[0]![0].data) {
+        expect(row.createdAt).toBeUndefined();
+      }
+    });
+
+    it("attaches AI metadata to the model turn only", async () => {
+      await repo.appendExchange("u1", "how much on food?", "₹1,200", {
+        intent: "QUERY",
+        model: "gpt-4o-mini",
+        latencyMs: 1830,
+        inputTokens: 900,
+        outputTokens: 40,
+      });
+
+      const [userTurn, modelTurn] = createMany.mock.calls[0]![0].data;
+      expect(userTurn.intent).toBeUndefined();
+      expect(modelTurn).toMatchObject({
+        intent: "QUERY",
+        model: "gpt-4o-mini",
+        latencyMs: 1830,
+      });
+    });
+
+    it("stores JsonNull rather than undefined for absent json columns", async () => {
+      await repo.appendExchange("u1", "hi", "hello");
+      const [, modelTurn] = createMany.mock.calls[0]![0].data;
+
+      // Prisma rejects `undefined` on a Json column at runtime; JsonNull is the
+      // documented way to write SQL NULL.
+      expect(modelTurn.entityRefs).not.toBeUndefined();
+      expect(modelTurn.toolCalls).not.toBeUndefined();
+    });
+  });
+
+  it("reads newest-first by seq and returns them oldest-first", async () => {
+    findMany.mockResolvedValue([
+      {
+        role: "model",
+        content: "b",
+        createdAt: new Date(2),
+        intent: "EXPENSE",
+        entityRefs: { expenseId: "e1" },
+      },
+      {
+        role: "user",
+        content: "a",
+        createdAt: new Date(1),
+        intent: null,
+        entityRefs: null,
+      },
+    ]);
+
+    const turns = await repo.getRecent("u1", 6);
+    expect(findMany.mock.calls[0]![0].orderBy).toEqual({ seq: "desc" });
+    expect(turns.map((t) => t.content)).toEqual(["a", "b"]);
+    expect(turns[1]!.entityRefs).toEqual({ expenseId: "e1" });
+  });
+});

--- a/src/data/repositories/PrismaConversationRepository.ts
+++ b/src/data/repositories/PrismaConversationRepository.ts
@@ -1,27 +1,76 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "../prisma/client";
 import {
   IConversationRepository,
   ConversationTurn,
+  TurnEntityRefs,
+  TurnMeta,
 } from "../../domain/repositories/IConversationRepository";
 
 export class PrismaConversationRepository implements IConversationRepository {
   async getRecent(userId: string, limit: number): Promise<ConversationTurn[]> {
     const rows = await prisma.conversationMessage.findMany({
       where: { userId },
-      orderBy: { createdAt: "desc" },
+      orderBy: { seq: "desc" },
       take: limit,
-      select: { role: true, content: true, createdAt: true },
+      select: {
+        role: true,
+        content: true,
+        createdAt: true,
+        intent: true,
+        entityRefs: true,
+      },
     });
-    return rows.reverse();
+    return rows.reverse().map((r) => ({
+      role: r.role,
+      content: r.content,
+      createdAt: r.createdAt,
+      intent: r.intent,
+      entityRefs: (r.entityRefs as TurnEntityRefs | null) ?? null,
+    }));
   }
 
-  async append(
+  async appendExchange(
     userId: string,
-    role: "user" | "model",
-    content: string,
+    userText: string,
+    modelText: string,
+    meta: TurnMeta = {},
   ): Promise<void> {
-    await prisma.conversationMessage.create({
-      data: { userId, role, content },
+    // One statement, so Postgres assigns `seq` in array order and the user turn
+    // can never be read back after its own reply. (Two exchanges written truly
+    // concurrently may still interleave — nextval is per row, so another session
+    // can slip between these two. That is honest chronology; an inverted pair
+    // was not.)
+    await prisma.conversationMessage.createMany({
+      data: [
+        {
+          userId,
+          role: "user",
+          content: userText,
+        },
+        {
+          userId,
+          role: "model",
+          content: modelText,
+          intent: meta.intent ?? null,
+          entityRefs: toJson(meta.entityRefs),
+          toolCalls: toJson(meta.toolCalls),
+          provider: meta.provider ?? null,
+          model: meta.model ?? null,
+          latencyMs: meta.latencyMs ?? null,
+          inputTokens: meta.inputTokens ?? null,
+          outputTokens: meta.outputTokens ?? null,
+          costUsd: meta.costUsd ?? null,
+        },
+      ],
     });
   }
+}
+
+function toJson(
+  value: unknown,
+): Prisma.InputJsonValue | typeof Prisma.JsonNull {
+  return value === undefined || value === null
+    ? Prisma.JsonNull
+    : (value as Prisma.InputJsonValue);
 }

--- a/src/data/repositories/PrismaExpenseRepository.spec.ts
+++ b/src/data/repositories/PrismaExpenseRepository.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PrismaExpenseRepository } from "./PrismaExpenseRepository";
+
+// A category name can match BOTH the shared system template (userId: null) and
+// the user's own copy. Their expenses point at their OWN row, so resolving the
+// filter to the template makes the query succeed and return nothing — the
+// assistant then reports "no spending" for a category in active use.
+describe("PrismaExpenseRepository.findRecent category resolution", () => {
+  let prisma: any;
+  let repo: PrismaExpenseRepository;
+
+  const systemRow = { id: "sys", name: "Fuel", userId: null };
+  const ownRow = { id: "own", name: "Fuel", userId: "u1" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma = {
+      category: { findMany: vi.fn() },
+      expense: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+    repo = new PrismaExpenseRepository(prisma);
+  });
+
+  it("filters on the user's own category, not the system template", async () => {
+    prisma.category.findMany.mockResolvedValue([systemRow, ownRow]);
+
+    await repo.findRecent("u1", { limit: 10, categoryName: "Fuel" });
+
+    expect(prisma.expense.findMany.mock.calls[0]![0].where.categoryId).toBe(
+      "own",
+    );
+  });
+
+  it("picks the user's row regardless of the order rows come back in", async () => {
+    prisma.category.findMany.mockResolvedValue([ownRow, systemRow]);
+
+    await repo.findRecent("u1", { limit: 10, categoryName: "Fuel" });
+
+    expect(prisma.expense.findMany.mock.calls[0]![0].where.categoryId).toBe(
+      "own",
+    );
+  });
+
+  it("falls back to the system template when the user has no copy", async () => {
+    prisma.category.findMany.mockResolvedValue([systemRow]);
+
+    await repo.findRecent("u1", { limit: 10, categoryName: "Fuel" });
+
+    expect(prisma.expense.findMany.mock.calls[0]![0].where.categoryId).toBe(
+      "sys",
+    );
+  });
+
+  it("returns no rows for an unknown category rather than dropping the filter", async () => {
+    prisma.category.findMany.mockResolvedValue([]);
+
+    const rows = await repo.findRecent("u1", {
+      limit: 10,
+      categoryName: "Nonexistent",
+    });
+
+    expect(rows).toEqual([]);
+    // Silently ignoring the filter would return the user's whole history and
+    // report it as spending on a category they never had.
+    expect(prisma.expense.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve a category at all when no filter is given", async () => {
+    await repo.findRecent("u1", { limit: 10 });
+
+    expect(prisma.category.findMany).not.toHaveBeenCalled();
+    expect(prisma.expense.findMany.mock.calls[0]![0].where).toEqual({
+      userId: "u1",
+      isDeleted: false,
+    });
+  });
+});

--- a/src/data/repositories/PrismaExpenseRepository.ts
+++ b/src/data/repositories/PrismaExpenseRepository.ts
@@ -238,6 +238,7 @@ export class PrismaExpenseRepository implements IExpenseRepository {
     });
 
     return rows.map((r) => ({
+      id: r.id,
       date: r.date,
       amount: Number(r.amount),
       bucket: r.bucket,

--- a/src/data/repositories/PrismaExpenseRepository.ts
+++ b/src/data/repositories/PrismaExpenseRepository.ts
@@ -212,12 +212,18 @@ export class PrismaExpenseRepository implements IExpenseRepository {
     const where: Prisma.ExpenseWhereInput = { userId, isDeleted: false };
 
     if (opts.categoryName) {
-      const category = await this.prisma.category.findFirst({
+      const matches = await this.prisma.category.findMany({
         where: {
           name: { equals: opts.categoryName, mode: "insensitive" },
           OR: [{ userId: null }, { userId }],
         },
       });
+      // A name can match BOTH the shared system template and the user's own
+      // copy. Their expenses point at their own row, so picking the template
+      // (which a bare findFirst does) silently filters to zero — the query
+      // succeeds and reports "no spending" for a category they actively use.
+      const category =
+        matches.find((c) => c.userId === userId) ?? matches[0] ?? null;
       // Unknown category → no matches rather than ignoring the filter.
       if (!category) return [];
       where.categoryId = category.id;

--- a/src/data/repositories/PrismaPendingActionRepository.ts
+++ b/src/data/repositories/PrismaPendingActionRepository.ts
@@ -1,0 +1,44 @@
+import { PendingAction, Prisma } from "@prisma/client";
+import { prisma } from "../prisma/client";
+import {
+  CreatePendingActionDTO,
+  IPendingActionRepository,
+} from "../../domain/repositories/IPendingActionRepository";
+
+export class PrismaPendingActionRepository implements IPendingActionRepository {
+  async create(data: CreatePendingActionDTO): Promise<PendingAction> {
+    return prisma.pendingAction.create({
+      data: {
+        userId: data.userId,
+        kind: data.kind,
+        payload: data.payload as Prisma.InputJsonValue,
+        summary: data.summary,
+        expiresAt: new Date(Date.now() + data.ttlMinutes * 60_000),
+      },
+    });
+  }
+
+  async findLiveForUser(
+    id: string,
+    userId: string,
+  ): Promise<PendingAction | null> {
+    return prisma.pendingAction.findFirst({
+      where: {
+        id,
+        userId,
+        consumedAt: null,
+        expiresAt: { gt: new Date() },
+      },
+    });
+  }
+
+  async consume(id: string, userId: string): Promise<boolean> {
+    // Conditional update: `consumedAt: null` in the WHERE makes this the lock.
+    // Two rapid taps both find a live row, but only one updateMany matches.
+    const { count } = await prisma.pendingAction.updateMany({
+      where: { id, userId, consumedAt: null, expiresAt: { gt: new Date() } },
+      data: { consumedAt: new Date() },
+    });
+    return count === 1;
+  }
+}

--- a/src/domain/entities/ParsedData.ts
+++ b/src/domain/entities/ParsedData.ts
@@ -5,6 +5,11 @@ import { z } from "zod";
 export const BUCKETS = ["NEEDS", "WANTS", "SAVINGS"] as const;
 export type ParsedBucket = (typeof BUCKETS)[number];
 
+// ESCALATE is the assistant lane's only non-logging outcome: "this is not a
+// clear spend or income — hand it to the assistant". When the lane is on, the
+// parser emits nothing else, so classifying between STATUS/UNDO/RECURRING/BOX/
+// QUERY stops being a job it can get wrong. Those intents remain for the
+// deterministic path used when the lane is off.
 export const PARSED_INTENTS = [
   "EXPENSE",
   "INCOME",
@@ -13,6 +18,7 @@ export const PARSED_INTENTS = [
   "RECURRING",
   "QUERY",
   "BOX",
+  "ESCALATE",
   "UNKNOWN",
 ] as const;
 export type ParsedIntent = (typeof PARSED_INTENTS)[number];

--- a/src/domain/entities/PendingAction.ts
+++ b/src/domain/entities/PendingAction.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { BUCKETS } from "./ParsedData";
+
+// Payloads for writes the assistant proposes. Validated with Zod on the way OUT
+// of the database, not just on the way in: the row is written from model-shaped
+// input, and between proposal and confirmation it is untrusted JSON.
+
+export const EditExpensePayload = z.object({
+  expenseId: z.string().min(1),
+  amount: z.number().positive().max(10_000_000).optional(),
+  bucket: z.enum(BUCKETS).optional(),
+  categoryName: z.string().min(1).max(50).optional(),
+  note: z.string().max(200).optional(),
+});
+
+export const DeleteExpensePayload = z.object({
+  expenseId: z.string().min(1),
+});
+
+export const SetRecurringPayload = z.object({
+  kind: z.enum(["INCOME", "EXPENSE"]),
+  amount: z.number().positive().max(1_000_000_000),
+  dayOfMonth: z.number().int().min(1).max(28),
+  bucket: z.enum(BUCKETS).optional(),
+  categoryName: z.string().min(1).max(50).optional(),
+  note: z.string().max(200).optional(),
+});
+
+export const BoxMovePayload = z.object({
+  boxName: z.string().min(1).max(60),
+  amount: z.number().positive().max(1_000_000_000),
+  direction: z.enum(["IN", "OUT"]),
+  note: z.string().max(200).optional(),
+});
+
+export const PENDING_ACTION_SCHEMAS = {
+  EDIT_EXPENSE: EditExpensePayload,
+  DELETE_EXPENSE: DeleteExpensePayload,
+  SET_RECURRING: SetRecurringPayload,
+  BOX_MOVE: BoxMovePayload,
+} as const;
+
+export type PendingActionKind = keyof typeof PENDING_ACTION_SCHEMAS;
+
+export const PENDING_ACTION_KINDS = Object.keys(
+  PENDING_ACTION_SCHEMAS,
+) as PendingActionKind[];
+
+export function isPendingActionKind(v: string): v is PendingActionKind {
+  return v in PENDING_ACTION_SCHEMAS;
+}
+
+// Parse a stored row's payload for its kind. Returns null rather than throwing
+// so a corrupt row degrades to "that expired" instead of a 500.
+export function parsePendingPayload(
+  kind: string,
+  payload: unknown,
+): { kind: PendingActionKind; data: unknown } | null {
+  if (!isPendingActionKind(kind)) return null;
+  const result = PENDING_ACTION_SCHEMAS[kind].safeParse(payload);
+  return result.success ? { kind, data: result.data } : null;
+}

--- a/src/domain/productFacts.ts
+++ b/src/domain/productFacts.ts
@@ -1,0 +1,137 @@
+// What Blipko is, told to users through the assistant.
+//
+// This is the product's equivalent of the grounding contract on the money
+// tools: the assistant answers "what can you do?" from THIS file, never from
+// what the model happens to remember about budgeting apps. A feature described
+// here that does not exist is a hallucination with a longer half-life than a
+// wrong number — the user acts on it and finds nothing.
+//
+// KEEP IN SYNC WITH THE CODE, not with README.md. The README currently
+// describes an in-chat onboarding wizard that ConnectAccountProcessor replaced
+// with a dashboard hand-off, which is exactly the kind of drift this file
+// exists to keep out of the model's mouth.
+//
+// The dashboard URL is passed in rather than written here so it can never
+// disagree with env.WEB_APP_URL.
+
+export interface ProductFeature {
+  name: string;
+  what: string;
+  // Why a user cares. The assistant is asked "how does this help me?" more
+  // often than "what does this do?".
+  why: string;
+}
+
+export interface ProductCommand {
+  command: string;
+  what: string;
+}
+
+export interface ProductFacts {
+  whatItIs: string;
+  howLoggingWorks: string;
+  features: ProductFeature[];
+  commands: ProductCommand[];
+  dashboard: { url: string; whatItIsFor: string; howToConnect: string };
+  dataHandling: string[];
+  creator: { name: string; site: string; license: string };
+}
+
+export function buildProductFacts(dashboardUrl: string): ProductFacts {
+  return {
+    whatItIs:
+      "Blipko is a personal budget tracker you use by chatting. You text what you spend in plain language and it sorts it into a 50/30/20 budget, tracks what's left, and answers questions about your money. There is no app to install and no forms to fill in.",
+
+    howLoggingWorks:
+      'Send what you spent the way you would say it — "chai 30", "auto 80 office", "petrol 500 koduthu". It reads English, Hindi, Hinglish, Malayalam and Manglish, including code-mixed. Voice notes work too: they are transcribed and logged the same way. If the category or bucket is unclear it asks before saving rather than guessing.',
+
+    features: [
+      {
+        name: "Conversational logging",
+        what: "Log a spend by texting or sending a voice note, in everyday mixed-language phrasing.",
+        why: "The reason most budgeting apps fail is friction — opening an app and tapping through forms. Texting takes a second, so the habit actually survives past week two.",
+      },
+      {
+        name: "50/30/20 budgeting on a payday cycle",
+        what: "Every spend lands in Needs (50%), Wants (30%) or Savings (20%). The split is adjustable, and the cycle runs from your payday rather than the 1st.",
+        why: "You see what is left in the pot that matters instead of one meaningless total, and the cycle lines up with when you actually get paid.",
+      },
+      {
+        name: "Safe daily spend",
+        what: "Shows what you can spend per day for the rest of the cycle without going over.",
+        why: "Turns an abstract remaining balance into a decision you can act on today.",
+      },
+      {
+        name: "Categories with monthly limits",
+        what: "Spending groups break down into categories (Rent, Groceries, Eating Out, Fuel…), each able to carry its own monthly limit.",
+        why: "Shows which specific habit is draining the month, not just that the month was expensive.",
+      },
+      {
+        name: "Boxes — named savings goals",
+        what: "Set money aside in named funds (a trip, an emergency fund) and track progress toward a target.",
+        why: "Savings stop being a leftover and become a thing with a name and a finish line.",
+      },
+      {
+        name: "Recurring income and expenses",
+        what: 'Set up repeating items once — "rent 8000 on 1st every month" — and they post themselves each cycle.',
+        why: "Rent, salary, EMIs and subscriptions are the predictable bulk of a month; logging them by hand is the boring part.",
+      },
+      {
+        name: "Ask anything about your money",
+        what: "Free-form questions answered from your real data: how much on food, biggest expense, can you afford something, are you spending more than last cycle.",
+        why: "Answers come from your actual records, so you get a number you can trust rather than a guess.",
+      },
+      {
+        name: "Reminders you control",
+        what: "Optional nudges as a bucket fills up, at four intensities from off to relentless.",
+        why: "A warning before you overspend is worth more than a report afterwards — but only if you chose how loud it is. Off is the default.",
+      },
+      {
+        name: "Web dashboard",
+        what: "Charts, trends, a filterable and exportable transaction list, and all settings.",
+        why: "Chat is best for capture and quick answers; the dashboard is where you review a month properly and change how things are set up.",
+      },
+    ],
+
+    commands: [
+      {
+        command: "/status",
+        what: "Budget health this cycle and safe daily spend.",
+      },
+      {
+        command: "/report",
+        what: "This cycle's summary and biggest spending leaks.",
+      },
+      { command: "/recurring", what: "See repeating income and expenses." },
+      {
+        command: "/boxes",
+        what: "See savings boxes and progress toward targets.",
+      },
+      { command: "/settings", what: "Change reminder intensity and income." },
+      { command: "/help", what: "Full guide to what the bot can do." },
+      { command: "undo", what: "Remove the last entry." },
+      { command: "/start", what: "Link this chat to a Blipko account." },
+    ],
+
+    dashboard: {
+      url: dashboardUrl,
+      whatItIsFor:
+        "Charts and trends, the full transaction list with CSV export, editing categories and their monthly limits, managing recurring rules, and all settings including income and reminder intensity.",
+      howToConnect:
+        "Sign in on the dashboard, then tap Connect Telegram there to link this chat. Setting up income and categories happens on the dashboard, not in chat.",
+    },
+
+    dataHandling: [
+      "Your messages are read by an AI model so it can work out the amount and category — that means the text you send is processed by an AI provider.",
+      "Your spending records live in your own Blipko account and are only ever used to answer your questions.",
+      "Every number reported is calculated by the app from your records, not made up by the AI. The AI chooses which figures to look up; the maths is done in code.",
+      "Reminders are off by default and you choose how insistent they are.",
+    ],
+
+    creator: {
+      name: "Mohammed Sadik",
+      site: "https://sadik.is-a.dev",
+      license: "Open source under the MIT licence.",
+    },
+  };
+}

--- a/src/domain/repositories/IConversationRepository.ts
+++ b/src/domain/repositories/IConversationRepository.ts
@@ -1,14 +1,49 @@
+// What a turn resolved to. Lets a follow-up ("make it 50", "delete that")
+// target a real row instead of re-parsing the rendered reply text.
+export interface TurnEntityRefs {
+  expenseId?: string;
+  incomeId?: string;
+  categoryId?: string;
+  boxId?: string;
+  batchId?: string;
+}
+
+export interface ToolCallTrace {
+  name: string;
+  args: unknown;
+  result: unknown;
+}
+
+// Everything known about the bot's half of an exchange beyond its text.
+export interface TurnMeta {
+  intent?: string | undefined;
+  entityRefs?: TurnEntityRefs | undefined;
+  toolCalls?: ToolCallTrace[] | undefined;
+  provider?: string | undefined;
+  model?: string | undefined;
+  latencyMs?: number | undefined;
+  inputTokens?: number | undefined;
+  outputTokens?: number | undefined;
+  costUsd?: number | undefined;
+}
+
 export interface ConversationTurn {
   role: string;
   content: string;
   createdAt: Date;
+  intent?: string | null;
+  entityRefs?: TurnEntityRefs | null;
 }
 
 export interface IConversationRepository {
   getRecent(userId: string, limit: number): Promise<ConversationTurn[]>;
-  append(
+  // Writes both halves of one exchange with explicit, strictly ordered
+  // timestamps. Two independent creates can land with equal or reversed
+  // createdAt, which silently scrambles the history the model reads back.
+  appendExchange(
     userId: string,
-    role: "user" | "model",
-    content: string,
+    userText: string,
+    modelText: string,
+    meta?: TurnMeta,
   ): Promise<void>;
 }

--- a/src/domain/repositories/IExpenseRepository.ts
+++ b/src/domain/repositories/IExpenseRepository.ts
@@ -93,6 +93,7 @@ export interface RecentExpenseFilter {
 }
 
 export interface RecentExpenseRow {
+  id: string;
   date: Date;
   amount: number;
   bucket: Bucket;

--- a/src/domain/repositories/IPendingActionRepository.ts
+++ b/src/domain/repositories/IPendingActionRepository.ts
@@ -1,0 +1,21 @@
+import { PendingAction } from "@prisma/client";
+
+export interface CreatePendingActionDTO {
+  userId: string;
+  kind: string;
+  payload: unknown;
+  summary: string;
+  ttlMinutes: number;
+}
+
+export interface IPendingActionRepository {
+  create(data: CreatePendingActionDTO): Promise<PendingAction>;
+  // Scoped to the user on purpose. The callback id is unguessable, but "hard to
+  // guess" is not an authorization check — the existing bkt: handler relies on
+  // exactly that and never verifies ownership.
+  findLiveForUser(id: string, userId: string): Promise<PendingAction | null>;
+  // Marks consumed only if it was still unconsumed, so a double-tap on the
+  // confirm button cannot apply the same write twice. Returns true for the
+  // call that won.
+  consume(id: string, userId: string): Promise<boolean>;
+}

--- a/src/domain/services/IAiParser.ts
+++ b/src/domain/services/IAiParser.ts
@@ -15,6 +15,13 @@ export interface CategoryHint {
 export interface ParseContext {
   categories: CategoryHint[];
   history?: ConversationTurn[];
+  // "YYYY-MM-DD" in the USER'S timezone. Passed in rather than derived inside
+  // the parser: a server-side UTC date tells an IST user it is yesterday every
+  // evening after 18:30, which silently misdates "spent 200 today".
+  today: string;
+  // True when the assistant lane is on. The parser then has one job — log or
+  // escalate — instead of classifying eight intents it can get wrong.
+  assistantMode?: boolean | undefined;
 }
 
 export interface IAiParser {

--- a/src/domain/services/IAssistantAgent.ts
+++ b/src/domain/services/IAssistantAgent.ts
@@ -1,0 +1,49 @@
+import { ConversationTurn } from "./IAiParser";
+
+// Context the assistant needs to ground an answer. Dates are YYYY-MM-DD in the
+// USER'S timezone, never the server's.
+export interface AssistantContext {
+  userId: string;
+  currency: string;
+  payday: number;
+  monthlyIncome: string; // formatted
+  today: string;
+  period: {
+    start: string;
+    end: string; // inclusive last day
+    day: number;
+    daysInPeriod: number;
+    remainingDays: number;
+  };
+  history?: ConversationTurn[] | undefined;
+  signal?: AbortSignal | undefined;
+}
+
+export interface ToolCallRecord {
+  name: string;
+  args: unknown;
+  result: unknown;
+}
+
+export interface AssistantAnswer {
+  text: string;
+  // The full tool trace, persisted with the turn so the next request can replay
+  // it and so a wrong number can be traced back to the call that produced it.
+  toolCalls: ToolCallRecord[];
+  model: string;
+  provider: string;
+  latencyMs: number;
+  inputTokens: number;
+  outputTokens: number;
+  // Money figures in `text` that appear in no tool result. Non-empty means the
+  // model invented or recomputed a number — the thing this whole design exists
+  // to prevent, so it is measured rather than assumed away.
+  ungroundedAmounts: string[];
+  // Set when the assistant proposed a write. Nothing has changed yet; the
+  // caller renders confirm/cancel buttons against this id.
+  pendingAction?: { id: string; summary: string } | undefined;
+}
+
+export interface IAssistantAgent {
+  answer(question: string, ctx: AssistantContext): Promise<AssistantAnswer>;
+}

--- a/src/domain/services/IAssistantAgent.ts
+++ b/src/domain/services/IAssistantAgent.ts
@@ -8,6 +8,9 @@ export interface AssistantContext {
   payday: number;
   monthlyIncome: string; // formatted
   today: string;
+  // From env.WEB_APP_URL, so a link the assistant hands out always matches
+  // where the app is actually deployed.
+  dashboardUrl: string;
   period: {
     start: string;
     end: string; // inclusive last day
@@ -42,6 +45,9 @@ export interface AssistantAnswer {
   // Set when the assistant proposed a write. Nothing has changed yet; the
   // caller renders confirm/cancel buttons against this id.
   pendingAction?: { id: string; summary: string } | undefined;
+  // Set when the assistant decided the user should go to the dashboard. The
+  // caller renders it as a button rather than pasting a URL into the text.
+  dashboardUrl?: string | undefined;
 }
 
 export interface IAssistantAgent {

--- a/src/domain/services/IAssistantWriteTools.ts
+++ b/src/domain/services/IAssistantWriteTools.ts
@@ -1,0 +1,50 @@
+// Writes the assistant can PROPOSE. Nothing here mutates the ledger: each
+// method records a PendingAction and returns its id plus the summary the user
+// will be asked to confirm. The actual write happens in a deterministic
+// processor after a button press.
+//
+// Failures are returned, never thrown, so the model can correct itself in-loop
+// (an unknown box name comes back with the list of real ones).
+export type ProposalResult =
+  | { ok: true; pendingId: string; summary: string }
+  | { ok: false; error: string; message: string; [extra: string]: unknown };
+
+export interface IAssistantWriteTools {
+  proposeRecurring(
+    userId: string,
+    input: {
+      kind: "INCOME" | "EXPENSE";
+      amount: number;
+      dayOfMonth: number;
+      bucket?: string | undefined;
+      category?: string | undefined;
+      note?: string | undefined;
+    },
+  ): Promise<ProposalResult>;
+
+  proposeBoxMove(
+    userId: string,
+    input: {
+      box: string;
+      amount: number;
+      direction: "IN" | "OUT";
+      note?: string | undefined;
+    },
+  ): Promise<ProposalResult>;
+
+  proposeDeleteExpense(
+    userId: string,
+    input: { expenseId: string },
+  ): Promise<ProposalResult>;
+
+  proposeExpenseEdit(
+    userId: string,
+    input: {
+      expenseId: string;
+      amount?: number | undefined;
+      bucket?: string | undefined;
+      category?: string | undefined;
+      note?: string | undefined;
+    },
+  ): Promise<ProposalResult>;
+}

--- a/src/domain/services/IFinancialDataTools.ts
+++ b/src/domain/services/IFinancialDataTools.ts
@@ -1,54 +1,163 @@
 import { Bucket } from "@prisma/client";
 
 // Read-only data accessors the query agent calls as tools. Each is scoped to a
-// single user (userId is bound server-side, never supplied by the model). All
-// dates are ISO strings on the wire; ranges default to the current budget cycle.
+// single user (userId is bound server-side, never supplied by the model).
+//
+// GROUNDING CONTRACT — every method here obeys all four:
+//  1. Money is returned PRE-FORMATTED ("₹1,200"). The model quotes strings; it
+//     never sees a raw rupee number it could do arithmetic on and get wrong.
+//  2. Every comparison/verdict the answer depends on is computed here, not by
+//     the model (see `status`, `verdict`, `direction`).
+//  3. Empty results carry an explicit `note` — "no rows" is not "spent ₹0".
+//  4. Dates on the wire are "YYYY-MM-DD" in the USER'S timezone, and `to` is
+//     INCLUSIVE (the caller-facing contract; converted to a half-open range
+//     internally). Exclusive end dates are an off-by-one trap for an LLM.
 
 export interface DateRange {
-  from?: string | undefined; // ISO date; defaults to current period start
-  to?: string | undefined; // ISO date (exclusive); defaults to current period end
+  from?: string | undefined; // YYYY-MM-DD; defaults to current cycle start
+  to?: string | undefined; // YYYY-MM-DD INCLUSIVE; defaults to current cycle end
 }
+
+// The range a result actually covers, echoed back so the model states the
+// window it is talking about instead of guessing what its input resolved to.
+export interface ResolvedRange {
+  from: string;
+  to: string; // inclusive
+}
+
+// Budget consumption for one bucket. `status` exists so the model never has to
+// compare spent against budget itself; `interpretation` exists because "over"
+// means something different for SAVINGS (good) than for WANTS (bad).
+export type BucketBudgetStatus =
+  | "NO_ACTIVITY"
+  | "ON_TRACK"
+  | "NEAR_LIMIT"
+  | "OVER";
 
 export interface BucketStatus {
   bucket: Bucket;
-  budget: number;
-  spent: number;
-  remaining: number;
+  budget: string;
+  spent: string;
+  remaining: string;
   pct: number;
+  safeDaily: string;
+  status: BucketBudgetStatus;
+  interpretation: string;
 }
 
 export interface PeriodStatus {
   currency: string;
   periodStart: string;
-  periodEnd: string;
+  periodEnd: string; // inclusive last day of the cycle
   day: number;
   daysInPeriod: number;
   remainingDays: number;
-  monthlyIncome: number; // effective income the budget is computed on
-  incomeLogged: number;
+  monthlyIncome: string; // effective income the budget is computed on
+  incomeLogged: string;
   buckets: BucketStatus[];
 }
 
-export interface CategoryTotal {
-  name: string;
-  total: number;
+export interface SpendByBucket {
+  range: ResolvedRange;
+  buckets: Array<{ bucket: Bucket; total: string }>;
+  note?: string;
+}
+
+export interface SpendByCategory {
+  range: ResolvedRange;
+  categories: Array<{ name: string; total: string }>;
+  note?: string;
+}
+
+export interface IncomeTotal {
+  range: ResolvedRange;
+  total: string;
+  note?: string;
 }
 
 export interface RecentExpense {
+  // Needed so the assistant can propose an edit or delete against a real row
+  // rather than describing one in prose.
+  id: string;
   date: string;
-  amount: number;
+  amount: string;
   bucket: Bucket;
   category: string;
   note: string | null;
 }
 
+export interface RecentExpenses {
+  rows: RecentExpense[];
+  note?: string;
+}
+
 export interface RecurringRuleSummary {
   kind: string;
-  amount: number;
+  amount: string;
   dayOfMonth: number;
   bucket: string | null;
   category: string | null;
   note: string | null;
+}
+
+export interface RecurringRules {
+  rules: RecurringRuleSummary[];
+  note?: string;
+}
+
+export interface CategorySummary {
+  name: string;
+  bucket: Bucket;
+  monthlyBudget: string | null;
+}
+
+export interface Categories {
+  categories: CategorySummary[];
+  note?: string;
+}
+
+export interface BoxSummary {
+  name: string;
+  balance: string;
+  target: string | null;
+  pctOfTarget: number | null;
+}
+
+export interface Boxes {
+  boxes: BoxSummary[];
+  note?: string;
+}
+
+export interface CycleSummary {
+  label: string; // "current" | "previous" | "3 cycles ago"
+  start: string;
+  end: string; // inclusive
+  total: string; // all-bucket spend
+  buckets: Array<{ bucket: Bucket; total: string }>;
+  income: string;
+}
+
+export interface CycleComparison {
+  cycles: CycleSummary[]; // newest first; [0] is the current (partial) cycle
+  // Null when there is no completed previous cycle to compare against.
+  vsPrevious: {
+    direction: "UP" | "DOWN" | "FLAT";
+    deltaPct: number;
+    delta: string; // signed, formatted
+    note: string; // states how far into the current cycle we are
+  } | null;
+}
+
+export interface Affordability {
+  amount: string;
+  bucket: Bucket;
+  verdict: "YES" | "TIGHT" | "NO";
+  remainingBefore: string;
+  remainingAfter: string;
+  daysLeft: number;
+  safeDailyBefore: string;
+  safeDailyAfter: string;
+  reason: string;
 }
 
 export interface IFinancialDataTools {
@@ -57,14 +166,14 @@ export interface IFinancialDataTools {
     userId: string,
     range: DateRange,
     bucket?: Bucket,
-  ): Promise<Array<{ bucket: Bucket; total: number }>>;
+  ): Promise<SpendByBucket>;
   getSpendByCategory(
     userId: string,
     range: DateRange,
     bucket?: Bucket,
     limit?: number,
-  ): Promise<CategoryTotal[]>;
-  getIncome(userId: string, range: DateRange): Promise<{ total: number }>;
+  ): Promise<SpendByCategory>;
+  getIncome(userId: string, range: DateRange): Promise<IncomeTotal>;
   getRecentExpenses(
     userId: string,
     opts: {
@@ -72,6 +181,18 @@ export interface IFinancialDataTools {
       category?: string | undefined;
       range?: DateRange | undefined;
     },
-  ): Promise<RecentExpense[]>;
-  getRecurringRules(userId: string): Promise<RecurringRuleSummary[]>;
+  ): Promise<RecentExpenses>;
+  getRecurringRules(userId: string): Promise<RecurringRules>;
+  getCategories(userId: string): Promise<Categories>;
+  getBoxes(userId: string): Promise<Boxes>;
+  // Current cycle vs the N most recent COMPLETE cycles, with the delta and
+  // direction computed here so the model never subtracts two totals itself.
+  compareCycles(userId: string, cycles?: number): Promise<CycleComparison>;
+  // Whether `amount` fits in the remaining bucket budget. The verdict is
+  // decided here — the prompt must never ask the model to do this subtraction.
+  checkAffordability(
+    userId: string,
+    amount: number,
+    bucket?: Bucket,
+  ): Promise<Affordability>;
 }

--- a/src/domain/services/IFinancialQueryAgent.ts
+++ b/src/domain/services/IFinancialQueryAgent.ts
@@ -3,16 +3,19 @@ import { ConversationTurn } from "./IAiParser";
 // Context the query agent needs to ground its answer. The agent itself is
 // read-only: it calls IFinancialDataTools to fetch real numbers and composes a
 // natural-language reply. It never writes/edits/deletes.
+// Dates here are YYYY-MM-DD in the USER'S timezone, never the server's — the
+// agent resolves "yesterday" against `today`, so a UTC date would put an IST
+// user a day behind every evening.
 export interface QueryAgentContext {
   userId: string;
   currency: string;
   locale: string;
   payday: number;
-  monthlyIncome: number; // expected salary (a floor); actual income may exceed it
-  now: Date;
+  monthlyIncome: string; // formatted; expected salary (a floor), actual may exceed it
+  today: string;
   period: {
-    start: string; // ISO
-    end: string; // ISO (exclusive)
+    start: string;
+    end: string; // inclusive last day of the cycle
     day: number;
     daysInPeriod: number;
     remainingDays: number;

--- a/src/domain/services/IFinancialQueryAgent.ts
+++ b/src/domain/services/IFinancialQueryAgent.ts
@@ -13,6 +13,7 @@ export interface QueryAgentContext {
   payday: number;
   monthlyIncome: string; // formatted; expected salary (a floor), actual may exceed it
   today: string;
+  dashboardUrl: string;
   period: {
     start: string;
     end: string; // inclusive last day of the cycle

--- a/src/presentation/controllers/TelegramWebhookController.ts
+++ b/src/presentation/controllers/TelegramWebhookController.ts
@@ -9,6 +9,9 @@ import { GeminiParser } from "../../data/ai/GeminiParser";
 import { OpenAIParser } from "../../data/ai/OpenAIParser";
 import { FallbackAiParser } from "../../data/ai/FallbackAiParser";
 import { OpenAiQueryAgent } from "../../data/ai/OpenAiQueryAgent";
+import { ClaudeAssistantAgent } from "../../data/ai/ClaudeAssistantAgent";
+import { AssistantWriteTools } from "../../application/use-cases/query/AssistantWriteTools";
+import { PrismaPendingActionRepository } from "../../data/repositories/PrismaPendingActionRepository";
 import { FinancialDataTools } from "../../application/use-cases/query/FinancialDataTools";
 import { SarvamTranscriptionService } from "../../data/ai/SarvamTranscriptionService";
 import { PrismaUserRepository } from "../../data/repositories/PrismaUserRepository";
@@ -84,8 +87,24 @@ const financialDataTools = new FinancialDataTools(
   budgetConfigRepository,
   recurringRuleRepository,
   categoryRepository,
+  boxRepository,
 );
 const queryAgent = new OpenAiQueryAgent(financialDataTools);
+
+// The assistant lane. Off unless both the flag and a key are set, so a missing
+// key degrades to the existing query path instead of breaking the bot.
+const assistantEnabled =
+  env.ASSISTANT_ENABLED && Boolean(env.ANTHROPIC_API_KEY);
+const pendingActionRepository = new PrismaPendingActionRepository();
+const assistantWriteTools = new AssistantWriteTools(
+  pendingActionRepository,
+  expenseRepository,
+  categoryRepository,
+  boxRepository,
+);
+const assistantAgent = assistantEnabled
+  ? new ClaudeAssistantAgent(financialDataTools, assistantWriteTools)
+  : null;
 
 const processIncomingMessage = new ProcessIncomingMessageUseCase(
   aiParser,
@@ -102,6 +121,8 @@ const processIncomingMessage = new ProcessIncomingMessageUseCase(
   queryAgent,
   runInTransaction,
   env.WEB_APP_URL,
+  assistantAgent,
+  assistantEnabled ? pendingActionRepository : null,
 );
 
 const processVoiceMessage = new ProcessVoiceMessageUseCase(

--- a/src/utils/describeError.spec.ts
+++ b/src/utils/describeError.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { describeError } from "./describeError";
+
+describe("describeError", () => {
+  it("extracts the message from an Error", () => {
+    expect(describeError(new Error("db is down"))).toBe("db is down");
+  });
+
+  it("survives JSON.stringify, which a raw Error does not", () => {
+    // This is the whole reason the helper exists. The logger serializes its
+    // fields with JSON.stringify, and Error's `message`/`stack` are
+    // non-enumerable — so `{ err: someError }` silently emits `{"err":{}}` and
+    // every server-side error log becomes useless.
+    const error = new Error("connection refused");
+
+    expect(JSON.stringify({ err: error })).toBe('{"err":{}}');
+    expect(JSON.stringify({ err: describeError(error) })).toBe(
+      '{"err":"connection refused"}',
+    );
+  });
+
+  it("handles a subclassed error", () => {
+    class Prismaish extends Error {}
+    expect(describeError(new Prismaish("P1001"))).toBe("P1001");
+  });
+
+  it("stringifies non-Error throws", () => {
+    expect(describeError("plain string")).toBe("plain string");
+    expect(describeError(undefined)).toBe("undefined");
+    expect(describeError({ code: 500 })).toBe("[object Object]");
+  });
+});

--- a/src/utils/describeError.ts
+++ b/src/utils/describeError.ts
@@ -1,0 +1,9 @@
+// Flatten an unknown thrown value to a loggable string.
+//
+// Necessary because the logger serializes fields with JSON.stringify, and
+// Error's `message`/`stack` are NON-ENUMERABLE — passing an Error straight
+// through as `{ err: error }` silently emits `{}`. Every log site that wants the
+// reason an operation failed has to call this first.
+export function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/utils/logger.spec.ts
+++ b/src/utils/logger.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+// The logger reads env at import time, so each case needs a fresh module.
+async function freshLogger(env: Record<string, string | undefined>) {
+  vi.resetModules();
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  return (await import("./logger")).logger;
+}
+
+function captureStdout() {
+  const lines: string[] = [];
+  const spy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk: any) => (lines.push(String(chunk)), true));
+  return { lines, spy };
+}
+
+describe("logger", () => {
+  const original = { ...process.env };
+
+  beforeEach(() => vi.resetModules());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...original };
+  });
+
+  it("defaults to info in production, not debug", async () => {
+    // The old threshold expression made this branch unreachable, so production
+    // logged at debug — dumping every raw parser response, which carries the
+    // user's message text and their parsed financial data.
+    const log = await freshLogger({
+      NODE_ENV: "production",
+      LOG_LEVEL: undefined,
+      LOG_FORMAT: undefined,
+    });
+    const { lines } = captureStdout();
+
+    log.debug("should be suppressed", {});
+    log.info("should appear", {});
+
+    expect(lines.join("")).not.toContain("should be suppressed");
+    expect(lines.join("")).toContain("should appear");
+  });
+
+  it("keeps debug in development", async () => {
+    const log = await freshLogger({
+      NODE_ENV: "development",
+      LOG_LEVEL: undefined,
+      LOG_FORMAT: undefined,
+    });
+    const { lines } = captureStdout();
+
+    log.debug("visible in dev", {});
+    expect(lines.join("")).toContain("visible in dev");
+  });
+
+  it("still honours an explicit LOG_LEVEL", async () => {
+    const log = await freshLogger({
+      NODE_ENV: "development",
+      LOG_LEVEL: "warn",
+      LOG_FORMAT: undefined,
+    });
+    const { lines } = captureStdout();
+
+    log.info("suppressed by level", {});
+    expect(lines.join("")).not.toContain("suppressed by level");
+  });
+
+  it("emits JSON in production so aggregators can parse it", async () => {
+    const log = await freshLogger({
+      NODE_ENV: "production",
+      LOG_LEVEL: undefined,
+      LOG_FORMAT: undefined,
+    });
+    const { lines } = captureStdout();
+
+    log.info("hello", { port: 4000 });
+    expect(JSON.parse(lines[0]!)).toMatchObject({
+      level: "info",
+      msg: "hello",
+      port: 4000,
+    });
+  });
+
+  describe("pretty mode", () => {
+    it("renders one readable line instead of escaped JSON", async () => {
+      const log = await freshLogger({
+        NODE_ENV: "development",
+        LOG_LEVEL: undefined,
+        LOG_FORMAT: "pretty",
+      });
+      const { lines } = captureStdout();
+
+      log.info("Assistant failed", { userId: "u1", err: "fetch failed" });
+
+      expect(lines[0]).toContain("INFO");
+      expect(lines[0]).toContain("Assistant failed");
+      expect(lines[0]).toContain("userId=u1");
+      expect(lines[0]).toContain("err=fetch failed");
+      expect(lines[0]).not.toContain('\\"');
+    });
+
+    it("truncates a long value rather than flooding the terminal", async () => {
+      const log = await freshLogger({
+        NODE_ENV: "development",
+        LOG_LEVEL: undefined,
+        LOG_FORMAT: "pretty",
+      });
+      const { lines } = captureStdout();
+
+      log.debug("parser response", { responseText: "x".repeat(1000) });
+
+      expect(lines[0]!.length).toBeLessThan(400);
+      expect(lines[0]).toContain("chars)");
+    });
+
+    it("omits undefined fields", async () => {
+      const log = await freshLogger({
+        NODE_ENV: "development",
+        LOG_LEVEL: undefined,
+        LOG_FORMAT: "pretty",
+      });
+      const { lines } = captureStdout();
+
+      log.info("msg", { present: 1, missing: undefined });
+      expect(lines[0]).toContain("present=1");
+      expect(lines[0]).not.toContain("missing");
+    });
+  });
+
+  it("lets LOG_FORMAT=json force JSON in development", async () => {
+    const log = await freshLogger({
+      NODE_ENV: "development",
+      LOG_LEVEL: undefined,
+      LOG_FORMAT: "json",
+    });
+    const { lines } = captureStdout();
+
+    log.info("hello", {});
+    expect(() => JSON.parse(lines[0]!)).not.toThrow();
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -12,23 +12,76 @@ const LEVELS: Record<Level, number> = {
   error: 40,
 };
 
-const configured = (process.env["LOG_LEVEL"] as Level | undefined) ?? null;
+const isProduction = process.env["NODE_ENV"] === "production";
+
+// `LEVELS[configured ?? "debug"]` would resolve for the unset case too, so the
+// production default below was unreachable and prod logged at debug — dumping
+// every raw parser response, which carries the user's message and their parsed
+// financial data.
+const configured = process.env["LOG_LEVEL"] as Level | undefined;
 const threshold =
-  LEVELS[configured ?? "debug"] ??
-  (process.env["NODE_ENV"] === "production" ? LEVELS.info : LEVELS.debug);
+  (configured ? LEVELS[configured] : undefined) ??
+  (isProduction ? LEVELS.info : LEVELS.debug);
+
+// JSON is for log aggregators; a human reading a terminal wants columns. Pretty
+// in dev, JSON in production, `LOG_FORMAT` overrides either way.
+const format = process.env["LOG_FORMAT"];
+const pretty = format ? format === "pretty" : !isProduction;
+
+// Long values (a whole parser response) destroy readability. Truncate in pretty
+// mode only — JSON output stays complete so nothing is lost for real debugging.
+const MAX_VALUE_CHARS = 180;
 
 type Fields = Record<string, unknown>;
 
+const LEVEL_COLOR: Record<Level, string> = {
+  debug: "\x1b[90m",
+  info: "\x1b[36m",
+  warn: "\x1b[33m",
+  error: "\x1b[31m",
+};
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+function color(text: string, code: string, tty: boolean): string {
+  return tty ? `${code}${text}${RESET}` : text;
+}
+
+function renderValue(value: unknown): string {
+  const raw = typeof value === "string" ? value : JSON.stringify(value);
+  const text = raw ?? String(value);
+  return text.length > MAX_VALUE_CHARS
+    ? `${text.slice(0, MAX_VALUE_CHARS)}… (+${text.length - MAX_VALUE_CHARS} chars)`
+    : text;
+}
+
+function formatPretty(
+  level: Level,
+  msg: string,
+  fields: Fields,
+  tty: boolean,
+): string {
+  const time = new Date().toISOString().slice(11, 19);
+  const head = `${color(time, DIM, tty)} ${color(level.toUpperCase().padEnd(5), LEVEL_COLOR[level], tty)} ${msg}`;
+  const rest = Object.entries(fields)
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => `${color(k + "=", DIM, tty)}${renderValue(v)}`);
+  return rest.length === 0 ? head : `${head}  ${rest.join(" ")}`;
+}
+
 function emit(level: Level, msg: string, fields: Fields): void {
   if (LEVELS[level] < threshold) return;
-  const line = JSON.stringify({
-    level,
-    time: new Date().toISOString(),
-    msg,
-    ...fields,
-  });
-  if (level === "error" || level === "warn") process.stderr.write(line + "\n");
-  else process.stdout.write(line + "\n");
+  const stream =
+    level === "error" || level === "warn" ? process.stderr : process.stdout;
+  const line = pretty
+    ? formatPretty(level, msg, fields, Boolean(stream.isTTY))
+    : JSON.stringify({
+        level,
+        time: new Date().toISOString(),
+        msg,
+        ...fields,
+      });
+  stream.write(line + "\n");
 }
 
 export interface Logger {

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -112,6 +112,7 @@ model User {
   boxEntries     BoxEntry[]
 
   conversationMessages ConversationMessage[]
+  pendingActions       PendingAction[]
   telegramLinkToken    TelegramLinkToken?
 }
 
@@ -383,13 +384,57 @@ model ProcessedMessage {
   processedAt DateTime @default(now())
 }
 
+// Rolling chat history replayed to the AI. Beyond the rendered text, a turn
+// carries what the bot actually DID (intent, the rows it touched, the tools it
+// called) so a follow-up like "make it 50" resolves to a real transaction
+// instead of being guessed from emoji-laden prose. The AI-metadata columns are
+// nullable: deterministic slash-command turns fill none of them.
 model ConversationMessage {
-  id        String   @id @default(cuid())
-  userId    String
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  role      String
-  content   String
+  id String @id @default(cuid())
+  // Append order. createdAt is not safe to order by: two turns written in the
+  // same millisecond tie, and across instances clocks drift — either way the
+  // transcript replayed to the model comes back scrambled.
+  seq     Int    @default(autoincrement())
+  userId  String
+  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  role    String
+  content String
+
+  // What the turn resolved to, and which rows it touched.
+  intent     String?
+  entityRefs Json?
+
+  // Per-turn AI trace: [{ name, args, result }]. Null for non-AI turns.
+  toolCalls Json?
+
+  // Observability — which model answered, how slow, how much it cost.
+  provider     String?
+  model        String?
+  latencyMs    Int?
+  inputTokens  Int?
+  outputTokens Int?
+  costUsd      Decimal? @db.Decimal(10, 6)
+
   createdAt DateTime @default(now())
+
+  @@index([userId, seq])
+}
+
+// A write the assistant has PROPOSED but not performed. The agent's tools only
+// ever create one of these; the user confirms with an inline button and a
+// deterministic processor does the actual write. Keeps a misread instruction
+// from silently mutating the ledger, the way a hallucinated income already
+// inflates every bucket budget today.
+model PendingAction {
+  id         String    @id @default(cuid())
+  userId     String
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  kind       String // PendingActionKind — validated with Zod on read
+  payload    Json
+  summary    String // what the user is shown before confirming
+  expiresAt  DateTime
+  consumedAt DateTime?
+  createdAt  DateTime  @default(now())
 
   @@index([userId, createdAt])
 }


### PR DESCRIPTION
Makes the bot answer money questions with numbers it can actually stand behind, and lets it answer questions about itself.

Researched how [we-promise/sure](https://github.com/we-promise/sure) does this. Their lesson: there is no intent classifier and no router — one agent, tools, and anti-hallucination that is ~85% architecture and ~15% prompt. Their system prompt does not contain "never make up numbers"; the strong language lives in tool descriptions.

## The problem

The `QUERY` path was the only place the model emitted final numbers as free text, returned to Telegram unchecked. Concretely:

- The parser prompt advertised *"am I spending more than last month?"* with **no previous-cycle tool** — `previousCycles()` sat unused in `budgetMath.ts`.
- Affordability was explicit LLM arithmetic: the prompt told the model to *"compare the amount to the remaining budget… and the days left"*.
- Model-supplied dates parsed as **UTC midnight** against IST cycle bounds, and the parser's `[Today]` told an IST user it was yesterday every evening after 18:30. `User.timezone` existed and no AI path read it.
- Conversation memory was rendered emoji prose, clipped to 200 chars, written fire-and-forget, and **not written at all** on the pre-parse path — so `/status` and every button press were invisible to the model.

## The approach

Grounding is structural, not prompt-based:

1. **Money is pre-formatted.** The model quotes strings; it never sees a rupee number it could get wrong.
2. **Verdicts are precomputed.** `check_affordability` returns `YES|TIGHT|NO`, `compare_cycles` returns direction and delta, bucket health returns a `status` enum. If the model would need to calculate, there is a tool.
3. **Schemas carry the user's real category names** as an `enum` — it cannot filter on, or invent, a category that doesn't exist.
4. **Tools never throw.** Failures return `{ ok: false, error, ...options }` so the model self-corrects in-loop.
5. **Absence ≠ zero.** Empty results carry an explicit note.
6. **One timezone, inclusive end dates** — exclusive ends are an off-by-one trap for an LLM.

`groundingCheck` then cross-checks every ₹ figure in an answer against the tool results behind it, so hallucination is measured rather than assumed away.

**Writes are proposals.** `propose_*` tools resolve references against real rows and stage a `PendingAction`; the user confirms with a button and a deterministic processor re-checks ownership, expiry and single-use before writing. The confirmation shows the **server-built summary**, not the model's prose.

**Product questions** are grounded the same way, from `productFacts.ts` — an invented feature is worse than a wrong number, because the user goes looking for it.

## Also fixed

- **Category filters silently returned nothing.** `findRecent` resolved a name with a bare `findFirst`, picking the shared system template while the user's expenses point at their own row. Every category-filtered query reported "no spending" for categories in active use. Caught by the grounding check firing on real traffic.
- **Error logging was a no-op.** The logger serializes with `JSON.stringify` and `Error.message` is non-enumerable, so every `err: error` emitted `{}`. Production also logged at debug — the `NODE_ENV` branch was unreachable — dumping raw parser responses containing user message text.
- **`/help` hardcoded `blipko.lol`**, sending any other deployment's users to the wrong app.

## Security review

Two independent passes over the authz and data-exposure paths. `userId` is bound server-side with no channel for the model to supply one; cross-user `PendingAction` access is blocked twice; ownership is re-checked at apply time; `consume` runs before the write; payloads are Zod-validated on read; no raw SQL; no cross-tenant read path; the API key never reaches logs or the DB.

One real finding, fixed: the confirmation rendered the model's prose instead of the verified summary, and `latestProposal` was last-wins — so with two proposals in one round the button could apply a different action than the text described. Now one proposal per turn, with the verified summary shown.

## Verification

- **325 tests** (from 177), `tsc`, lint and build clean
- Live-tested against the real Anthropic API: comparisons repeat the partial-cycle caveat, affordability quotes the server verdict, a no-data category says so rather than reporting ₹0, and a box move proposes without writing
- Turn ordering and the confirm/double-tap/expiry cycle verified against real Postgres

## Deploying

**Nothing changes in production until `ASSISTANT_ENABLED=true` and `ANTHROPIC_API_KEY` are set on Railway.** With either unset, the parser stays in 8-intent mode and the existing query agent answers as before.

Three migrations apply via `prisma migrate deploy`. `conversation_message_seq` adds a `SERIAL` column that backfills in physical row order, which may not exactly match `createdAt` for existing rows — it only affects the rolling 6-row history window.