### PR TITLE
fix(nudges): make reminder frequency control frequency

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,8 +116,11 @@ model User {
   telegramLinkToken    TelegramLinkToken?
 }
 
-// Idempotency log for proactive nudges: at most one row per
-// (user, bucket, kind, month), so a nudge is sent once per month, not daily.
+// Idempotency log for proactive nudges. periodKey carries the repeat scope, and
+// the scope IS the repeat rate — see SendBudgetNudges. One of:
+//   "c:<cycle-start>"        once per budget cycle
+//   "d:<date>"               once per day
+//   "d:<date>#<hour>"        once per send window
 model BudgetNudge {
   id        String    @id @default(cuid())
   userId    String

--- a/src/application/use-cases/SendBudgetNudges.spec.ts
+++ b/src/application/use-cases/SendBudgetNudges.spec.ts
@@ -59,7 +59,7 @@ describe("SendBudgetNudges", () => {
 
     const { sent } = await useCase.execute(NOW, true);
 
-    expect(sent).toBe(1);
+    expect(sent).toBe(2); // the alert, plus the check-in every dosage now gets
     expect(nudgeRepository.recordSentIfNew).toHaveBeenCalledWith(
       "u1",
       "WANTS",
@@ -97,13 +97,19 @@ describe("SendBudgetNudges", () => {
     expect(messageService.sendMessage).not.toHaveBeenCalled();
   });
 
-  it("stays quiet when buckets are under the threshold", async () => {
+  it("sends only the check-in when every bucket is under the threshold", async () => {
     setSpend({ NEEDS: 5000, WANTS: 5000 });
 
-    await useCase.execute(NOW, true);
+    const { sent } = await useCase.execute(NOW, true);
 
-    expect(nudgeRepository.recordSentIfNew).not.toHaveBeenCalled();
-    expect(messageService.sendMessage).not.toHaveBeenCalled();
+    expect(sent).toBe(1);
+    const kinds = nudgeRepository.recordSentIfNew.mock.calls.map(
+      (c: any) => c[2],
+    );
+    expect(kinds).toEqual(["CHECKIN"]);
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "Daily check-in",
+    );
   });
 
   it("sends nothing when the user's dosage is OFF", async () => {
@@ -118,49 +124,14 @@ describe("SendBudgetNudges", () => {
     expect(messageService.sendMessage).not.toHaveBeenCalled();
   });
 
-  // The delivery window (19:00-22:59 local). The fixture user is on UTC, so the
-  // UTC hour is the local hour. These run WITHOUT force — they are the gate.
-  describe("local delivery window", () => {
-    const at = (hour: number) => new Date(Date.UTC(2026, 5, 15, hour));
+  // Send windows are per dosage, and the fixture user is on UTC, so the UTC hour
+  // IS the local hour. These run WITHOUT force — they are the gate.
+  describe("send windows per dosage", () => {
+    const at = (hour: number, day = 15) =>
+      new Date(Date.UTC(2026, 5, day, hour));
 
-    it("stays quiet before the window opens", async () => {
-      setSpend({ WANTS: 16200 });
-
-      const result = await useCase.execute(at(18));
-
-      expect(result.sent).toBe(0);
-      expect(result.skipped.outsideWindow).toBe(1);
-      expect(messageService.sendMessage).not.toHaveBeenCalled();
-    });
-
-    it("sends at the opening hour", async () => {
-      setSpend({ WANTS: 16200 });
-
-      const { sent } = await useCase.execute(at(19));
-
-      expect(sent).toBe(1);
-    });
-
-    it("still sends late in the window, so a delayed tick is not lost", async () => {
-      setSpend({ WANTS: 16200 });
-
-      const { sent } = await useCase.execute(at(22));
-
-      expect(sent).toBe(1);
-    });
-
-    it("stays quiet after the window closes", async () => {
-      setSpend({ WANTS: 16200 });
-
-      const result = await useCase.execute(at(23));
-
-      expect(result.sent).toBe(0);
-      expect(result.skipped.outsideWindow).toBe(1);
-    });
-
-    it("sends once across several ticks inside the window", async () => {
-      setSpend({ WANTS: 16200 });
-      // Stand in for the unique index: the first record wins, later ones lose.
+    // Stand in for the unique index: first record of a key wins, later ones lose.
+    const useLedger = () => {
       const recorded = new Set<string>();
       nudgeRepository.recordSentIfNew = vi.fn(
         (u: string, b: string, k: string, key: string) => {
@@ -170,6 +141,50 @@ describe("SendBudgetNudges", () => {
           return Promise.resolve(true);
         },
       );
+      return recorded;
+    };
+
+    const asDosage = (notificationDosage: string) =>
+      userRepository.findOnboardedWithTelegram.mockResolvedValue([
+        { ...user, notificationDosage },
+      ]);
+
+    it("GENTLE speaks in the evening only", async () => {
+      asDosage("GENTLE");
+
+      expect((await useCase.execute(at(9))).sent).toBe(0);
+      expect((await useCase.execute(at(13))).sent).toBe(0);
+      expect((await useCase.execute(at(19))).sent).toBe(1);
+      expect((await useCase.execute(at(23))).sent).toBe(0);
+    });
+
+    it("AGGRESSIVE adds a midday window", async () => {
+      asDosage("AGGRESSIVE");
+
+      expect((await useCase.execute(at(9))).sent).toBe(0);
+      expect((await useCase.execute(at(13))).sent).toBe(1);
+      expect((await useCase.execute(at(19))).sent).toBe(1);
+    });
+
+    it("RELENTLESS speaks in three windows", async () => {
+      asDosage("RELENTLESS");
+
+      expect((await useCase.execute(at(9))).sent).toBe(1);
+      expect((await useCase.execute(at(14))).sent).toBe(1);
+      expect((await useCase.execute(at(19))).sent).toBe(1);
+      expect((await useCase.execute(at(23))).sent).toBe(0);
+    });
+
+    it("still sends late in a window, so a delayed tick is not lost", async () => {
+      asDosage("AGGRESSIVE");
+
+      expect((await useCase.execute(at(16))).sent).toBe(1); // 13:00 window, last hour
+      expect((await useCase.execute(at(22))).sent).toBe(1); // 19:00 window, last hour
+    });
+
+    it("collapses several ticks inside one window into a single send", async () => {
+      asDosage("RELENTLESS");
+      useLedger();
 
       const first = await useCase.execute(at(19));
       const second = await useCase.execute(at(21));
@@ -177,6 +192,61 @@ describe("SendBudgetNudges", () => {
       expect(first.sent).toBe(1);
       expect(second.sent).toBe(0);
       expect(messageService.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    // The point of the whole change: dosage sets messages per day.
+    it("gives RELENTLESS three check-ins a day where GENTLE gets one", async () => {
+      const countCheckins = async (dosage: string) => {
+        vi.clearAllMocks();
+        asDosage(dosage);
+        useLedger();
+        messageService.sendMessage = vi.fn().mockResolvedValue("m1");
+        for (const h of [9, 11, 14, 16, 19, 21]) await useCase.execute(at(h));
+        return messageService.sendMessage.mock.calls.length;
+      };
+
+      expect(await countCheckins("RELENTLESS")).toBe(3);
+      expect(await countCheckins("AGGRESSIVE")).toBe(2);
+      expect(await countCheckins("GENTLE")).toBe(1);
+    });
+  });
+
+  // A bucket sitting at 80-100% used to alert once per CYCLE, so it could stay
+  // hot all month in silence. That is what the user reported.
+  describe("a hot bucket keeps nagging", () => {
+    const evening = (day: number) => new Date(Date.UTC(2026, 5, day, 19));
+
+    const warnsAcrossTwoDays = async (dosage: string) => {
+      const recorded = new Set<string>();
+      nudgeRepository.recordSentIfNew = vi.fn(
+        (u: string, b: string, k: string, key: string) => {
+          const id = [u, b, k, key].join("|");
+          if (recorded.has(id)) return Promise.resolve(false);
+          recorded.add(id);
+          return Promise.resolve(true);
+        },
+      );
+      userRepository.findOnboardedWithTelegram.mockResolvedValue([
+        { ...user, notificationDosage: dosage },
+      ]);
+      setSpend({ WANTS: 13500 }); // 90% of 15000
+
+      await useCase.execute(evening(15));
+      await useCase.execute(evening(16));
+
+      return [...recorded].filter((k) => k.includes("WARN_80")).length;
+    };
+
+    it("repeats WARN_80 daily for RELENTLESS", async () => {
+      expect(await warnsAcrossTwoDays("RELENTLESS")).toBe(2);
+    });
+
+    it("repeats WARN_80 daily for AGGRESSIVE", async () => {
+      expect(await warnsAcrossTwoDays("AGGRESSIVE")).toBe(2);
+    });
+
+    it("keeps WARN_80 to once a cycle for GENTLE", async () => {
+      expect(await warnsAcrossTwoDays("GENTLE")).toBe(1);
     });
   });
 

--- a/src/application/use-cases/SendBudgetNudges.ts
+++ b/src/application/use-cases/SendBudgetNudges.ts
@@ -15,18 +15,31 @@ import {
   periodKey,
   pctSpent,
 } from "./budgetMath";
-import { inLocalHourWindow, zonedYmd } from "../../utils/time";
+import { zonedParts, zonedYmd } from "../../utils/time";
 
 const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
 // Savings overspend is good, not a leak — only nudge the spending buckets.
 const WATCHED: Bucket[] = ["NEEDS", "WANTS"];
-// Nudges go out in the 19:00-22:59 window of each user's local timezone. It is a
-// window and not a single hour because the cron tick drifts and is sometimes
-// dropped; an exact-hour gate loses the whole day's nudges when that happens.
-// Every nudge is ledger-deduped per day or per cycle, so extra ticks inside the
-// window cannot re-send.
-const NUDGE_HOUR = 19;
-const NUDGE_WINDOW_HOURS = 4;
+// How often a dosage is allowed to speak, as local-time send windows. This is
+// what "Reminder frequency" actually controls — one burst per window, so GENTLE
+// gets one a day and RELENTLESS three.
+//
+// Windows are 4h wide and never overlap. Width, not a single hour, because the
+// cron tick drifts by tens of minutes and is sometimes dropped outright; an
+// exact-hour gate loses the whole day. Every nudge is ledger-deduped, so extra
+// ticks inside one window cannot re-send.
+const WINDOW_HOURS = 4;
+const NUDGE_WINDOWS: Record<NotificationDosage, number[]> = {
+  OFF: [],
+  GENTLE: [19], //           19:00-22:59
+  AGGRESSIVE: [13, 19], //   13:00-16:59, 19:00-22:59
+  RELENTLESS: [9, 14, 19], // 09:00-12:59, 14:00-17:59, 19:00-22:59
+};
+
+// Which window this tick falls in, or null when the user should hear nothing.
+function currentWindow(hour: number, starts: number[]): number | null {
+  return starts.find((s) => hour >= s && hour < s + WINDOW_HOURS) ?? null;
+}
 
 export type NudgeSkipReason =
   | "noTelegram"
@@ -42,12 +55,17 @@ export interface SendBudgetNudgesResult {
   skipped: Record<NudgeSkipReason, number>;
 }
 
-// Proactive reminders, gated by each user's notificationDosage:
-//   OFF        → nothing.
-//   GENTLE     → WARN_80 + OVER, once per bucket per cycle (the original behavior).
-//   AGGRESSIVE → adds WARN_50 + a once-a-day CHECKIN summary.
-//   RELENTLESS → as AGGRESSIVE, and OVER repeats daily until they're back under.
-// Idempotency via INudgeRepository keeps a single daily run from spamming.
+// Proactive reminders. notificationDosage picks both how many windows a day the
+// user hears from (NUDGE_WINDOWS) and how often each kind may repeat:
+//
+//   kind      GENTLE   AGGRESSIVE   RELENTLESS
+//   CHECKIN   slot     slot         slot          → once per window
+//   WARN_80   cycle    day          day           → a hot bucket keeps nagging
+//   WARN_50   —        cycle        cycle         → 50% is not "running hot"
+//   OVER      cycle    day          slot
+//
+// Idempotency via INudgeRepository is what enforces all of it: the key scope IS
+// the repeat rate, so several ticks inside one window collapse to one send.
 export class SendBudgetNudgesUseCase {
   constructor(
     private readonly userRepository: IUserRepository,
@@ -101,18 +119,24 @@ export class SendBudgetNudgesUseCase {
     if (!user.telegramId) return { sent: 0, skip: "noTelegram" };
     if (dosage === "OFF") return { sent: 0, skip: "dosageOff" };
 
-    // Send only inside the user's local evening window (unless forced for testing).
+    // Send only inside one of this dosage's local windows (unless forced).
     const tz = user.timezone;
-    if (!force && !inLocalHourWindow(now, tz, NUDGE_HOUR, NUDGE_WINDOW_HOURS)) {
-      return { sent: 0, skip: "outsideWindow" };
-    }
+    const windows = NUDGE_WINDOWS[dosage];
+    const window = currentWindow(zonedParts(now, tz).hour, windows);
+    if (!force && window === null) return { sent: 0, skip: "outsideWindow" };
+    // Forced runs have no real window; pin to the first so keys stay deterministic.
+    const slotHour = window ?? windows[0];
 
     const loud = dosage === "AGGRESSIVE" || dosage === "RELENTLESS";
 
     // Per-user payday cycle, computed in the user's timezone.
     const { start, end } = currentBudgetPeriod(user.payday, now, tz);
-    const cycleKey = periodKey(user.payday, now, tz);
-    const dayKey = zonedYmd(now, tz);
+    // Three dedupe scopes sharing one column. Prefixed because periodKey() returns
+    // the cycle START DATE, the same YYYY-MM-DD shape as the day key — on a
+    // payday-1 cycle the two would otherwise collide and swallow a nudge.
+    const cycleKey = `c:${periodKey(user.payday, now, tz)}`;
+    const dayKey = `d:${zonedYmd(now, tz)}`;
+    const slotKey = `${dayKey}#${slotHour}`;
     const { day, daysInPeriod } = periodDayInfo(user.payday, now, tz);
     const daysLeft = daysInPeriod - day;
 
@@ -142,8 +166,10 @@ export class SendBudgetNudgesUseCase {
       summary.push(`${meta.emoji} ${meta.label} ${pctSpent(spent, budget)}%`);
 
       if (spent > budget) {
-        // RELENTLESS repeats the over-budget alert daily; others once per cycle.
-        const overKey = dosage === "RELENTLESS" ? dayKey : cycleKey;
+        // Over budget is the emergency: RELENTLESS re-raises it every window,
+        // AGGRESSIVE every day, GENTLE once for the cycle.
+        const overKey =
+          dosage === "RELENTLESS" ? slotKey : loud ? dayKey : cycleKey;
         if (
           await this.nudgeRepository.recordSentIfNew(
             user.id,
@@ -159,12 +185,14 @@ export class SendBudgetNudgesUseCase {
           sent++;
         }
       } else if (spent / budget >= 0.8) {
+        // "When a bucket runs hot" — daily for the loud levels. Cycle-keyed here
+        // meant a bucket could sit at 88% all month after one alert.
         if (
           await this.nudgeRepository.recordSentIfNew(
             user.id,
             bucket,
             "WARN_80",
-            cycleKey,
+            loud ? dayKey : cycleKey,
           )
         ) {
           await this.send(
@@ -191,14 +219,16 @@ export class SendBudgetNudgesUseCase {
       }
     }
 
-    // Aggressive/Relentless also get a once-a-day check-in summary.
-    if (loud && summary.length > 0) {
+    // Every dosage gets the check-in, once per window — this is the thing that
+    // makes the levels differ in volume. GENTLE without it sent nothing at all
+    // unless a bucket crossed 80%.
+    if (summary.length > 0) {
       if (
         await this.nudgeRepository.recordSentIfNew(
           user.id,
           "NEEDS",
           "CHECKIN",
-          dayKey,
+          slotKey,
         )
       ) {
         await this.send(

--- a/src/application/use-cases/processors/SettingsProcessor.ts
+++ b/src/application/use-cases/processors/SettingsProcessor.ts
@@ -13,9 +13,9 @@ import { formatMoney } from "../budgetMath";
 
 const DOSAGE_LABEL: Record<NotificationDosage, string> = {
   OFF: "No reminders",
-  GENTLE: "Gentle (1–2 a day)",
-  AGGRESSIVE: "Aggressive",
-  RELENTLESS: "Relentless",
+  GENTLE: "Gentle (once a day)",
+  AGGRESSIVE: "Aggressive (twice a day)",
+  RELENTLESS: "Relentless (3x a day)",
 };
 
 const VALID: NotificationDosage[] = [

--- a/src/domain/productFacts.ts
+++ b/src/domain/productFacts.ts
@@ -83,7 +83,7 @@ export function buildProductFacts(dashboardUrl: string): ProductFacts {
       },
       {
         name: "Reminders you control",
-        what: "Optional nudges as a bucket fills up, at four intensities from off to relentless.",
+        what: "Optional nudges as a bucket fills up. Four intensities set how many times a day the bot speaks: off, gentle (once, in the evening), aggressive (twice), relentless (three times, and it keeps repeating while a bucket is over 80%).",
         why: "A warning before you overspend is worth more than a report afterwards — but only if you chose how loud it is. Off is the default.",
       },
       {

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -116,8 +116,11 @@ model User {
   telegramLinkToken    TelegramLinkToken?
 }
 
-// Idempotency log for proactive nudges: at most one row per
-// (user, bucket, kind, month), so a nudge is sent once per month, not daily.
+// Idempotency log for proactive nudges. periodKey carries the repeat scope, and
+// the scope IS the repeat rate — see SendBudgetNudges. One of:
+//   "c:<cycle-start>"        once per budget cycle
+//   "d:<date>"               once per day
+//   "d:<date>#<hour>"        once per send window
 model BudgetNudge {
   id        String    @id @default(cuid())
   userId    String

--- a/web/src/lib/budget.ts
+++ b/web/src/lib/budget.ts
@@ -256,9 +256,13 @@ export const DOSAGES: {
   hint: string;
 }[] = [
   { value: "OFF", label: "Off", hint: "No reminders" },
-  { value: "GENTLE", label: "Gentle", hint: "1–2 a day" },
-  { value: "AGGRESSIVE", label: "Aggressive", hint: "+ daily check-in" },
-  { value: "RELENTLESS", label: "Relentless", hint: "Daily + repeats" },
+  { value: "GENTLE", label: "Gentle", hint: "Once a day, in the evening" },
+  { value: "AGGRESSIVE", label: "Aggressive", hint: "Twice a day" },
+  {
+    value: "RELENTLESS",
+    label: "Relentless",
+    hint: "3x a day, and repeats while a bucket is hot",
+  },
 ];
 
 export function localeForCurrency(currency: string): string {


### PR DESCRIPTION
## Why

"Reminder frequency" never changed how often the bot spoke. Every dosage sent one burst at the first cron tick inside a single 19:00–22:59 window; dosage only picked which *kinds* were eligible and whether `OVER` repeated on later **days**.

Production ledger for the reporting user (RELENTLESS), cycle Aug 1–26: **18 nudges in 26 days = 15 daily check-ins + 2 WARN_50 + 1 WARN_80.** One message a day.

Their state — effective income ₹69,146, split 35/35/30 → ₹24,201 per bucket — is **NEEDS 88%, WANTS 56%**. Neither is over budget, so:

| Nudge | Key before | Fires |
|---|---|---|
| `WARN_50` | cycle | once a month — spent early August |
| `WARN_80` | cycle | once a month — spent Aug 24 |
| `CHECKIN` | day | once a day ← the only one left |
| `OVER` | day (RELENTLESS) | daily, but only past 100%; never reached |

Two defects: frequency was never a dimension of the design, and `WARN_80` was cycle-keyed for *every* dosage, so a bucket could sit at 88% all month after one alert.

Prod shows how little the levels differed: an **AGGRESSIVE user got 18 nudges too** (identical to RELENTLESS — they differ only in `overKey`, and nobody has gone over budget), and the **GENTLE user got 0 all cycle**, because the check-in was gated behind `loud` while the UI promised "1–2 a day".

## What

Dosage now selects local send windows, 4h wide (to absorb cron drift) and non-overlapping:

| Dosage | Windows |
|---|---|
| GENTLE | 19:00–22:59 |
| AGGRESSIVE | 13:00–16:59, 19:00–22:59 |
| RELENTLESS | 09:00–12:59, 14:00–17:59, 19:00–22:59 |

The dedupe key scope *is* the repeat rate, so the rest lives there:

| Kind | GENTLE | AGGRESSIVE | RELENTLESS |
|---|---|---|---|
| `CHECKIN` | slot | slot | slot |
| `WARN_80` | cycle | **day** | **day** |
| `WARN_50` | — | cycle | cycle |
| `OVER` | cycle | **day** | **slot** |

- Check-in no longer gated behind `loud`, so GENTLE stops sending nothing.
- Keys prefixed `c:` / `d:` / `d:<date>#<slot>`. `periodKey()` returns the cycle **start date** — the same `YYYY-MM-DD` shape as the day key — so on a payday-1 cycle the two collided and swallowed a nudge. A third scope in that column would have made it worse.
- Copy updated in `web/src/lib/budget.ts`, `SettingsProcessor.ts`, and `productFacts.ts` (the assistant answers "how often does it remind me" from that file).

Resulting volume for the reporting user: **GENTLE 0/day → 1, AGGRESSIVE 1 → 3, RELENTLESS 1 → 4.**

## Verified

- `pnpm test:unit` **360 passed** (was 356); 16 in the nudge spec. Backend build + lint clean, web build + lint clean.
- **Regression proven, not assumed.** Reverting the four behaviors (single window, cycle-keyed `WARN_80`, `loud`-gated day-keyed check-in) fails **9** of the new tests.
- Live locally at 08:47 IST against the GENTLE fixture: `{"sent":0,"considered":1,"skipped":{"outsideWindow":1,...}}` — correctly outside the 19:00 window.

## Migration

Existing ledger rows carry unprefixed keys, so the first tick after deploy may send one extra nudge per (bucket, kind). Self-healing within a day; `periodKey` is free text, so no migration.

## Deliberately left alone

- `WARN_50` stays cycle-keyed — 50% is not a hot bucket.
- **Effective income is driven by logged income, not the setting.** This user set ₹40,000 but logged ₹69,146 this cycle, so `effectiveMonthlyIncome` (`budgetMath.ts:102`) uses the larger and every bucket budget is ~73% wider than configured. Behaving as written, but it silently overrides the setting — worth its own discussion.