### PR TITLE
fix(web): budget the dashboard on earned income, not gross

### DIFF
--- a/web/src/lib/actions/analytics.ts
+++ b/web/src/lib/actions/analytics.ts
@@ -12,6 +12,7 @@ import {
   bucketBudget,
   categoryPacing,
   effectiveMonthlyIncome,
+  EARNED_ONLY,
   pctSpent,
   type BudgetSplit,
   type CategoryPacing,
@@ -274,6 +275,7 @@ export async function getOverviewAnalytics(
         userId: ctx.userId,
         isDeleted: false,
         date: { gte: current.start, lt: current.end },
+        ...EARNED_ONLY,
       },
     }),
     prisma.expense.groupBy({
@@ -893,6 +895,7 @@ export async function getCommitmentAnalytics(): Promise<CommitmentAnalytics> {
         userId: ctx.userId,
         isDeleted: false,
         date: { gte: current.start, lt: current.end },
+        ...EARNED_ONLY,
       },
     }),
     prisma.expense.aggregate({

--- a/web/src/lib/actions/budget.ts
+++ b/web/src/lib/actions/budget.ts
@@ -13,6 +13,7 @@ import {
   currentBudgetPeriod,
   periodDayInfo,
   effectiveMonthlyIncome,
+  EARNED_ONLY,
   pctSpent,
   type BudgetSplit,
 } from "@/lib/budget";
@@ -44,7 +45,7 @@ export async function getBudgetOverview() {
   const { start, end } = currentBudgetPeriod(user?.payday ?? 1);
   const { day, daysInPeriod, remainingDays } = periodDayInfo(user?.payday ?? 1);
 
-  const [config, grouped, recent, categoryGroups, incomeAgg] =
+  const [config, grouped, recent, categoryGroups, incomeAgg, earnedAgg] =
     await Promise.all([
       prisma.budgetConfig.findUnique({ where: { userId } }),
       prisma.expense.groupBy({
@@ -67,12 +68,24 @@ export async function getBudgetOverview() {
         _sum: { amount: true },
         where: { userId, isDeleted: false, date: { gte: start, lt: end } },
       }),
+      prisma.income.aggregate({
+        _sum: { amount: true },
+        where: {
+          userId,
+          isDeleted: false,
+          date: { gte: start, lt: end },
+          ...EARNED_ONLY,
+        },
+      }),
     ]);
 
   const expectedIncome = Number(user?.monthlyIncome ?? 0);
+  // Gross (what landed) is what the Income card shows; earned (refunds excluded)
+  // is what budgets are built on.
   const incomeThisMonth = Number(incomeAgg._sum.amount ?? 0);
-  // Budgets track actual income this month, floored at the expected salary.
-  const monthlyIncome = effectiveMonthlyIncome(expectedIncome, incomeThisMonth);
+  const earnedThisMonth = Number(earnedAgg._sum.amount ?? 0);
+  // Budgets track earned income this month, floored at the expected salary.
+  const monthlyIncome = effectiveMonthlyIncome(expectedIncome, earnedThisMonth);
   const currency = user?.currency ?? "INR";
   const locale = user?.locale ?? "en-IN";
   const split: BudgetSplit = config

--- a/web/src/lib/budget.ts
+++ b/web/src/lib/budget.ts
@@ -164,6 +164,10 @@ export function effectiveMonthlyIncome(
   return Math.max(expected, incomeThisMonth);
 }
 
+// Income `where` fragment for budget math: drop refunds, reimbursements and
+// repaid loans. NOT{false} rather than {true} so uncategorised rows still count.
+export const EARNED_ONLY = { NOT: { category: { countsAsEarnings: false } } };
+
 // Integer percentage of budget spent (0 when budget is 0).
 export function pctSpent(spent: number, budget: number): number {
   if (budget <= 0) return 0;


### PR DESCRIPTION
**2 of 2.** Draft until #58 merges — it needs the `IncomeCategory` model.

## The bug

#58 makes the bot exclude refunds, reimbursements and repaid loans from the budget basis. The dashboard still sums every `Income` row, so the same user gets two different budgets: Telegram says ₹62,000, the web app says ₹69,000.

## The change

Three call sites needed the same predicate — `getBudgetOverview`, `getOverviewAnalytics`, `getCommitmentAnalytics` — so it lives in one place:

```ts
// web/src/lib/budget.ts
export const EARNED_ONLY = { NOT: { category: { countsAsEarnings: false } } };
```

`NOT countsAsEarnings=false` rather than `countsAsEarnings=true` on purpose: the former keeps uncategorised rows in the basis, the latter would silently shrink the budget of every user whose income predates the taxonomy.

The Income card still shows gross. Budgets are what changes here, not what landed.

## Why it is separate

Both Railway services rebuild on a commit touching `prisma/**` and `web/**`. Shipping these together races the web deploy against the bot's `preDeployCommand` migration — if web wins, `getBudgetOverview` queries a table that does not exist yet and the dashboard 500s. Two PRs, merged in order, closes that window.

Standalone this branch will not typecheck, since its Prisma client has no `IncomeCategory` until #58's schema lands. Rebase after #58 merges. (CI does not build the web app, so it goes green either way — that is not evidence this can merge first.)

## Verification

Verified on the combined tree (#58 + this): `tsc --noEmit` clean for both root and `web/`, `pnpm lint` 0 errors in both, `pnpm test:unit` 369 passed.
