### PR TITLE
feat(income): categorise income so refunds stop inflating the budget

### DIFF
--- a/prisma/migrations/20260827060000_income_categories/migration.sql
+++ b/prisma/migrations/20260827060000_income_categories/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable
+ALTER TABLE "Income" ADD COLUMN     "categoryId" TEXT;
+
+-- CreateTable
+CREATE TABLE "IncomeCategory" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "countsAsEarnings" BOOLEAN NOT NULL DEFAULT true,
+    "userId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IncomeCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IncomeCategory_userId_name_key" ON "IncomeCategory"("userId", "name");
+
+-- AddForeignKey
+ALTER TABLE "Income" ADD CONSTRAINT "Income_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "IncomeCategory"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "IncomeCategory" ADD CONSTRAINT "IncomeCategory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,7 @@ model User {
   incomes        Income[]
   budgetConfig   BudgetConfig?
   categories     Category[]
+  incomeCategories IncomeCategory[]
   logs           ParseLog[]
   budgetNudges   BudgetNudge[]
   recurringRules RecurringRule[]
@@ -276,12 +277,43 @@ model Income {
   userId String
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  // What kind of money this is. Null = uncategorised, which counts as earnings
+  // so rows predating the taxonomy keep their old budget behaviour.
+  categoryId String?
+  category   IncomeCategory? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
+
   isDeleted Boolean   @default(false)
   deletedAt DateTime?
 
   @@index([userId, date])
   @@index([userId, isDeleted, date])
   @@index([userId, batchId])
+}
+
+// Income taxonomy. Separate from Category (the expense one) on purpose: that
+// model requires a `bucket`, is uniquely named per user in the same namespace,
+// and carries monthlyBudget/weight/Box — none of which mean anything for income.
+//
+// countsAsEarnings is the whole point. It lives on the CATEGORY, not the row, so
+// a new kind of income is a data change rather than a code change, and
+// re-pointing a category moves every past and future row with it.
+model IncomeCategory {
+  id   String @id @default(cuid())
+  name String
+
+  // False for money that is not new income — a refund, a friend paying you back,
+  // a loan. Those must not widen the budget: the matching expense already
+  // consumed it, so counting the return too inflates the budget twice over.
+  countsAsEarnings Boolean @default(true)
+
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  incomes Income[]
+
+  createdAt DateTime @default(now())
+
+  @@unique([userId, name])
 }
 
 // ─── Boxes ───────────────────────────────────────────────────────────────────

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import { CATEGORY_TEMPLATE } from "../src/domain/categoryTemplate";
+import { INCOME_CATEGORY_TEMPLATE } from "../src/domain/incomeCategoryTemplate";
 
 const prisma = new PrismaClient();
 
@@ -42,6 +43,27 @@ async function upsertSystemCategory(data: {
   return created.id;
 }
 
+// Seeds the SYSTEM income taxonomy (userId = null). Idempotent, and it reconciles
+// countsAsEarnings in place — that flag is the budget rule, so a template change
+// has to reach existing rows rather than only new ones. Not prisma.upsert: the
+// unique key is (userId, name) and Prisma will not take a null in a compound
+// unique where.
+async function seedIncomeCategories(): Promise<void> {
+  for (const { name, countsAsEarnings } of INCOME_CATEGORY_TEMPLATE) {
+    const existing = await prisma.incomeCategory.findFirst({
+      where: { userId: null, name },
+    });
+    if (existing) {
+      await prisma.incomeCategory.update({
+        where: { id: existing.id },
+        data: { countsAsEarnings },
+      });
+    } else {
+      await prisma.incomeCategory.create({ data: { name, countsAsEarnings } });
+    }
+  }
+}
+
 async function main() {
   let groups = 0;
   let leaves = 0;
@@ -65,7 +87,10 @@ async function main() {
       leaves++;
     }
   }
-  console.log(`Seeded ${groups} system groups and ${leaves} leaf categories.`);
+  await seedIncomeCategories();
+  console.log(
+    `Seeded ${groups} system groups, ${leaves} leaf categories, and ${INCOME_CATEGORY_TEMPLATE.length} income categories.`,
+  );
 }
 
 main()

--- a/scripts/backfill-income-categories.ts
+++ b/scripts/backfill-income-categories.ts
@@ -1,0 +1,77 @@
+/**
+ * One-off: tag existing Income rows that are NOT earnings.
+ *
+ * Only non-earning rows need a category — an uncategorised row already counts as
+ * earnings, so writing "Salary" or "Other Income" onto one would change nothing.
+ *
+ * Deliberately NOT wired into preDeployCommand — it is a manual tool, so it
+ * cannot fire on a deploy. Dry-runs by default; `--apply` is required to write.
+ *
+ *   pnpm exec ts-node-dev --transpile-only --exit-child scripts/backfill-income-categories.ts
+ *   pnpm exec ts-node-dev --transpile-only --exit-child scripts/backfill-income-categories.ts --apply
+ *
+ * Targets whatever DATABASE_URL points at. Check that before running.
+ */
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+
+// Ordered: first match wins, so the more specific phrases come first. These are
+// intentionally conservative — anything that does not clearly read as money
+// coming back is left alone and keeps counting as earnings.
+const RULES: { pattern: RegExp; category: string }[] = [
+  { pattern: /\b(advance)\b/i, category: "Loan / Advance Received" },
+  { pattern: /\b(lend|lent|lending)\b/i, category: "Money Lent Returned" },
+  { pattern: /\b(reimburse\w*)\b/i, category: "Reimbursement" },
+  { pattern: /\b(refund\w*)\b/i, category: "Refund" },
+  { pattern: /\b(returns?|returned)\b/i, category: "Money Lent Returned" },
+];
+
+async function main() {
+  const categories = await prisma.incomeCategory.findMany({
+    where: { userId: null },
+  });
+  if (categories.length === 0) {
+    throw new Error("No system income categories — run the seed first.");
+  }
+  const byName = new Map(categories.map((c) => [c.name, c]));
+
+  const rows = await prisma.income.findMany({
+    where: { categoryId: null, isDeleted: false },
+    select: { id: true, amount: true, rawText: true, source: true, note: true },
+    orderBy: { date: "asc" },
+  });
+
+  let excluded = 0;
+  for (const row of rows) {
+    const text = [row.rawText, row.source, row.note].filter(Boolean).join(" ");
+    const name = RULES.find((r) => r.pattern.test(text))?.category;
+    if (!name) continue;
+    const category = byName.get(name)!;
+    excluded++;
+    console.log(
+      `  ${String(Number(row.amount)).padStart(9)}  ${name.padEnd(26)} ${JSON.stringify(text.slice(0, 48))}`,
+    );
+    if (APPLY) {
+      await prisma.income.update({
+        where: { id: row.id },
+        data: { categoryId: category.id },
+      });
+    }
+  }
+
+  console.log(
+    `\n${excluded} of ${rows.length} uncategorised row(s) are money coming back; the rest keep counting as earnings.`,
+  );
+  console.log(APPLY ? "Applied." : "Dry run — re-run with --apply to write.");
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/application/use-cases/ProcessIncomingMessage.spec.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.spec.ts
@@ -25,6 +25,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
   let budgetConfigRepository: any;
   let parseLogRepository: any;
   let incomeRepository: any;
+  let incomeCategoryRepository: any;
   let recurringRuleRepository: any;
   let boxRepository: any;
   let conversationRepository: any;
@@ -73,9 +74,16 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       create: vi.fn().mockResolvedValue({ id: "plog1" }),
       findById: vi.fn().mockResolvedValue(null),
     };
+    incomeCategoryRepository = {
+      findAllForUser: vi.fn().mockResolvedValue([
+        { id: "salary", name: "Salary", countsAsEarnings: true },
+        { id: "other", name: "Other Income", countsAsEarnings: true },
+      ]),
+    };
     incomeRepository = {
       create: vi.fn().mockResolvedValue({ id: "inc1" }),
       sumForMonth: vi.fn().mockResolvedValue(0),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(0),
       findLastByUserId: vi.fn().mockResolvedValue(null),
       findByConfirmationMessageId: vi.fn().mockResolvedValue(null),
       updateConfirmationMessageId: vi.fn().mockResolvedValue(undefined),
@@ -115,6 +123,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       budgetConfigRepository,
       parseLogRepository,
       incomeRepository,
+      incomeCategoryRepository,
       recurringRuleRepository,
       boxRepository,
       conversationRepository,
@@ -123,6 +132,22 @@ describe("ProcessIncomingMessage (budget flow)", () => {
       async (fn: any) => fn({}),
       "https://blipko.lol",
     );
+  });
+
+  // Without the income list in the prompt the model cannot tell a refund from a
+  // salary, and every return lands on the earnings side by default.
+  it("passes the income categories to the parser", async () => {
+    aiParser.parseText.mockResolvedValue({
+      transactions: [{ intent: "UNKNOWN", confidence: 0.9 }],
+    });
+
+    await useCase.execute({
+      platformUserId: "123",
+      textMessage: "1500 from nadha returned",
+    } as any);
+
+    const ctx = aiParser.parseText.mock.calls[0]![1];
+    expect(ctx.incomeCategories).toEqual(["Salary", "Other Income"]);
   });
 
   describe("assistant lane", () => {
@@ -135,6 +160,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
         budgetConfigRepository,
         parseLogRepository,
         incomeRepository,
+        incomeCategoryRepository,
         recurringRuleRepository,
         boxRepository,
         conversationRepository,
@@ -434,6 +460,7 @@ describe("ProcessIncomingMessage (budget flow)", () => {
 
   it("records income and replies with the refreshed budget", async () => {
     incomeRepository.sumForMonth.mockResolvedValue(55000);
+    incomeRepository.sumEarnedForMonth.mockResolvedValue(55000);
     aiParser.parseText.mockResolvedValue({
       transactions: [
         { intent: "INCOME", amount: 5000, note: "freelance", confidence: 0.9 },
@@ -446,7 +473,13 @@ describe("ProcessIncomingMessage (budget flow)", () => {
     });
 
     expect(incomeRepository.create).toHaveBeenCalledWith(
-      expect.objectContaining({ amount: 5000, userId: "u1" }),
+      // The categories loaded for the prompt are the same rows IncomeProcessor
+      // resolves against — no category named, so it lands on the fallback.
+      expect.objectContaining({
+        amount: 5000,
+        userId: "u1",
+        categoryId: "other",
+      }),
     );
     expect(messageService.sendInteractiveMessage.mock.calls[0][1]).toContain(
       "Income this cycle: ₹55,000",

--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -10,6 +10,7 @@ import { ICategoryRepository } from "../../domain/repositories/ICategoryReposito
 import { IBudgetConfigRepository } from "../../domain/repositories/IBudgetConfigRepository";
 import { IParseLogRepository } from "../../domain/repositories/IParseLogRepository";
 import { IIncomeRepository } from "../../domain/repositories/IIncomeRepository";
+import { IIncomeCategoryRepository } from "../../domain/repositories/IIncomeCategoryRepository";
 import { IRecurringRuleRepository } from "../../domain/repositories/IRecurringRuleRepository";
 import { IBoxRepository } from "../../domain/repositories/IBoxRepository";
 import { IConversationRepository } from "../../domain/repositories/IConversationRepository";
@@ -86,6 +87,7 @@ export class ProcessIncomingMessageUseCase {
     private readonly budgetConfigRepository: IBudgetConfigRepository,
     private readonly parseLogRepository: IParseLogRepository,
     private readonly incomeRepository: IIncomeRepository,
+    private readonly incomeCategoryRepository: IIncomeCategoryRepository,
     private readonly recurringRuleRepository: IRecurringRuleRepository,
     private readonly boxRepository: IBoxRepository,
     private readonly conversationRepository: IConversationRepository,
@@ -295,10 +297,15 @@ export class ProcessIncomingMessageUseCase {
       }
     }
 
-    // AI parse with the user's category list as context.
-    const categories = await this.loadCategoryHints(user.id);
+    // AI parse with the user's category lists as context.
+    const [categories, incomeCategories] = await Promise.all([
+      this.loadCategoryHints(user.id),
+      this.incomeCategoryRepository.findAllForUser(user.id),
+    ]);
+    context.incomeCategories = incomeCategories;
     const batch = await this.aiParser.parseText(payload.textMessage, {
       categories,
+      incomeCategories: incomeCategories.map((c) => c.name),
       history,
       today: zonedYmd(new Date(), user.timezone),
       assistantMode: this.assistantAgent !== null,

--- a/src/application/use-cases/SendBudgetNudges.spec.ts
+++ b/src/application/use-cases/SendBudgetNudges.spec.ts
@@ -43,7 +43,10 @@ describe("SendBudgetNudges", () => {
     };
     nudgeRepository = { recordSentIfNew: vi.fn().mockResolvedValue(true) };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
-    const incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
+    const incomeRepository = {
+      sumForMonth: vi.fn().mockResolvedValue(0),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(0),
+    };
     useCase = new SendBudgetNudgesUseCase(
       userRepository,
       expenseRepository,

--- a/src/application/use-cases/SendBudgetNudges.ts
+++ b/src/application/use-cases/SendBudgetNudges.ts
@@ -142,7 +142,7 @@ export class SendBudgetNudgesUseCase {
 
     const income = effectiveMonthlyIncome(
       Number(user.monthlyIncome ?? 0),
-      await this.incomeRepository.sumForMonth(user.id, start, end),
+      await this.incomeRepository.sumEarnedForMonth(user.id, start, end),
     );
     if (income <= 0) return { sent: 0, skip: "noIncome" };
 

--- a/src/application/use-cases/SendCycleReport.spec.ts
+++ b/src/application/use-cases/SendCycleReport.spec.ts
@@ -35,7 +35,10 @@ describe("SendCycleReport", () => {
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
     nudgeRepository = { recordSentIfNew: vi.fn().mockResolvedValue(true) };
-    incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
+    incomeRepository = {
+      sumForMonth: vi.fn().mockResolvedValue(0),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(0),
+    };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
     useCase = new SendCycleReportUseCase(
       userRepository,

--- a/src/application/use-cases/cycleReport.spec.ts
+++ b/src/application/use-cases/cycleReport.spec.ts
@@ -27,7 +27,10 @@ describe("buildCycleReport", () => {
         .fn()
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
-    incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(50000) };
+    incomeRepository = {
+      sumForMonth: vi.fn().mockResolvedValue(50000),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(50000),
+    };
 
     const ended: Record<string, number> = {
       NEEDS: 20000,

--- a/src/application/use-cases/cycleReport.ts
+++ b/src/application/use-cases/cycleReport.ts
@@ -162,7 +162,7 @@ export async function buildCycleReport(
   const config =
     (await deps.budgetConfigRepository.findByUserId(user.id)) ?? DEFAULT_SPLIT;
 
-  const endedLogged = await deps.incomeRepository.sumForMonth(
+  const endedLogged = await deps.incomeRepository.sumEarnedForMonth(
     user.id,
     ended.start,
     ended.end,

--- a/src/application/use-cases/expenseFlow.ts
+++ b/src/application/use-cases/expenseFlow.ts
@@ -233,7 +233,7 @@ export async function recordExpenseAndReply(
   );
   const config =
     (await deps.budgetConfigRepository.findByUserId(user.id)) ?? DEFAULT_SPLIT;
-  const monthIncome = await deps.incomeRepository.sumForMonth(
+  const monthIncome = await deps.incomeRepository.sumEarnedForMonth(
     user.id,
     start,
     end,

--- a/src/application/use-cases/processors/BatchProcessor.spec.ts
+++ b/src/application/use-cases/processors/BatchProcessor.spec.ts
@@ -42,6 +42,7 @@ describe("BatchProcessor", () => {
     incomeRepository = {
       create: vi.fn().mockResolvedValue({ id: "inc1" }),
       sumForMonth: vi.fn().mockResolvedValue(50000),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(50000),
     };
     messageService = {
       sendMessage: vi.fn().mockResolvedValue("summary-msg"),

--- a/src/application/use-cases/processors/BatchProcessor.ts
+++ b/src/application/use-cases/processors/BatchProcessor.ts
@@ -104,7 +104,11 @@ export class BatchProcessor implements MessageProcessor {
       DEFAULT_SPLIT;
     const batchIncome = effectiveMonthlyIncome(
       Number(user.monthlyIncome ?? 0),
-      await this.incomeRepository.sumForMonth(user.id, periodStart, periodEnd),
+      await this.incomeRepository.sumEarnedForMonth(
+        user.id,
+        periodStart,
+        periodEnd,
+      ),
     );
 
     for (const item of items) {
@@ -194,7 +198,7 @@ export class BatchProcessor implements MessageProcessor {
     let budgetLine = "";
     if (recordedIncome) {
       const { start, end } = currentBudgetPeriod(user.payday);
-      const monthIncome = await this.incomeRepository.sumForMonth(
+      const monthIncome = await this.incomeRepository.sumEarnedForMonth(
         user.id,
         start,
         end,

--- a/src/application/use-cases/processors/ConfirmBucketProcessor.spec.ts
+++ b/src/application/use-cases/processors/ConfirmBucketProcessor.spec.ts
@@ -46,7 +46,10 @@ describe("ConfirmBucketProcessor", () => {
         .fn()
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
-    incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
+    incomeRepository = {
+      sumForMonth: vi.fn().mockResolvedValue(0),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(0),
+    };
     messageService = {
       sendMessage: vi.fn().mockResolvedValue("m1"),
       sendInteractiveMessage: vi.fn().mockResolvedValue("m2"),

--- a/src/application/use-cases/processors/ExpenseProcessor.spec.ts
+++ b/src/application/use-cases/processors/ExpenseProcessor.spec.ts
@@ -39,7 +39,10 @@ describe("ExpenseProcessor", () => {
     parseLogRepository = {
       create: vi.fn().mockResolvedValue({ id: "log1" }),
     };
-    incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
+    incomeRepository = {
+      sumForMonth: vi.fn().mockResolvedValue(0),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(0),
+    };
     boxRepository = {
       findByCategoryId: vi.fn().mockResolvedValue(null),
       addEntry: vi.fn().mockResolvedValue({ id: "be1" }),

--- a/src/application/use-cases/processors/IncomeProcessor.spec.ts
+++ b/src/application/use-cases/processors/IncomeProcessor.spec.ts
@@ -3,6 +3,13 @@ import { IncomeProcessor } from "./IncomeProcessor";
 
 const user = { id: "u1", telegramId: "123", monthlyIncome: 50000 };
 
+// Loaded once upstream (for the parser prompt) and handed down on the context.
+const incomeCategories = [
+  { id: "salary", name: "Salary", countsAsEarnings: true },
+  { id: "other", name: "Other Income", countsAsEarnings: true },
+  { id: "returned", name: "Money Lent Returned", countsAsEarnings: false },
+];
+
 describe("IncomeProcessor", () => {
   let incomeRepository: any;
   let budgetConfigRepository: any;
@@ -15,6 +22,7 @@ describe("IncomeProcessor", () => {
       create: vi.fn().mockResolvedValue({ id: "inc1" }),
       // After creating, this month's income totals 55,000 (50k salary + 5k freelance).
       sumForMonth: vi.fn().mockResolvedValue(55000),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(55000),
     };
     budgetConfigRepository = {
       findByUserId: vi
@@ -79,6 +87,68 @@ describe("IncomeProcessor", () => {
       "inc1",
       "m2",
     );
+  });
+
+  // The bug this taxonomy exists for: a friend paying you back is not a raise.
+  // The expense it offsets already consumed budget, so counting the return as
+  // income would widen the budget on money that was already spent.
+  it("files a refund under a non-earning category and says the budget is unchanged", async () => {
+    const output = await processor.process({
+      user: { id: "u1", monthlyIncome: 40000, payday: 1 },
+      incomeCategories,
+      platformUserId: "123",
+      textMessage: "1500 from nadha, he returned the money",
+      parsed: {
+        intent: "INCOME",
+        amount: 1500,
+        category: "Money Lent Returned",
+        note: "return from nadha",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(incomeRepository.create.mock.calls[0]![0].categoryId).toBe(
+      "returned",
+    );
+    expect(output.response).toContain("Money coming back, not new income");
+  });
+
+  it("does not say that for real earnings", async () => {
+    const output = await processor.process({
+      user: { id: "u1", monthlyIncome: 40000, payday: 1 },
+      incomeCategories,
+      platformUserId: "123",
+      textMessage: "got salary 40000",
+      parsed: {
+        intent: "INCOME",
+        amount: 40000,
+        category: "Salary",
+        note: "salary",
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(incomeRepository.create.mock.calls[0]![0].categoryId).toBe("salary");
+    expect(output.response).not.toContain("Money coming back");
+  });
+
+  // An unknown name must not throw or write a dangling id — it lands on the
+  // fallback, which counts as earnings, i.e. the pre-taxonomy behaviour.
+  it("falls back to Other Income when the parser invents a category", async () => {
+    await processor.process({
+      user: { id: "u1", monthlyIncome: 40000, payday: 1 },
+      incomeCategories,
+      platformUserId: "123",
+      textMessage: "got 500 from somewhere",
+      parsed: {
+        intent: "INCOME",
+        amount: 500,
+        category: "Crypto Airdrop",
+        confidence: 0.7,
+      },
+    } as any);
+
+    expect(incomeRepository.create.mock.calls[0]![0].categoryId).toBe("other");
   });
 
   it("asks again when the amount is missing", async () => {

--- a/src/application/use-cases/processors/IncomeProcessor.ts
+++ b/src/application/use-cases/processors/IncomeProcessor.ts
@@ -4,6 +4,7 @@ import {
   ProcessOutput,
 } from "./MessageProcessor";
 import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
+import { INCOME_FALLBACK_CATEGORY } from "../../../domain/incomeCategoryTemplate";
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import { txnCb } from "../txnCallback";
@@ -19,9 +20,10 @@ import {
 const DEFAULT_SPLIT = { needsPct: 50, wantsPct: 30, savingsPct: 20 };
 const MAX_AMOUNT = 1_000_000_000;
 
-// Records an income event (salary, freelance, bonus) and replies with this
-// month's effective income and the refreshed 50/30/20 bucket budgets. The
-// budget grows as income lands (effectiveMonthlyIncome = max(expected, actual)).
+// Records an income event and replies with this cycle's effective income and the
+// refreshed bucket budgets. The budget grows as EARNED income lands
+// (effectiveMonthlyIncome = max(expected, earned)) — a refund or a repaid loan is
+// still recorded and still reported, but does not widen the budget.
 export class IncomeProcessor implements MessageProcessor {
   constructor(
     private readonly incomeRepository: IIncomeRepository,
@@ -53,6 +55,15 @@ export class IncomeProcessor implements MessageProcessor {
       return { response, parsed };
     }
 
+    // Resolve the parser's category name against the user's real rows (loaded
+    // upstream for the prompt). An unknown or missing name lands on the fallback,
+    // which counts as earnings — the behaviour from before the taxonomy existed.
+    const all = context.incomeCategories ?? [];
+    const wanted = parsed.category?.trim().toLowerCase();
+    const category =
+      (wanted && all.find((c) => c.name.toLowerCase() === wanted)) ||
+      all.find((c) => c.name === INCOME_FALLBACK_CATEGORY);
+
     const income = await this.incomeRepository.create({
       userId: user.id,
       amount,
@@ -60,15 +71,16 @@ export class IncomeProcessor implements MessageProcessor {
       confidence: parsed.confidence,
       source: parsed.note,
       note: parsed.note,
+      categoryId: category?.id,
     });
 
-    // Refresh the month's effective income + budgets (sum already includes the new income).
+    // Two sums, deliberately: gross is what landed and is what we report back;
+    // earned is what the budget is built on. A refund moves the first, not the second.
     const { start, end } = currentBudgetPeriod(user.payday);
-    const monthIncome = await this.incomeRepository.sumForMonth(
-      user.id,
-      start,
-      end,
-    );
+    const [grossIncome, monthIncome] = await Promise.all([
+      this.incomeRepository.sumForMonth(user.id, start, end),
+      this.incomeRepository.sumEarnedForMonth(user.id, start, end),
+    ]);
     const config =
       (await this.budgetConfigRepository.findByUserId(user.id)) ??
       DEFAULT_SPLIT;
@@ -76,8 +88,14 @@ export class IncomeProcessor implements MessageProcessor {
     const effective = effectiveMonthlyIncome(expected, monthIncome);
 
     const label = parsed.note ? ` (${sanitizeMd(parsed.note)})` : "";
-    const response = `✅ Income ${formatMoney(amount)}${label}
-💵 Income this cycle: ${formatMoney(monthIncome)}
+    // Say so explicitly, otherwise the budget line looks broken: money went in
+    // and nothing moved.
+    const notEarned =
+      (category?.countsAsEarnings ?? true)
+        ? ""
+        : "\n↩️ Money coming back, not new income — your budget is unchanged.";
+    const response = `✅ Income ${formatMoney(amount)}${label}${notEarned}
+💵 Income this cycle: ${formatMoney(grossIncome)}
 Budget on ${formatMoney(effective)} → ${BUCKET_META.NEEDS.emoji} Needs ${formatMoney(bucketBudget(effective, config, "NEEDS"))} · ${BUCKET_META.WANTS.emoji} Wants ${formatMoney(bucketBudget(effective, config, "WANTS"))} · ${BUCKET_META.SAVINGS.emoji} Savings ${formatMoney(bucketBudget(effective, config, "SAVINGS"))}`;
 
     // Send with quick-action buttons + store the message id so the user can

--- a/src/application/use-cases/processors/MessageProcessor.ts
+++ b/src/application/use-cases/processors/MessageProcessor.ts
@@ -1,4 +1,4 @@
-import { User } from "@prisma/client";
+import { IncomeCategory, User } from "@prisma/client";
 import { ParsedData, ParsedBatch } from "../../../domain/entities/ParsedData";
 import { ConversationTurn } from "../../../domain/services/IAiParser";
 import { TransactionRef } from "../transactionActions";
@@ -20,6 +20,10 @@ export interface ProcessContext {
   // processors gate on this (canHandle can't do async lookups).
   replyTarget?: TransactionRef | undefined;
   conversationHistory?: ConversationTurn[] | undefined;
+  // The user's income taxonomy, loaded once for the parser prompt and reused by
+  // IncomeProcessor to resolve the name the parser picked. Unset on the pre-parse
+  // path, where nothing needs it.
+  incomeCategories?: IncomeCategory[] | undefined;
 }
 
 export interface ProcessOutput {

--- a/src/application/use-cases/processors/ReportProcessor.spec.ts
+++ b/src/application/use-cases/processors/ReportProcessor.spec.ts
@@ -32,7 +32,10 @@ describe("ReportProcessor", () => {
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
-    const incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
+    const incomeRepository = {
+      sumForMonth: vi.fn().mockResolvedValue(0),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(0),
+    };
     processor = new ReportProcessor(
       expenseRepository,
       budgetConfigRepository,

--- a/src/application/use-cases/processors/ReportProcessor.ts
+++ b/src/application/use-cases/processors/ReportProcessor.ts
@@ -50,7 +50,7 @@ export class ReportProcessor implements MessageProcessor {
       DEFAULT_SPLIT;
     const { start, end } = currentBudgetPeriod(user.payday);
     const prior = previousCycles(user.payday, 1)[0]!;
-    const loggedIncome = await this.incomeRepository.sumForMonth(
+    const loggedIncome = await this.incomeRepository.sumEarnedForMonth(
       user.id,
       start,
       end,

--- a/src/application/use-cases/processors/StatusProcessor.spec.ts
+++ b/src/application/use-cases/processors/StatusProcessor.spec.ts
@@ -28,7 +28,10 @@ describe("StatusProcessor", () => {
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
-    const incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
+    const incomeRepository = {
+      sumForMonth: vi.fn().mockResolvedValue(0),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(0),
+    };
     processor = new StatusProcessor(
       expenseRepository,
       budgetConfigRepository,

--- a/src/application/use-cases/processors/StatusProcessor.ts
+++ b/src/application/use-cases/processors/StatusProcessor.ts
@@ -49,14 +49,15 @@ export class StatusProcessor implements MessageProcessor {
       DEFAULT_SPLIT;
     const { start, end } = currentBudgetPeriod(user.payday);
     const { day, daysInPeriod, remainingDays } = periodDayInfo(user.payday);
-    const loggedIncome = await this.incomeRepository.sumForMonth(
-      user.id,
-      start,
-      end,
-    );
+    // Gross is what landed; earned drives the budget. Showing only one of them
+    // makes the other look wrong — "I got 69k, why is my budget 62k?"
+    const [loggedIncome, earnedIncome] = await Promise.all([
+      this.incomeRepository.sumForMonth(user.id, start, end),
+      this.incomeRepository.sumEarnedForMonth(user.id, start, end),
+    ]);
     const monthlyIncome = effectiveMonthlyIncome(
       Number(user.monthlyIncome ?? 0),
-      loggedIncome,
+      earnedIncome,
     );
 
     const lines: string[] = [];
@@ -94,7 +95,13 @@ export class StatusProcessor implements MessageProcessor {
       }
     }
 
-    let body = `📊 This cycle — Day ${day} of ${daysInPeriod}\n💵 Income: ${formatMoney(loggedIncome)} (budget on ${formatMoney(monthlyIncome)})\n\n${lines.join("\n")}`;
+    // Only call out the gap when there is one, so the common case stays short.
+    const notCounted = loggedIncome - earnedIncome;
+    const basisNote =
+      notCounted > 0
+        ? ` — ${formatMoney(notCounted)} of that is money coming back, so it doesn't raise the budget`
+        : "";
+    let body = `📊 This cycle — Day ${day} of ${daysInPeriod}\n💵 Income: ${formatMoney(loggedIncome)} (budget on ${formatMoney(monthlyIncome)})${basisNote}\n\n${lines.join("\n")}`;
     if (dailyParts.length > 0) {
       body += `\n\nSafe daily spend left:  ${dailyParts.join(" · ")}`;
     }

--- a/src/application/use-cases/processors/TransactionActionProcessor.spec.ts
+++ b/src/application/use-cases/processors/TransactionActionProcessor.spec.ts
@@ -30,7 +30,10 @@ describe("TransactionActionProcessor", () => {
       update: vi.fn().mockResolvedValue(undefined),
       sumByBucketForMonth: vi.fn().mockResolvedValue(0),
     };
-    incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(0) };
+    incomeRepository = {
+      sumForMonth: vi.fn().mockResolvedValue(0),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(0),
+    };
     categoryRepository = {
       findById: vi
         .fn()

--- a/src/application/use-cases/query/FinancialDataTools.spec.ts
+++ b/src/application/use-cases/query/FinancialDataTools.spec.ts
@@ -49,7 +49,10 @@ describe("FinancialDataTools", () => {
         },
       ]),
     };
-    incomeRepository = { sumForMonth: vi.fn().mockResolvedValue(50000) };
+    incomeRepository = {
+      sumForMonth: vi.fn().mockResolvedValue(50000),
+      sumEarnedForMonth: vi.fn().mockResolvedValue(50000),
+    };
     budgetConfigRepository = {
       findByUserId: vi
         .fn()
@@ -211,6 +214,7 @@ describe("FinancialDataTools", () => {
     it("says NO when there is no budget at all rather than inventing one", async () => {
       userRepository.findById.mockResolvedValue({ ...user, monthlyIncome: 0 });
       incomeRepository.sumForMonth.mockResolvedValue(0);
+      incomeRepository.sumEarnedForMonth.mockResolvedValue(0);
       const res = await tools.checkAffordability("u1", 100, "WANTS");
       expect(res.verdict).toBe("NO");
       expect(res.reason).toMatch(/no income recorded/i);

--- a/src/application/use-cases/query/FinancialDataTools.ts
+++ b/src/application/use-cases/query/FinancialDataTools.ts
@@ -339,11 +339,13 @@ export class FinancialDataTools implements IFinancialDataTools {
       now,
       tz,
     );
-    const incomeLogged = await this.incomeRepository.sumForMonth(
-      user.id,
-      start,
-      end,
-    );
+    // Two different numbers on purpose: incomeLogged is what actually landed
+    // (what the model should quote), incomeEarned is what the budget is built on.
+    // A refund shows up in the first and not the second.
+    const [incomeLogged, incomeEarned] = await Promise.all([
+      this.incomeRepository.sumForMonth(user.id, start, end),
+      this.incomeRepository.sumEarnedForMonth(user.id, start, end),
+    ]);
     return {
       tz,
       config,
@@ -355,7 +357,7 @@ export class FinancialDataTools implements IFinancialDataTools {
       incomeLogged,
       monthlyIncome: effectiveMonthlyIncome(
         Number(user.monthlyIncome ?? 0),
-        incomeLogged,
+        incomeEarned,
       ),
     };
   }

--- a/src/application/use-cases/transactionActions.ts
+++ b/src/application/use-cases/transactionActions.ts
@@ -340,7 +340,7 @@ export async function bucketRemaining(
     (await deps.budgetConfigRepository.findByUserId(user.id)) ?? DEFAULT_SPLIT;
   const income = effectiveMonthlyIncome(
     Number(user.monthlyIncome ?? 0),
-    await deps.incomeRepository.sumForMonth(user.id, start, end),
+    await deps.incomeRepository.sumEarnedForMonth(user.id, start, end),
   );
   return bucketBudget(income, config, bucket) - spent;
 }

--- a/src/data/ai/GeminiParser.ts
+++ b/src/data/ai/GeminiParser.ts
@@ -112,6 +112,7 @@ export class GeminiParser implements IAiParser {
       config: {
         systemInstruction: buildBudgetSystemPrompt(
           ctx.categories,
+          ctx.incomeCategories,
           ctx.history,
           ctx.assistantMode,
         ),

--- a/src/data/ai/OpenAIParser.ts
+++ b/src/data/ai/OpenAIParser.ts
@@ -33,6 +33,7 @@ export class OpenAIParser implements IAiParser {
           role: "system",
           content: buildBudgetSystemPrompt(
             ctx.categories,
+            ctx.incomeCategories,
             ctx.history,
             ctx.assistantMode,
           ),

--- a/src/data/ai/budgetParserPrompt.ts
+++ b/src/data/ai/budgetParserPrompt.ts
@@ -14,6 +14,7 @@ import { renderHistoryBlock } from "./historyBlock";
 // confirm the bucket before saving (handled downstream).
 export function buildBudgetSystemPrompt(
   categories: CategoryHint[],
+  incomeCategories: string[],
   history?: ConversationTurn[],
   assistantMode = false,
 ): string {
@@ -21,15 +22,18 @@ export function buildBudgetSystemPrompt(
     categories.length > 0
       ? categories.map((c) => `- ${c.name} (${c.bucket})`).join("\n")
       : "- (none yet)";
+  const incomeBlock = renderIncomeCategoryBlock(incomeCategories);
 
   if (assistantMode) {
-    return buildLogOrEscalatePrompt(categoryList, history);
+    return buildLogOrEscalatePrompt(categoryList, incomeBlock, history);
   }
 
   return `You are an expert budgeting assistant for Indian users. You read an informal money message in English, Hindi, Hinglish, Malayalam, or Manglish (often code-mixed) and return STRICT JSON describing it.
 
 ### USER'S CATEGORIES (map to one of these when it fits):
 ${categoryList}
+
+${incomeBlock}
 ${renderHistoryBlock(history)}
 ### OUTPUT (strict JSON, no prose):
 Always return an object with a "transactions" array — never a bare transaction
@@ -116,6 +120,24 @@ ones that don't apply.
 - Output ONLY the JSON object.`;
 }
 
+// One copy, used by both prompt modes. The earnings/not-earnings rule is the
+// whole feature; two copies of it would drift.
+function renderIncomeCategoryBlock(incomeCategories: string[]): string {
+  const list =
+    incomeCategories.length > 0
+      ? incomeCategories.map((c) => `- ${c}`).join("\n")
+      : "- (none yet)";
+  return `### INCOME CATEGORIES (for intent INCOME, put the name in "category"):
+${list}
+
+Money coming back to the user is NOT earnings. "X returned the money", "got my
+refund", "he paid me back for lunch", "advance from Y" → Money Lent Returned,
+Refund, Reimbursement or Loan / Advance Received. Earned money — salary, a
+freelance payment, a dividend, a bonus — gets the matching earnings category.
+This distinction changes their budget, so read the message rather than defaulting
+to Salary.`;
+}
+
 // The assistant-lane prompt. The parser has exactly one decision to make here:
 // is this a clear spend or income to log, or is it something the assistant
 // should handle? Everything conversational — questions, commands, corrections,
@@ -127,12 +149,15 @@ ones that don't apply.
 // it out with the user's real data in front of it.
 function buildLogOrEscalatePrompt(
   categoryList: string,
+  incomeBlock: string,
   history?: ConversationTurn[],
 ): string {
   return `You are the fast-path classifier for an Indian budgeting bot. You read an informal money message in English, Hindi, Hinglish, Malayalam, or Manglish (often code-mixed) and return STRICT JSON.
 
 ### USER'S CATEGORIES (map to one of these when it fits):
 ${categoryList}
+
+${incomeBlock}
 ${renderHistoryBlock(history)}
 ### YOUR ONLY DECISION
 Is this message a CLEAR record of money the user just spent or received?

--- a/src/data/repositories/PrismaIncomeCategoryRepository.ts
+++ b/src/data/repositories/PrismaIncomeCategoryRepository.ts
@@ -1,0 +1,13 @@
+import { IncomeCategory, PrismaClient } from "@prisma/client";
+import { IIncomeCategoryRepository } from "../../domain/repositories/IIncomeCategoryRepository";
+
+export class PrismaIncomeCategoryRepository implements IIncomeCategoryRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findAllForUser(userId: string): Promise<IncomeCategory[]> {
+    return this.prisma.incomeCategory.findMany({
+      where: { OR: [{ userId: null }, { userId }] },
+      orderBy: { name: "asc" },
+    });
+  }
+}

--- a/src/data/repositories/PrismaIncomeRepository.spec.ts
+++ b/src/data/repositories/PrismaIncomeRepository.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PrismaIncomeRepository } from "./PrismaIncomeRepository";
+
+// Two sums that must not be confused. sumForMonth is "money that landed" and
+// feeds the income page, Wrapped and the assistant's earnings question.
+// sumEarnedForMonth is the BUDGET BASIS and drops refunds, repaid loans and
+// advances — money that offsets an expense which already consumed budget.
+describe("PrismaIncomeRepository income sums", () => {
+  let prisma: any;
+  let repo: PrismaIncomeRepository;
+
+  const START = new Date("2026-08-01T00:00:00Z");
+  const END = new Date("2026-09-01T00:00:00Z");
+  const whereOf = (call: number) =>
+    prisma.income.aggregate.mock.calls[call]![0].where;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma = {
+      income: {
+        aggregate: vi.fn().mockResolvedValue({ _sum: { amount: 0 } }),
+      },
+    };
+    repo = new PrismaIncomeRepository(prisma);
+  });
+
+  it("sumForMonth stays gross — no category filter at all", async () => {
+    await repo.sumForMonth("u1", START, END);
+
+    const where = whereOf(0);
+    expect(where).toEqual({
+      userId: "u1",
+      isDeleted: false,
+      date: { gte: START, lt: END },
+    });
+    expect(where.NOT).toBeUndefined();
+  });
+
+  it("sumEarnedForMonth excludes non-earning categories", async () => {
+    await repo.sumEarnedForMonth("u1", START, END);
+
+    expect(whereOf(0).NOT).toEqual({ category: { countsAsEarnings: false } });
+  });
+
+  // The subtle one: filtering on countsAsEarnings=true would drop every row
+  // written before the taxonomy existed, silently shrinking the budget of every
+  // user who has not been backfilled.
+  it("keeps uncategorised rows in the basis by negating, not asserting", async () => {
+    await repo.sumEarnedForMonth("u1", START, END);
+
+    const where = whereOf(0);
+    expect(where.category).toBeUndefined();
+    expect(where.NOT.category.countsAsEarnings).toBe(false);
+  });
+
+  it("still excludes soft-deleted rows from the basis", async () => {
+    await repo.sumEarnedForMonth("u1", START, END);
+
+    expect(whereOf(0).isDeleted).toBe(false);
+  });
+
+  it("persists the category when creating income", async () => {
+    prisma.income.create = vi.fn().mockResolvedValue({ id: "i1" });
+
+    await repo.create({
+      userId: "u1",
+      amount: 100,
+      rawText: "x",
+      confidence: 1,
+      categoryId: "cat1",
+    });
+
+    expect(prisma.income.create.mock.calls[0]![0].data.categoryId).toBe("cat1");
+  });
+});

--- a/src/data/repositories/PrismaIncomeRepository.ts
+++ b/src/data/repositories/PrismaIncomeRepository.ts
@@ -19,6 +19,7 @@ export class PrismaIncomeRepository implements IIncomeRepository {
         source: data.source ?? null,
         note: data.note ?? null,
         batchId: data.batchId ?? null,
+        categoryId: data.categoryId ?? null,
       },
     });
   }
@@ -34,6 +35,25 @@ export class PrismaIncomeRepository implements IIncomeRepository {
         userId,
         isDeleted: false,
         date: { gte: monthStart, lt: monthEnd },
+      },
+    });
+    return Number(result._sum.amount ?? 0);
+  }
+
+  async sumEarnedForMonth(
+    userId: string,
+    monthStart: Date,
+    monthEnd: Date,
+  ): Promise<number> {
+    const result = await this.prisma.income.aggregate({
+      _sum: { amount: true },
+      where: {
+        userId,
+        isDeleted: false,
+        date: { gte: monthStart, lt: monthEnd },
+        // NOT { category: { countsAsEarnings: true } } — that would drop
+        // uncategorised rows, silently shrinking every pre-taxonomy user's budget.
+        NOT: { category: { countsAsEarnings: false } },
       },
     });
     return Number(result._sum.amount ?? 0);

--- a/src/domain/incomeCategoryTemplate.ts
+++ b/src/domain/incomeCategoryTemplate.ts
@@ -1,0 +1,34 @@
+// The system income taxonomy, seeded with userId = null (same pattern as
+// CATEGORY_TEMPLATE). Fed to the parser so it maps incoming money onto a real
+// category instead of inventing one, and read by sumEarnedForMonth.
+//
+// countsAsEarnings is what the budget math cares about. "false" means the money
+// is not new income — a refund, a friend settling up, a loan — and must not widen
+// the budget, because the expense it offsets already consumed budget once.
+
+export interface IncomeCategoryTemplate {
+  name: string;
+  countsAsEarnings: boolean;
+}
+
+// The name new income falls back to when the parser picks something unknown.
+export const INCOME_FALLBACK_CATEGORY = "Other Income";
+
+export const INCOME_CATEGORY_TEMPLATE: IncomeCategoryTemplate[] = [
+  // Earnings — money you actually made. These widen the budget.
+  { name: "Salary", countsAsEarnings: true },
+  { name: "Freelance", countsAsEarnings: true },
+  { name: "Business Income", countsAsEarnings: true },
+  { name: "Dividend & Interest", countsAsEarnings: true },
+  { name: "Rent Received", countsAsEarnings: true },
+  { name: "Bonus", countsAsEarnings: true },
+  { name: "Gift", countsAsEarnings: true },
+  { name: INCOME_FALLBACK_CATEGORY, countsAsEarnings: true },
+
+  // Not earnings — money moving back to you. These must not widen the budget.
+  { name: "Reimbursement", countsAsEarnings: false },
+  { name: "Refund", countsAsEarnings: false },
+  { name: "Money Lent Returned", countsAsEarnings: false },
+  { name: "Loan / Advance Received", countsAsEarnings: false },
+  { name: "Transfer Between Accounts", countsAsEarnings: false },
+];

--- a/src/domain/productFacts.ts
+++ b/src/domain/productFacts.ts
@@ -87,6 +87,11 @@ export function buildProductFacts(dashboardUrl: string): ProductFacts {
         why: "A warning before you overspend is worth more than a report afterwards — but only if you chose how loud it is. Off is the default.",
       },
       {
+        name: "Income that knows what it is",
+        what: "Logged income is filed under a category — salary, freelance, dividend, or a non-earning one like a refund, a reimbursement, money you lent being paid back, or a loan. Only earnings raise your budget; the rest is still recorded and still shows in your income total.",
+        why: "When a friend pays you back for lunch, that is not a raise. Counting it as income would widen your budget on money you already spent, so the same lunch would be paid for twice.",
+      },
+      {
         name: "Web dashboard",
         what: "Charts, trends, a filterable and exportable transaction list, and all settings.",
         why: "Chat is best for capture and quick answers; the dashboard is where you review a month properly and change how things are set up.",

--- a/src/domain/repositories/IIncomeCategoryRepository.ts
+++ b/src/domain/repositories/IIncomeCategoryRepository.ts
@@ -1,0 +1,7 @@
+import { IncomeCategory } from "@prisma/client";
+
+export interface IIncomeCategoryRepository {
+  // System categories (userId = null) plus any the user owns. Used both to
+  // prompt the parser and to resolve the name it picks back to a row.
+  findAllForUser(userId: string): Promise<IncomeCategory[]>;
+}

--- a/src/domain/repositories/IIncomeRepository.ts
+++ b/src/domain/repositories/IIncomeRepository.ts
@@ -9,6 +9,7 @@ export interface CreateIncomeDTO {
   source?: string | undefined;
   note?: string | undefined;
   batchId?: string | undefined;
+  categoryId?: string | undefined;
 }
 
 // Partial edit of an existing income (amount/source/note).
@@ -20,8 +21,19 @@ export interface UpdateIncomeDTO {
 
 export interface IIncomeRepository {
   create(data: CreateIncomeDTO, tx?: TxClient): Promise<Income>;
-  // Sum of non-deleted income within [monthStart, monthEnd).
+  // GROSS: every non-deleted income within [monthStart, monthEnd), whatever kind.
+  // This is "money that landed" — what the income page, Wrapped and the
+  // assistant's earnings question all want. Do NOT use it for budget math.
   sumForMonth(
+    userId: string,
+    monthStart: Date,
+    monthEnd: Date,
+  ): Promise<number>;
+  // BUDGET BASIS: the same window, minus categories flagged
+  // countsAsEarnings = false. A refund offsets an expense that already consumed
+  // budget, so counting it again would widen the budget on money you did not
+  // earn. An uncategorised row still counts, so pre-taxonomy rows behave as before.
+  sumEarnedForMonth(
     userId: string,
     monthStart: Date,
     monthEnd: Date,

--- a/src/domain/services/IAiParser.ts
+++ b/src/domain/services/IAiParser.ts
@@ -14,6 +14,9 @@ export interface CategoryHint {
 
 export interface ParseContext {
   categories: CategoryHint[];
+  // Income category names. A plain list, not CategoryHint[]: income has no
+  // bucket, and the 50/30/20 split is a property of spending only.
+  incomeCategories: string[];
   history?: ConversationTurn[];
   // "YYYY-MM-DD" in the USER'S timezone. Passed in rather than derived inside
   // the parser: a server-side UTC date tells an IST user it is yesterday every

--- a/src/presentation/controllers/TelegramWebhookController.ts
+++ b/src/presentation/controllers/TelegramWebhookController.ts
@@ -20,6 +20,7 @@ import { PrismaCategoryRepository } from "../../data/repositories/PrismaCategory
 import { PrismaBudgetConfigRepository } from "../../data/repositories/PrismaBudgetConfigRepository";
 import { PrismaParseLogRepository } from "../../data/repositories/PrismaParseLogRepository";
 import { PrismaIncomeRepository } from "../../data/repositories/PrismaIncomeRepository";
+import { PrismaIncomeCategoryRepository } from "../../data/repositories/PrismaIncomeCategoryRepository";
 import { PrismaRecurringRuleRepository } from "../../data/repositories/PrismaRecurringRuleRepository";
 import { PrismaBoxRepository } from "../../data/repositories/PrismaBoxRepository";
 import { PrismaConversationRepository } from "../../data/repositories/PrismaConversationRepository";
@@ -69,6 +70,7 @@ const categoryRepository = new PrismaCategoryRepository(prisma);
 const budgetConfigRepository = new PrismaBudgetConfigRepository(prisma);
 const parseLogRepository = new PrismaParseLogRepository(prisma);
 const incomeRepository = new PrismaIncomeRepository(prisma);
+const incomeCategoryRepository = new PrismaIncomeCategoryRepository(prisma);
 const recurringRuleRepository = new PrismaRecurringRuleRepository(prisma);
 const boxRepository = new PrismaBoxRepository(prisma);
 const nudgeRepository = new PrismaNudgeRepository(prisma);
@@ -114,6 +116,7 @@ const processIncomingMessage = new ProcessIncomingMessageUseCase(
   budgetConfigRepository,
   parseLogRepository,
   incomeRepository,
+  incomeCategoryRepository,
   recurringRuleRepository,
   boxRepository,
   conversationRepository,

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -105,6 +105,7 @@ model User {
   incomes        Income[]
   budgetConfig   BudgetConfig?
   categories     Category[]
+  incomeCategories IncomeCategory[]
   logs           ParseLog[]
   budgetNudges   BudgetNudge[]
   recurringRules RecurringRule[]
@@ -276,12 +277,43 @@ model Income {
   userId String
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  // What kind of money this is. Null = uncategorised, which counts as earnings
+  // so rows predating the taxonomy keep their old budget behaviour.
+  categoryId String?
+  category   IncomeCategory? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
+
   isDeleted Boolean   @default(false)
   deletedAt DateTime?
 
   @@index([userId, date])
   @@index([userId, isDeleted, date])
   @@index([userId, batchId])
+}
+
+// Income taxonomy. Separate from Category (the expense one) on purpose: that
+// model requires a `bucket`, is uniquely named per user in the same namespace,
+// and carries monthlyBudget/weight/Box — none of which mean anything for income.
+//
+// countsAsEarnings is the whole point. It lives on the CATEGORY, not the row, so
+// a new kind of income is a data change rather than a code change, and
+// re-pointing a category moves every past and future row with it.
+model IncomeCategory {
+  id   String @id @default(cuid())
+  name String
+
+  // False for money that is not new income — a refund, a friend paying you back,
+  // a loan. Those must not widen the budget: the matching expense already
+  // consumed it, so counting the return too inflates the budget twice over.
+  countsAsEarnings Boolean @default(true)
+
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  incomes Income[]
+
+  createdAt DateTime @default(now())
+
+  @@unique([userId, name])
 }
 
 // ─── Boxes ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
**1 of 2.** Backend + schema. The web half is #59.

## The bug

A friend paying you back is not a raise. Every `Income` row counted towards the budget basis, so a ₹1,500 repayment widened Needs/Wants/Savings by ₹1,500 — on money already spent once. The offsetting expense consumed budget, then the return handed the same budget back.

## The shape

`Income.categoryId` → new `IncomeCategory` table, and the flag that decides this lives on the **category**, not the row:

- `countsAsEarnings = true` — Salary, Freelance, Business Income, Dividend & Interest, Rent Received, Bonus, Gift, Other Income
- `countsAsEarnings = false` — Reimbursement, Refund, Money Lent Returned, Loan / Advance Received, Transfer Between Accounts

A new kind of income is a data change instead of a code change, and re-pointing a category moves every past and future row with it.

Two sums, deliberately:

| | what it is | used for |
|---|---|---|
| `sumForMonth` | gross — everything that landed | what we report back |
| `sumEarnedForMonth` | minus `countsAsEarnings = false` | the budget basis |

Both are shown, because showing one makes the other look broken — *"I got 69k, why is my budget 62k?"*. `/status` and the income confirmation name the gap explicitly.

## Why nobody's budget moves on deploy

`sumEarnedForMonth` filters `NOT { countsAsEarnings: false }`, **not** `{ countsAsEarnings: true }`. Uncategorised rows stay in the basis, so every row predating the taxonomy behaves exactly as it does today. The parser gets the taxonomy in its prompt and returns a name; the processor resolves that name against the user's real rows and falls back to Other Income, so an invented category cannot write a dangling id.

## Rollout

`preDeployCommand` already runs `prisma migrate deploy && seed`, and the seed reconciles `countsAsEarnings` in place, so the taxonomy lands automatically. The migration is additive (nullable column + new table, FK validates against all-NULL).

`scripts/backfill-income-categories.ts` retro-tags historical rows that read as money coming back. Manual, dry-run by default, five conservative patterns, deliberately **not** wired into `preDeployCommand`.

**Merge this before #59.** Until that one lands the dashboard still budgets on gross, so a refund-logging user sees Telegram and the web app disagree.

## Known gaps (not in scope)

`BatchProcessor` and `postRecurringRule` create income without a category, so a refund inside a multi-transaction message still counts as earnings. Only the single-message `INCOME` path is categorised.

## Verification

- `pnpm test:unit` — 369 passed (46 files)
- `tsc --noEmit` clean, `pnpm lint` 0 errors
- seed run against a real DB: 13 rows, idempotent on re-run
- backfill dry-run executes; patterns spot-checked against 8 sample strings