### PR TITLE
fix(income): categorise batch income and stop /report hiding refunds

### DIFF
--- a/src/application/use-cases/budgetMath.ts
+++ b/src/application/use-cases/budgetMath.ts
@@ -112,6 +112,23 @@ export function formatMoney(amount: number): string {
   return `₹${inr.format(Math.round(amount))}`;
 }
 
+// The income line every summary shares. Gross is what landed and is what the
+// user recognises; the budget is built on earnings. Printing only one makes the
+// other look wrong — "I got 69k, why is my budget 62k?" — so name the gap, and
+// only when there is one, to keep the common case short.
+export function incomeBasisLine(
+  gross: number,
+  earned: number,
+  effective: number,
+): string {
+  const notCounted = gross - earned;
+  const note =
+    notCounted > 0
+      ? ` — ${formatMoney(notCounted)} of that is money coming back, so it doesn't raise the budget`
+      : "";
+  return `Income ${formatMoney(gross)} (budget on ${formatMoney(effective)})${note}`;
+}
+
 export interface PeriodDayInfo {
   day: number; // 1-based day within the cycle
   daysInPeriod: number;

--- a/src/application/use-cases/cycleReport.spec.ts
+++ b/src/application/use-cases/cycleReport.spec.ts
@@ -66,7 +66,27 @@ describe("buildCycleReport", () => {
     const { text, endedKey } = await buildCycleReport(deps(), user, NOW);
     expect(endedKey).toBe("2026-05-01");
     expect(text).toContain("May wrapped");
-    expect(text).toContain("Income logged ₹50,000");
+    expect(text).toContain("Income ₹50,000");
+  });
+
+  // The wrapped report printed the EARNED figure labelled "Income logged", so a
+  // refund vanished from it while /status named it.
+  it("names the money coming back when gross and earned differ", async () => {
+    const d = deps();
+    d.incomeRepository.sumForMonth = vi.fn().mockResolvedValue(57000);
+    d.incomeRepository.sumEarnedForMonth = vi.fn().mockResolvedValue(50000);
+
+    const { text } = await buildCycleReport(d, user, NOW);
+    expect(text).toContain("Income ₹57,000");
+    expect(text).toContain("budget on ₹50,000");
+    expect(text).toContain("₹7,000 of that is money coming back");
+  });
+
+  // Net is computed from the effective figure (which carries the expected-salary
+  // floor), so calling it "income − spend" made the on-screen sums not add up.
+  it("labels net against the budget, not income", async () => {
+    const { text } = await buildCycleReport(deps(), user, NOW);
+    expect(text).toContain("(budget − spend)");
   });
 
   it("headlines the overall spend change vs the prior cycle", async () => {

--- a/src/application/use-cases/cycleReport.ts
+++ b/src/application/use-cases/cycleReport.ts
@@ -7,6 +7,7 @@ import {
   bucketBudget,
   effectiveMonthlyIncome,
   formatMoney,
+  incomeBasisLine,
   previousCycles,
   sanitizeMd,
 } from "./budgetMath";
@@ -162,12 +163,14 @@ export async function buildCycleReport(
   const config =
     (await deps.budgetConfigRepository.findByUserId(user.id)) ?? DEFAULT_SPLIT;
 
-  const endedLogged = await deps.incomeRepository.sumEarnedForMonth(
-    user.id,
-    ended.start,
-    ended.end,
-  );
-  const endedIncome = effectiveMonthlyIncome(expected, endedLogged);
+  // Gross for the line, earned for the budget. This used to print the earned
+  // figure labelled "Income logged", so a refund vanished from the wrapped
+  // report while /status named it.
+  const [endedGross, endedEarned] = await Promise.all([
+    deps.incomeRepository.sumForMonth(user.id, ended.start, ended.end),
+    deps.incomeRepository.sumEarnedForMonth(user.id, ended.start, ended.end),
+  ]);
+  const endedIncome = effectiveMonthlyIncome(expected, endedEarned);
 
   const lines: string[] = [];
   let totalSpent = 0;
@@ -224,9 +227,12 @@ export async function buildCycleReport(
   let text =
     `📊 ${label} wrapped\n\n` +
     headline +
-    `\n\nIncome logged ${formatMoney(endedLogged)} (budget on ${formatMoney(endedIncome)})\n` +
+    `\n\n${incomeBasisLine(endedGross, endedEarned, endedIncome)}\n` +
     lines.join("\n") +
-    `\n\n${net >= 0 ? "Net saved" : "Net overspent"} ${formatMoney(Math.abs(net))} (income − spend)`;
+    // "budget − spend", not "income − spend": net is computed from the effective
+    // figure, which carries the expected-salary floor. Saying "income" made the
+    // arithmetic on screen fail to add up whenever the floor applied.
+    `\n\n${net >= 0 ? "Net saved" : "Net overspent"} ${formatMoney(Math.abs(net))} (budget − spend)`;
 
   if (moverBits.length > 0) {
     text += `\n\nBiggest movers: ${moverBits.join(" · ")}`;

--- a/src/application/use-cases/processors/BatchProcessor.spec.ts
+++ b/src/application/use-cases/processors/BatchProcessor.spec.ts
@@ -10,6 +10,13 @@ const user = {
   locale: "en-IN",
 };
 
+// Loaded once upstream (for the parser prompt) and handed down on the context.
+const INCOME_CATEGORIES = [
+  { id: "salary", name: "Salary", countsAsEarnings: true },
+  { id: "other", name: "Other Income", countsAsEarnings: true },
+  { id: "returned", name: "Money Lent Returned", countsAsEarnings: false },
+];
+
 describe("BatchProcessor", () => {
   let expenseRepository: any;
   let categoryRepository: any;
@@ -133,6 +140,67 @@ describe("BatchProcessor", () => {
       "e1",
       "summary-msg",
     );
+  });
+
+  // The gap this closes: batch income used to be written with no category, and
+  // an uncategorised row counts as earnings — so a refund buried in a
+  // multi-transaction message widened the budget anyway.
+  it("files batch income under a category, and marks money coming back", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "chai 30, nadha returned 1500",
+      incomeCategories: INCOME_CATEGORIES,
+      parsedBatch: {
+        transactions: [
+          {
+            intent: "EXPENSE",
+            amount: 30,
+            category: "Eating Out",
+            bucket: "WANTS",
+            confidence: 0.9,
+          },
+          {
+            intent: "INCOME",
+            amount: 1500,
+            category: "Money Lent Returned",
+            note: "nadha",
+            confidence: 0.9,
+          },
+        ],
+      },
+    } as any);
+
+    expect(incomeRepository.create.mock.calls[0]![0].categoryId).toBe(
+      "returned",
+    );
+    const summary = messageService.sendInteractiveMessage.mock.calls[0][1];
+    expect(summary).toContain("↩️ Income ₹1,500");
+  });
+
+  it("falls back to Other Income for a batch item with no category", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "chai 30, got 500",
+      incomeCategories: INCOME_CATEGORIES,
+      parsedBatch: {
+        transactions: [
+          {
+            intent: "EXPENSE",
+            amount: 30,
+            category: "Eating Out",
+            bucket: "WANTS",
+            confidence: 0.9,
+          },
+          { intent: "INCOME", amount: 500, confidence: 0.9 },
+        ],
+      },
+    } as any);
+
+    expect(incomeRepository.create.mock.calls[0]![0].categoryId).toBe("other");
+    const summary = messageService.sendInteractiveMessage.mock.calls[0][1];
+    expect(summary).toContain("✅ Income ₹500");
   });
 
   it("counts invented categories in one footer instead of per line", async () => {

--- a/src/application/use-cases/processors/BatchProcessor.ts
+++ b/src/application/use-cases/processors/BatchProcessor.ts
@@ -9,6 +9,7 @@ import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepos
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
 import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
 import { IParseLogRepository } from "../../../domain/repositories/IParseLogRepository";
+import { resolveIncomeCategory } from "../../../domain/incomeCategoryTemplate";
 import {
   IMessagingPlatform,
   InlineButtonRows,
@@ -115,6 +116,13 @@ export class BatchProcessor implements MessageProcessor {
       // Batch mode only logs money; skip stray non-EXPENSE/INCOME items.
       if (item.intent === "INCOME") {
         if (!isValidAmount(item.amount, INCOME_MAX)) continue;
+        // Same resolve-or-fallback as the single-income path. Without it a
+        // refund buried in a batch stays uncategorised, and an uncategorised
+        // row counts as earnings — so it widens the budget anyway.
+        const category = resolveIncomeCategory(
+          context.incomeCategories ?? [],
+          item.category,
+        );
         await this.incomeRepository.create({
           userId: user.id,
           amount: item.amount,
@@ -123,10 +131,13 @@ export class BatchProcessor implements MessageProcessor {
           source: item.note,
           note: item.note,
           batchId,
+          categoryId: category?.id,
         });
         recordedIncome = true;
         const label = item.note ? ` (${sanitizeMd(item.note)})` : "";
-        logged.push(`✅ Income ${formatMoney(item.amount)}${label}`);
+        // Mark money coming back, so it is not silently invisible in the summary.
+        const tick = category && !category.countsAsEarnings ? "↩️" : "✅";
+        logged.push(`${tick} Income ${formatMoney(item.amount)}${label}`);
         continue;
       }
       if (item.intent !== "EXPENSE") continue;

--- a/src/application/use-cases/processors/IncomeProcessor.ts
+++ b/src/application/use-cases/processors/IncomeProcessor.ts
@@ -4,7 +4,7 @@ import {
   ProcessOutput,
 } from "./MessageProcessor";
 import { IIncomeRepository } from "../../../domain/repositories/IIncomeRepository";
-import { INCOME_FALLBACK_CATEGORY } from "../../../domain/incomeCategoryTemplate";
+import { resolveIncomeCategory } from "../../../domain/incomeCategoryTemplate";
 import { IBudgetConfigRepository } from "../../../domain/repositories/IBudgetConfigRepository";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import { txnCb } from "../txnCallback";
@@ -55,14 +55,11 @@ export class IncomeProcessor implements MessageProcessor {
       return { response, parsed };
     }
 
-    // Resolve the parser's category name against the user's real rows (loaded
-    // upstream for the prompt). An unknown or missing name lands on the fallback,
-    // which counts as earnings — the behaviour from before the taxonomy existed.
-    const all = context.incomeCategories ?? [];
-    const wanted = parsed.category?.trim().toLowerCase();
-    const category =
-      (wanted && all.find((c) => c.name.toLowerCase() === wanted)) ||
-      all.find((c) => c.name === INCOME_FALLBACK_CATEGORY);
+    // Rows were loaded upstream for the parser prompt; reuse them here.
+    const category = resolveIncomeCategory(
+      context.incomeCategories ?? [],
+      parsed.category,
+    );
 
     const income = await this.incomeRepository.create({
       userId: user.id,

--- a/src/application/use-cases/processors/ReportProcessor.spec.ts
+++ b/src/application/use-cases/processors/ReportProcessor.spec.ts
@@ -7,6 +7,7 @@ describe("ReportProcessor", () => {
   let expenseRepository: any;
   let budgetConfigRepository: any;
   let messageService: any;
+  let incomeRepository: any;
   let processor: ReportProcessor;
 
   beforeEach(() => {
@@ -32,7 +33,7 @@ describe("ReportProcessor", () => {
         .mockResolvedValue({ needsPct: 50, wantsPct: 30, savingsPct: 20 }),
     };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
-    const incomeRepository = {
+    incomeRepository = {
       sumForMonth: vi.fn().mockResolvedValue(0),
       sumEarnedForMonth: vi.fn().mockResolvedValue(0),
     };
@@ -66,7 +67,7 @@ describe("ReportProcessor", () => {
 
     const body = messageService.sendMessage.mock.calls[0][0].body;
     expect(body).toContain("summary");
-    expect(body).toContain("Income logged ₹0");
+    expect(body).toContain("Income ₹0");
     expect(body).toContain("budget on ₹50,000");
     expect(body).toContain("₹23,400 / ₹25,000");
     expect(body).toContain("under by ₹1,600");
@@ -76,6 +77,39 @@ describe("ReportProcessor", () => {
     expect(body).toContain("Biggest leaks in Wants:");
     expect(body).toContain("Food delivery  ₹3,800");
     expect(body).toContain("Shopping  ₹2,900");
+  });
+
+  // /report used to print the EARNED figure under the label "Income logged", so
+  // a refund was invisible here while /status called it out. Same line now.
+  it("names the money coming back when gross and earned differ", async () => {
+    incomeRepository.sumForMonth.mockResolvedValue(69000);
+    incomeRepository.sumEarnedForMonth.mockResolvedValue(62000);
+
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "report",
+    } as any);
+
+    const body = messageService.sendMessage.mock.calls[0][0].body;
+    expect(body).toContain("Income ₹69,000");
+    expect(body).toContain("budget on ₹62,000");
+    expect(body).toContain("₹7,000 of that is money coming back");
+  });
+
+  it("stays short when every rupee was earned", async () => {
+    incomeRepository.sumForMonth.mockResolvedValue(62000);
+    incomeRepository.sumEarnedForMonth.mockResolvedValue(62000);
+
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "report",
+    } as any);
+
+    const body = messageService.sendMessage.mock.calls[0][0].body;
+    expect(body).toContain("Income ₹62,000");
+    expect(body).not.toContain("money coming back");
   });
 
   it("omits the leaks section when there is no Wants spend", async () => {

--- a/src/application/use-cases/processors/ReportProcessor.ts
+++ b/src/application/use-cases/processors/ReportProcessor.ts
@@ -14,6 +14,7 @@ import {
   currentBudgetPeriod,
   effectiveMonthlyIncome,
   formatMoney,
+  incomeBasisLine,
   previousCycles,
   sanitizeMd,
 } from "../budgetMath";
@@ -50,14 +51,16 @@ export class ReportProcessor implements MessageProcessor {
       DEFAULT_SPLIT;
     const { start, end } = currentBudgetPeriod(user.payday);
     const prior = previousCycles(user.payday, 1)[0]!;
-    const loggedIncome = await this.incomeRepository.sumEarnedForMonth(
-      user.id,
-      start,
-      end,
-    );
+    // Gross for the line, earned for the budget — /report used to print the
+    // earned figure under the label "Income logged", so a refund was invisible
+    // here while /status called it out. The two now agree.
+    const [grossIncome, earnedIncome] = await Promise.all([
+      this.incomeRepository.sumForMonth(user.id, start, end),
+      this.incomeRepository.sumEarnedForMonth(user.id, start, end),
+    ]);
     const monthlyIncome = effectiveMonthlyIncome(
       Number(user.monthlyIncome ?? 0),
-      loggedIncome,
+      earnedIncome,
     );
     const monthName = new Intl.DateTimeFormat("en-IN", {
       timeZone: user.timezone,
@@ -83,7 +86,7 @@ export class ReportProcessor implements MessageProcessor {
       lines.push(this.bucketLine(bucket, spent, budget, prevSpent));
     }
 
-    let body = `📅 ${monthName} summary\n\nIncome logged ${formatMoney(loggedIncome)} (budget on ${formatMoney(monthlyIncome)})\n${lines.join("\n")}`;
+    let body = `📅 ${monthName} summary\n\n${incomeBasisLine(grossIncome, earnedIncome, monthlyIncome)}\n${lines.join("\n")}`;
 
     const vs = vsLastSuffix(totalSpent, totalPrev);
     if (vs) body += `\n\nTotal spend ${formatMoney(totalSpent)}${vs}`;

--- a/src/application/use-cases/processors/StatusProcessor.ts
+++ b/src/application/use-cases/processors/StatusProcessor.ts
@@ -14,8 +14,9 @@ import {
   currentBudgetPeriod,
   effectiveMonthlyIncome,
   formatMoney,
-  periodDayInfo,
+  incomeBasisLine,
   pctSpent,
+  periodDayInfo,
   progressBar,
 } from "../budgetMath";
 
@@ -95,13 +96,7 @@ export class StatusProcessor implements MessageProcessor {
       }
     }
 
-    // Only call out the gap when there is one, so the common case stays short.
-    const notCounted = loggedIncome - earnedIncome;
-    const basisNote =
-      notCounted > 0
-        ? ` — ${formatMoney(notCounted)} of that is money coming back, so it doesn't raise the budget`
-        : "";
-    let body = `📊 This cycle — Day ${day} of ${daysInPeriod}\n💵 Income: ${formatMoney(loggedIncome)} (budget on ${formatMoney(monthlyIncome)})${basisNote}\n\n${lines.join("\n")}`;
+    let body = `📊 This cycle — Day ${day} of ${daysInPeriod}\n💵 ${incomeBasisLine(loggedIncome, earnedIncome, monthlyIncome)}\n\n${lines.join("\n")}`;
     if (dailyParts.length > 0) {
       body += `\n\nSafe daily spend left:  ${dailyParts.join(" · ")}`;
     }

--- a/src/data/repositories/PrismaIncomeRepository.spec.ts
+++ b/src/data/repositories/PrismaIncomeRepository.spec.ts
@@ -72,4 +72,34 @@ describe("PrismaIncomeRepository income sums", () => {
 
     expect(prisma.income.create.mock.calls[0]![0].data.categoryId).toBe("cat1");
   });
+
+  it("updates the category when one is given", async () => {
+    prisma.income.update = vi.fn().mockResolvedValue({});
+
+    await repo.update("i1", { categoryId: "cat2" });
+
+    expect(prisma.income.update.mock.calls[0]![0].data).toEqual({
+      categoryId: "cat2",
+    });
+  });
+
+  // Preservation by omission. The Telegram edit path cannot set a category, so
+  // it must not blank the one the parser assigned.
+  it("leaves the category untouched when the field is absent", async () => {
+    prisma.income.update = vi.fn().mockResolvedValue({});
+
+    await repo.update("i1", { amount: 500 });
+
+    expect(prisma.income.update.mock.calls[0]![0].data).not.toHaveProperty(
+      "categoryId",
+    );
+  });
+
+  it("can clear the category with an explicit null", async () => {
+    prisma.income.update = vi.fn().mockResolvedValue({});
+
+    await repo.update("i1", { categoryId: null });
+
+    expect(prisma.income.update.mock.calls[0]![0].data.categoryId).toBeNull();
+  });
 });

--- a/src/data/repositories/PrismaIncomeRepository.ts
+++ b/src/data/repositories/PrismaIncomeRepository.ts
@@ -96,6 +96,7 @@ export class PrismaIncomeRepository implements IIncomeRepository {
         ...(data.amount !== undefined && { amount: data.amount }),
         ...(data.source !== undefined && { source: data.source }),
         ...(data.note !== undefined && { note: data.note }),
+        ...(data.categoryId !== undefined && { categoryId: data.categoryId }),
       },
     });
   }

--- a/src/domain/incomeCategoryTemplate.spec.ts
+++ b/src/domain/incomeCategoryTemplate.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  INCOME_CATEGORY_TEMPLATE,
+  INCOME_FALLBACK_CATEGORY,
+  resolveIncomeCategory,
+} from "./incomeCategoryTemplate";
+
+const rows = [
+  { id: "salary", name: "Salary", countsAsEarnings: true },
+  { id: "other", name: "Other Income", countsAsEarnings: true },
+  { id: "returned", name: "Money Lent Returned", countsAsEarnings: false },
+];
+
+describe("resolveIncomeCategory", () => {
+  it("matches a name exactly", () => {
+    expect(resolveIncomeCategory(rows, "Money Lent Returned")?.id).toBe(
+      "returned",
+    );
+  });
+
+  it("matches case- and whitespace-insensitively", () => {
+    expect(resolveIncomeCategory(rows, "  sAlArY ")?.id).toBe("salary");
+  });
+
+  // The whole point of sharing this: an unknown or absent name must land on a
+  // category that counts as earnings, i.e. the pre-taxonomy behaviour.
+  it("falls back to Other Income for an invented name", () => {
+    expect(resolveIncomeCategory(rows, "Crypto Airdrop")?.id).toBe("other");
+  });
+
+  it("falls back when no name was parsed", () => {
+    expect(resolveIncomeCategory(rows, undefined)?.id).toBe("other");
+    expect(resolveIncomeCategory(rows, null)?.id).toBe("other");
+    expect(resolveIncomeCategory(rows, "   ")?.id).toBe("other");
+  });
+
+  it("returns undefined rather than throwing when nothing is seeded", () => {
+    expect(resolveIncomeCategory([], "Salary")).toBeUndefined();
+  });
+
+  // The fallback name must exist in the seeded taxonomy, or every unknown
+  // category silently resolves to undefined and writes a null categoryId.
+  it("has a fallback that the template actually seeds", () => {
+    expect(
+      INCOME_CATEGORY_TEMPLATE.some((c) => c.name === INCOME_FALLBACK_CATEGORY),
+    ).toBe(true);
+  });
+});

--- a/src/domain/incomeCategoryTemplate.ts
+++ b/src/domain/incomeCategoryTemplate.ts
@@ -32,3 +32,18 @@ export const INCOME_CATEGORY_TEMPLATE: IncomeCategoryTemplate[] = [
   { name: "Loan / Advance Received", countsAsEarnings: false },
   { name: "Transfer Between Accounts", countsAsEarnings: false },
 ];
+
+// Resolve a parser-supplied category name against the user's real rows. An
+// unknown or missing name lands on the fallback, which counts as earnings — the
+// behaviour from before the taxonomy existed. Shared so the fallback RULE lives
+// in one place; duplicating it is how the next call site drifts.
+export function resolveIncomeCategory<T extends { name: string }>(
+  all: T[],
+  name: string | null | undefined,
+): T | undefined {
+  const wanted = name?.trim().toLowerCase();
+  const hit = wanted
+    ? all.find((c) => c.name.toLowerCase() === wanted)
+    : undefined;
+  return hit ?? all.find((c) => c.name === INCOME_FALLBACK_CATEGORY);
+}

--- a/src/domain/productFacts.ts
+++ b/src/domain/productFacts.ts
@@ -88,7 +88,7 @@ export function buildProductFacts(dashboardUrl: string): ProductFacts {
       },
       {
         name: "Income that knows what it is",
-        what: "Logged income is filed under a category — salary, freelance, dividend, or a non-earning one like a refund, a reimbursement, money you lent being paid back, or a loan. Only earnings raise your budget; the rest is still recorded and still shows in your income total.",
+        what: "Income you log is filed under a category — salary, freelance, dividend, or a non-earning one like a refund, a reimbursement, money you lent being paid back, or a loan. Only earnings raise your budget; the rest is still recorded and still shows in your income total. If the bot files something wrongly, you can change the category on the dashboard.",
         why: "When a friend pays you back for lunch, that is not a raise. Counting it as income would widen your budget on money you already spent, so the same lunch would be paid for twice.",
       },
       {
@@ -101,7 +101,7 @@ export function buildProductFacts(dashboardUrl: string): ProductFacts {
     commands: [
       {
         command: "/status",
-        what: "Budget health this cycle and safe daily spend.",
+        what: "Budget health this cycle and safe daily spend, including what raised your budget and what did not.",
       },
       {
         command: "/report",
@@ -121,7 +121,7 @@ export function buildProductFacts(dashboardUrl: string): ProductFacts {
     dashboard: {
       url: dashboardUrl,
       whatItIsFor:
-        "Charts and trends, the full transaction list with CSV export, editing categories and their monthly limits, managing recurring rules, and all settings including income and reminder intensity.",
+        "Charts and trends, the full transaction list with CSV export, editing categories and their monthly limits, changing which category an income is filed under, managing recurring rules, and all settings including income and reminder intensity.",
       howToConnect:
         "Sign in on the dashboard, then tap Connect Telegram there to link this chat. Setting up income and categories happens on the dashboard, not in chat.",
     },

--- a/src/domain/repositories/IIncomeRepository.ts
+++ b/src/domain/repositories/IIncomeRepository.ts
@@ -12,11 +12,14 @@ export interface CreateIncomeDTO {
   categoryId?: string | undefined;
 }
 
-// Partial edit of an existing income (amount/source/note).
+// Partial edit of an existing income (amount/source/note/category). Every field
+// is applied only when present, so a caller that omits one leaves it untouched —
+// which is how the Telegram edit path preserves a category it cannot set.
 export interface UpdateIncomeDTO {
   amount?: number | undefined;
   source?: string | null | undefined;
   note?: string | null | undefined;
+  categoryId?: string | null | undefined;
 }
 
 export interface IIncomeRepository {


### PR DESCRIPTION
**1 of 5** in completing the income-category feature. Bot only — no schema, no web.

## Two holes that let a refund behave like earnings again

**Batch income was uncategorised.** `"chai 30, nadha returned 1500"` wrote the income row with no `categoryId`. An uncategorised row counts as earnings *by design* — that's what keeps pre-taxonomy rows behaving as before — so a refund buried in a batch widened the budget exactly as it used to, in the same file that already budgets on `sumEarnedForMonth`. `BatchProcessor` is post-parse, so the categories loaded for the parser prompt were already on the context, unused. A non-earning item now renders `↩️` instead of `✅`.

**`/report` labelled earned income as logged.** Both `/report` and the cycle wrapped printed `sumEarnedForMonth` under "Income logged", so a refund was invisible there while `/status` called it out — the two commands disagreed about the same cycle. `StatusProcessor` had already solved this, so its wording moves into `incomeBasisLine()` and all three render the same line.

```
Income ₹69,000 (budget on ₹62,000) — ₹7,000 of that is money coming
back, so it doesn't raise the budget
```

The gap is named only when there is one, so the common case stays one short line.

## Also

- Cycle report's net said `(income − spend)` but was computed from the effective figure, which carries the expected-salary floor — the on-screen arithmetic didn't add up whenever the floor applied. Now `(budget − spend)`; the number is unchanged.
- `resolveIncomeCategory()` moves beside the constant it depends on. Three call sites need it (the third arrives with recurring income in PR 4) and what would be duplicated is the *fallback rule*.
- `UpdateIncomeDTO` gains `categoryId`, applied only when present — so the dashboard can correct a mis-filed income (PR 2) while the Telegram edit path keeps preserving it by omission.
- `productFacts.ts` no longer overstates coverage, and now tells users where to fix a wrong category.

## Verification

- `pnpm test:unit` — **384 passed** (was 369), `tsc --noEmit` clean, `pnpm lint` 0 errors.
- The two batch tests are real regression tests: with the fix reverted they fail (`categoryId` undefined, `↩️` missing), confirmed before committing.
- New: `resolveIncomeCategory` cases (exact / case-insensitive / invented → fallback / no name / empty taxonomy), and a check that the fallback name is one the template actually seeds — otherwise every unknown category silently writes a null `categoryId`.
- `PrismaIncomeRepository.update` — writes `categoryId`, omits it when absent, clears on explicit null.

No schema, no web files, so nothing can race the deploy.
