### PR TITLE
fix(cron): gate scheduled jobs on a window, not one hour

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,11 +1,15 @@
 name: cron-tick
 
 # Drives the backend's scheduled jobs (nudges, cycle report, recurring). Each job
-# self-gates on the user's local hour, so an hourly UTC tick covers every local
-# hour once per day. Runs on a schedule + on-demand via the Actions tab.
+# self-gates on a multi-hour window in the user's local timezone and is deduped by
+# its own ledger, so a dense UTC tick covers every local window once per day and
+# extra ticks are no-ops. Runs on a schedule + on-demand via the Actions tab.
+#
+# Every 20 min, not hourly: GitHub's shared schedulers routinely delay runs by
+# 20-50 min and drop them under load, and ":00" is the most congested slot.
 on:
   schedule:
-    - cron: "0 * * * *" # hourly, on the hour (UTC)
+    - cron: "*/20 * * * *"
   workflow_dispatch: {}
 
 jobs:

--- a/src/application/use-cases/PostRecurringCharges.spec.ts
+++ b/src/application/use-cases/PostRecurringCharges.spec.ts
@@ -77,6 +77,50 @@ describe("PostRecurringCharges", () => {
     );
   });
 
+  // The posting window (06:00-09:59 local) — no `force`, so this is the gate.
+  describe("local posting window", () => {
+    const at = (hour: number) => new Date(Date.UTC(2026, 5, 15, hour));
+
+    it("stays quiet before the window opens", async () => {
+      const { posted } = await useCase.execute(at(5));
+      expect(posted).toBe(0);
+      expect(expenseRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("posts at the opening hour", async () => {
+      const { posted } = await useCase.execute(at(6));
+      expect(posted).toBe(1);
+    });
+
+    it("still posts late in the window, so a delayed tick is not lost", async () => {
+      const { posted } = await useCase.execute(at(9));
+      expect(posted).toBe(1);
+    });
+
+    it("stays quiet after the window closes", async () => {
+      const { posted } = await useCase.execute(at(10));
+      expect(posted).toBe(0);
+    });
+
+    it("posts once across several ticks inside the window", async () => {
+      // Stand in for lastPostedKey: markPosted flips the rule for later ticks.
+      recurringRuleRepository.markPosted = vi.fn(
+        async (id: string, key: string) => {
+          recurringRuleRepository.findAllActive.mockResolvedValue([
+            { ...expenseRule, id, lastPostedKey: key },
+          ]);
+        },
+      );
+
+      const first = await useCase.execute(at(6));
+      const second = await useCase.execute(at(8));
+
+      expect(first.posted).toBe(1);
+      expect(second.posted).toBe(0);
+      expect(expenseRepository.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("posts a due box contribution as an IN entry, notifies without undo hint", async () => {
     recurringRuleRepository.findAllActive.mockResolvedValue([
       {

--- a/src/application/use-cases/PostRecurringCharges.ts
+++ b/src/application/use-cases/PostRecurringCharges.ts
@@ -8,10 +8,13 @@ import { IBoxRepository } from "../../domain/repositories/IBoxRepository";
 import { RunInTransaction } from "../../domain/repositories/UnitOfWork";
 import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import { postRecurringRule } from "./postRecurringRule";
-import { zonedParts } from "../../utils/time";
+import { inLocalHourWindow, zonedParts } from "../../utils/time";
 
-// Recurring rules auto-post at ~06:00 in the owner's local timezone.
+// Recurring rules auto-post in the 06:00-09:59 window of the owner's local
+// timezone. A window and not a single hour because the cron tick drifts and is
+// sometimes dropped; `lastPostedKey` keeps it to one post per month regardless.
 const RECURRING_HOUR = 6;
+const RECURRING_WINDOW_HOURS = 4;
 
 export interface PostRecurringChargesResult {
   posted: number;
@@ -51,8 +54,17 @@ export class PostRecurringChargesUseCase {
         }
         if (!user?.telegramId) continue;
 
-        const { year, month, day, hour } = zonedParts(now, user.timezone);
-        if (!force && hour !== RECURRING_HOUR) continue;
+        const { year, month, day } = zonedParts(now, user.timezone);
+        if (
+          !force &&
+          !inLocalHourWindow(
+            now,
+            user.timezone,
+            RECURRING_HOUR,
+            RECURRING_WINDOW_HOURS,
+          )
+        )
+          continue;
 
         const monthKey = `${year}-${String(month).padStart(2, "0")}`;
         if (rule.lastPostedKey === monthKey) continue; // already posted this month

--- a/src/application/use-cases/SendBudgetNudges.spec.ts
+++ b/src/application/use-cases/SendBudgetNudges.spec.ts
@@ -118,6 +118,86 @@ describe("SendBudgetNudges", () => {
     expect(messageService.sendMessage).not.toHaveBeenCalled();
   });
 
+  // The delivery window (19:00-22:59 local). The fixture user is on UTC, so the
+  // UTC hour is the local hour. These run WITHOUT force — they are the gate.
+  describe("local delivery window", () => {
+    const at = (hour: number) => new Date(Date.UTC(2026, 5, 15, hour));
+
+    it("stays quiet before the window opens", async () => {
+      setSpend({ WANTS: 16200 });
+
+      const result = await useCase.execute(at(18));
+
+      expect(result.sent).toBe(0);
+      expect(result.skipped.outsideWindow).toBe(1);
+      expect(messageService.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("sends at the opening hour", async () => {
+      setSpend({ WANTS: 16200 });
+
+      const { sent } = await useCase.execute(at(19));
+
+      expect(sent).toBe(1);
+    });
+
+    it("still sends late in the window, so a delayed tick is not lost", async () => {
+      setSpend({ WANTS: 16200 });
+
+      const { sent } = await useCase.execute(at(22));
+
+      expect(sent).toBe(1);
+    });
+
+    it("stays quiet after the window closes", async () => {
+      setSpend({ WANTS: 16200 });
+
+      const result = await useCase.execute(at(23));
+
+      expect(result.sent).toBe(0);
+      expect(result.skipped.outsideWindow).toBe(1);
+    });
+
+    it("sends once across several ticks inside the window", async () => {
+      setSpend({ WANTS: 16200 });
+      // Stand in for the unique index: the first record wins, later ones lose.
+      const recorded = new Set<string>();
+      nudgeRepository.recordSentIfNew = vi.fn(
+        (u: string, b: string, k: string, key: string) => {
+          const id = [u, b, k, key].join("|");
+          if (recorded.has(id)) return Promise.resolve(false);
+          recorded.add(id);
+          return Promise.resolve(true);
+        },
+      );
+
+      const first = await useCase.execute(at(19));
+      const second = await useCase.execute(at(21));
+
+      expect(first.sent).toBe(1);
+      expect(second.sent).toBe(0);
+      expect(messageService.sendMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("reports why users were skipped", async () => {
+    userRepository.findOnboardedWithTelegram.mockResolvedValue([
+      { ...user, id: "off", notificationDosage: "OFF" },
+      { ...user, id: "noTg", telegramId: null },
+      { ...user, id: "broke", monthlyIncome: 0 },
+    ]);
+
+    const result = await useCase.execute(NOW, true);
+
+    expect(result.considered).toBe(3);
+    expect(result.skipped).toEqual({
+      dosageOff: 1,
+      noTelegram: 1,
+      noIncome: 1,
+      outsideWindow: 0,
+    });
+  });
+
   it("adds a daily check-in summary for RELENTLESS on top of alerts", async () => {
     userRepository.findOnboardedWithTelegram.mockResolvedValue([
       { ...user, notificationDosage: "RELENTLESS" },

--- a/src/application/use-cases/SendBudgetNudges.ts
+++ b/src/application/use-cases/SendBudgetNudges.ts
@@ -15,16 +15,31 @@ import {
   periodKey,
   pctSpent,
 } from "./budgetMath";
-import { zonedParts, zonedYmd } from "../../utils/time";
+import { inLocalHourWindow, zonedYmd } from "../../utils/time";
 
 const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
 // Savings overspend is good, not a leak — only nudge the spending buckets.
 const WATCHED: Bucket[] = ["NEEDS", "WANTS"];
-// Nudges go out at ~19:00 in each user's local timezone.
+// Nudges go out in the 19:00-22:59 window of each user's local timezone. It is a
+// window and not a single hour because the cron tick drifts and is sometimes
+// dropped; an exact-hour gate loses the whole day's nudges when that happens.
+// Every nudge is ledger-deduped per day or per cycle, so extra ticks inside the
+// window cannot re-send.
 const NUDGE_HOUR = 19;
+const NUDGE_WINDOW_HOURS = 4;
+
+export type NudgeSkipReason =
+  | "noTelegram"
+  | "dosageOff"
+  | "outsideWindow"
+  | "noIncome";
 
 export interface SendBudgetNudgesResult {
   sent: number;
+  considered: number;
+  // Why the other users got nothing — without this, `sent: 0` is indistinguishable
+  // from the job never running at all.
+  skipped: Record<NudgeSkipReason, number>;
 }
 
 // Proactive reminders, gated by each user's notificationDosage:
@@ -51,15 +66,23 @@ export class SendBudgetNudgesUseCase {
     const users = await this.userRepository.findOnboardedWithTelegram();
 
     let sent = 0;
+    const skipped: Record<NudgeSkipReason, number> = {
+      noTelegram: 0,
+      dosageOff: 0,
+      outsideWindow: 0,
+      noIncome: 0,
+    };
     for (const user of users) {
       try {
-        sent += await this.nudgeUser(user, now, force);
+        const result = await this.nudgeUser(user, now, force);
+        sent += result.sent;
+        if (result.skip) skipped[result.skip]++;
       } catch (err) {
         // One user's failure must not abort the batch.
         console.error(`Nudge failed for user ${user.id}:`, err);
       }
     }
-    return { sent };
+    return { sent, considered: users.length, skipped };
   }
 
   private async nudgeUser(
@@ -73,13 +96,16 @@ export class SendBudgetNudgesUseCase {
     },
     now: Date,
     force: boolean,
-  ): Promise<number> {
+  ): Promise<{ sent: number; skip?: NudgeSkipReason }> {
     const dosage = user.notificationDosage;
-    if (!user.telegramId || dosage === "OFF") return 0;
+    if (!user.telegramId) return { sent: 0, skip: "noTelegram" };
+    if (dosage === "OFF") return { sent: 0, skip: "dosageOff" };
 
-    // Send only at the user's local evening hour (unless forced for testing).
+    // Send only inside the user's local evening window (unless forced for testing).
     const tz = user.timezone;
-    if (!force && zonedParts(now, tz).hour !== NUDGE_HOUR) return 0;
+    if (!force && !inLocalHourWindow(now, tz, NUDGE_HOUR, NUDGE_WINDOW_HOURS)) {
+      return { sent: 0, skip: "outsideWindow" };
+    }
 
     const loud = dosage === "AGGRESSIVE" || dosage === "RELENTLESS";
 
@@ -94,7 +120,7 @@ export class SendBudgetNudgesUseCase {
       Number(user.monthlyIncome ?? 0),
       await this.incomeRepository.sumForMonth(user.id, start, end),
     );
-    if (income <= 0) return 0;
+    if (income <= 0) return { sent: 0, skip: "noIncome" };
 
     const config =
       (await this.budgetConfigRepository.findByUserId(user.id)) ??
@@ -182,7 +208,7 @@ export class SendBudgetNudgesUseCase {
         sent++;
       }
     }
-    return sent;
+    return { sent };
   }
 
   private async send(telegramId: string, body: string): Promise<void> {

--- a/src/application/use-cases/SendCycleReport.spec.ts
+++ b/src/application/use-cases/SendCycleReport.spec.ts
@@ -71,6 +71,32 @@ describe("SendCycleReport", () => {
     expect(messageService.sendMessage).not.toHaveBeenCalled();
   });
 
+  // The delivery window (07:00-10:59 local) — no `force`, so this is the gate.
+  describe("local delivery window", () => {
+    const dayOne = (hour: number) => new Date(Date.UTC(2026, 5, 1, hour));
+
+    it("stays quiet before the window opens", async () => {
+      const { sent } = await useCase.execute(dayOne(6));
+      expect(sent).toBe(0);
+      expect(messageService.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("sends at the opening hour", async () => {
+      const { sent } = await useCase.execute(dayOne(7));
+      expect(sent).toBe(1);
+    });
+
+    it("still sends late in the window, so a delayed tick is not lost", async () => {
+      const { sent } = await useCase.execute(dayOne(10));
+      expect(sent).toBe(1);
+    });
+
+    it("stays quiet after the window closes", async () => {
+      const { sent } = await useCase.execute(dayOne(11));
+      expect(sent).toBe(0);
+    });
+  });
+
   it("is idempotent — skips when already recorded for this cycle", async () => {
     nudgeRepository.recordSentIfNew.mockResolvedValue(false);
     const { sent } = await useCase.execute(

--- a/src/application/use-cases/SendCycleReport.ts
+++ b/src/application/use-cases/SendCycleReport.ts
@@ -6,10 +6,14 @@ import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
 import { IMessagingPlatform } from "../interfaces/IMessagingPlatform";
 import { buildCycleReport } from "./cycleReport";
 import { periodDayInfo } from "./budgetMath";
-import { zonedParts } from "../../utils/time";
+import { inLocalHourWindow } from "../../utils/time";
 
-// The cycle report goes out at ~07:00 in the user's local timezone, on day 1.
+// The cycle report goes out in the 07:00-10:59 window of the user's local
+// timezone, on day 1. A window and not a single hour because the cron tick
+// drifts and is sometimes dropped; the CYCLE_REPORT ledger row keeps it to one
+// send per ended cycle no matter how many ticks land inside the window.
 const REPORT_HOUR = 7;
+const REPORT_WINDOW_HOURS = 4;
 
 export interface SendCycleReportResult {
   sent: number;
@@ -62,7 +66,8 @@ export class SendCycleReportUseCase {
     if (!user.telegramId) return 0;
     const tz = user.timezone;
     // Morning of day 1 in the user's timezone (unless forced for testing).
-    if (!force && zonedParts(now, tz).hour !== REPORT_HOUR) return 0;
+    if (!force && !inLocalHourWindow(now, tz, REPORT_HOUR, REPORT_WINDOW_HOURS))
+      return 0;
     if (periodDayInfo(user.payday, now, tz).day !== 1) return 0;
 
     const { text, endedKey } = await buildCycleReport(

--- a/src/presentation/controllers/CronController.ts
+++ b/src/presentation/controllers/CronController.ts
@@ -11,10 +11,12 @@ import { logger } from "../../utils/logger";
 const log = logger.child({ component: "cron" });
 const PRUNE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
-// Runs the scheduled jobs, driven by an hourly Railway cron hitting
-// POST /api/cron/tick with the shared secret. Each job self-gates on the user's
-// local hour, so the same hourly tick delivers everything at the right local
-// time. `?force=1` bypasses the hour gate (testing); `?only=nudges|recurring|report`
+// Runs the scheduled jobs, driven by the GitHub Actions cron
+// (.github/workflows/cron.yml) hitting POST /api/cron/tick with the shared
+// secret every 20 minutes. Each job self-gates on a multi-hour window in the
+// user's local timezone and dedupes itself, so the same tick delivers everything
+// at the right local time and repeat ticks inside a window are no-ops.
+// `?force=1` bypasses the window gate (testing); `?only=nudges|recurring|report`
 // runs a single job.
 export class CronController {
   constructor(

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -48,6 +48,20 @@ export function zonedParts(date: Date, tz: string): ZonedParts {
   };
 }
 
+// True when `date` falls in [startHour, startHour + hours) local wall-clock in
+// `tz`. Scheduled jobs gate on a window, not an exact hour: the cron tick drifts
+// by tens of minutes and is sometimes dropped outright, and an exact-hour gate
+// turns either into a silently lost day.
+export function inLocalHourWindow(
+  date: Date,
+  tz: string,
+  startHour: number,
+  hours: number,
+): boolean {
+  const { hour } = zonedParts(date, tz);
+  return hour >= startHour && hour < startHour + hours;
+}
+
 // "YYYY-MM-DD" of `date` in the given timezone.
 export function zonedYmd(date: Date, tz: string): string {
   return new Intl.DateTimeFormat("en-CA", {


### PR DESCRIPTION
## Why

Users set a reminder dosage and got nothing, or got it on some days and not others. The dosage code was never the problem — **the job that reads it did not run.**

Every scheduled job gated on exact local-hour equality:

```ts
if (!force && zonedParts(now, tz).hour !== NUDGE_HOUR) return 0;
```

One qualifying tick per user per day, no catch-up if missed. The driver is GitHub Actions, whose scheduled runs are best-effort. 19 IST days of `gh run list --workflow=cron.yml`: every run succeeded, but only ~17.4 of 24 hourly ticks landed, with 20–50 min drift routine and `:00` the most congested slot. For `Asia/Kolkata` (the default timezone) that left 30 minutes of tolerance before a tick drifted into the next local hour and the gate rejected it.

Whole days were lost — on a lost day every user got nothing, at every dosage:

| Job | Local hour | Days the hour was never observed |
|---|---|---|
| Budget nudges | 19:00 | **7 / 19 (37%)** |
| Cycle report | 07:00 | **12 / 19 (63%)** |
| Recurring charges | 06:00 | **9 / 19 (47%)** |

## What

- New `inLocalHourWindow()` in `src/utils/time.ts`; all three jobs gate on a 4h window instead of one hour. Each already dedupes independently of the hour — nudges on the `BudgetNudge` unique index, the report on its `CYCLE_REPORT` row, recurring on `lastPostedKey` — so extra ticks inside a window are no-ops. Bounded at 4h rather than open to end-of-day so a "daily check-in" cannot arrive at 23:55.
- Cron `0 * * * *` → `*/20 * * * *`: triples tick density and moves off `:00`, so the window fix is not carrying the whole load alone.
- Nudges now return `considered` and per-reason skip counters. `sent: 0` was indistinguishable from "the job never ran", which is why this went unnoticed.

## Verified

- `pnpm build` and `pnpm lint` clean; `pnpm test:unit` **356 passed** (was 343). 13 new tests: window boundaries per job, plus dedupe tests proving several ticks inside a window send once.
- **Regression proven, not assumed.** Temporarily reverting `inLocalHourWindow` to `hour === startHour` fails 3 tests, one per job ("still sends late in the window").
- Live against a local DB, no `force`, at local hour 23 (outside the window):
  ```json
  {"sent":0,"considered":1,"skipped":{"noTelegram":0,"dosageOff":0,"outsideWindow":1,"noIncome":0}}
  ```
  Previously a bare `{"sent":0}` — the ambiguity that hid this.

Not verified locally: the Playwright API suite (CI covers it), and an in-window live send, which would DM a real Telegram chat.

## Deliberately left alone

Real, but neither is why notifications stopped arriving:

- `RELENTLESS` is silent between 80% and 100% of budget — `WARN_80` is cycle-keyed for every dosage; only over-budget repeats daily.
- `periodKey()` returns `YYYY-MM-DD` (the cycle start date) and shares one string column with `dayKey`. They collide on a payday-1 cycle boundary, which can suppress one alert.