### PR TITLE
feat(web): show, filter and correct the category on income

### DIFF
--- a/web/src/app/dashboard/categories/income/page.tsx
+++ b/web/src/app/dashboard/categories/income/page.tsx
@@ -1,0 +1,117 @@
+// Nested under /dashboard/categories so the sidebar's startsWith match keeps
+// "Categories" active. This shadows the sibling [id] segment — static wins over
+// dynamic, and category ids are cuids, so "income" can never collide.
+import { ContentLayout } from "@/components/admin-panel/content-layout";
+import { CategoriesTabs } from "@/components/categories-tabs";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { getIncomeCategoryTotals } from "@/lib/actions/income";
+import { formatMoney } from "@/lib/budget";
+
+type Item = { name: string; total: number };
+
+function Group({
+  title,
+  hint,
+  total,
+  items,
+  money,
+}: {
+  title: string;
+  hint: string;
+  total: number;
+  items: Item[];
+  money: (n: number) => string;
+}) {
+  return (
+    <Card>
+      <CardContent className="space-y-3 py-4">
+        <div className="flex items-baseline justify-between gap-4">
+          <div>
+            <h2 className="text-sm font-medium">{title}</h2>
+            <p className="text-xs text-muted-foreground">{hint}</p>
+          </div>
+          <span className="text-sm font-medium tabular-nums">
+            {money(total)}
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {items.map((item) => (
+            <Badge
+              key={item.name}
+              variant="outline"
+              className="gap-1.5 font-normal"
+            >
+              {item.name}
+              {item.total > 0 && (
+                <span className="text-muted-foreground tabular-nums">
+                  {money(item.total)}
+                </span>
+              )}
+            </Badge>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// Biggest first, so the cycle reads at a glance; ties fall back to name.
+const byTotalThenName = (a: Item, b: Item) =>
+  b.total - a.total || a.name.localeCompare(b.name);
+
+export default async function Page() {
+  const { categories, uncategorised, currency, locale } =
+    await getIncomeCategoryTotals();
+  const money = (n: number) => formatMoney(n, currency, locale);
+
+  const earning: Item[] = categories
+    .filter((c) => c.countsAsEarnings)
+    .map((c) => ({ name: c.name, total: c.total }));
+  // Uncategorised income counts as earnings — that is what the budget basis
+  // encodes — so it belongs in this group, not hidden.
+  if (uncategorised > 0) {
+    earning.push({ name: "Uncategorised", total: uncategorised });
+  }
+  earning.sort(byTotalThenName);
+
+  const other: Item[] = categories
+    .filter((c) => !c.countsAsEarnings)
+    .map((c) => ({ name: c.name, total: c.total }))
+    .sort(byTotalThenName);
+
+  const sum = (items: Item[]) => items.reduce((n, i) => n + i.total, 0);
+
+  return (
+    <ContentLayout title="Categories">
+      <div className="space-y-4">
+        <CategoriesTabs />
+        <p className="text-sm text-muted-foreground">
+          Where your income lands this cycle. Only earnings raise your budget —
+          money coming back is still recorded, but it has already been counted
+          once as the expense it offsets.
+        </p>
+
+        <Group
+          title="Counts as income"
+          hint="Raises your budget"
+          total={sum(earning)}
+          items={earning}
+          money={money}
+        />
+        <Group
+          title="Doesn't raise your budget"
+          hint="Money coming back to you"
+          total={sum(other)}
+          items={other}
+          money={money}
+        />
+
+        <p className="text-xs text-muted-foreground">
+          These are fixed. To change what an income is filed under, edit the row
+          in Transactions → Income.
+        </p>
+      </div>
+    </ContentLayout>
+  );
+}

--- a/web/src/app/dashboard/categories/page.tsx
+++ b/web/src/app/dashboard/categories/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { useQueryState, parseAsString } from "nuqs";
 import { ContentLayout } from "@/components/admin-panel/content-layout";
+import { CategoriesTabs } from "@/components/categories-tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Tabs,
@@ -132,6 +133,7 @@ export default function CategoriesPage() {
   return (
     <ContentLayout title="Categories">
       <div className="space-y-4">
+        <CategoriesTabs />
         <div className="space-y-1">
           <p className="text-sm text-muted-foreground">
             Your spending split into 50/30/20 buckets. Each bucket is your

--- a/web/src/app/dashboard/income/_components/columns.tsx
+++ b/web/src/app/dashboard/income/_components/columns.tsx
@@ -3,78 +3,102 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { Checkbox } from "@/components/ui/checkbox";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
-import { IncomeData } from "@/lib/actions/income";
+import {
+  type IncomeData,
+  type IncomeCategoryOption,
+} from "@/lib/actions/income";
 import { formatMoney } from "@/lib/budget";
+import { Badge } from "@/components/ui/badge";
 import { IncomeRowActions } from "./income-row-actions";
 
-export const columns: ColumnDef<IncomeData>[] = [
-  {
-    id: "select",
-    header: ({ table }) => (
-      <Checkbox
-        checked={
-          table.getIsAllPageRowsSelected() ||
-          (table.getIsSomePageRowsSelected() && "indeterminate")
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label="Select all"
-        className="translate-y-0.5"
-      />
-    ),
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label="Select row"
-        className="translate-y-0.5"
-      />
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
-  {
-    accessorKey: "date",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} label="Date" />
-    ),
-    cell: ({ row }) => {
-      const date = row.getValue("date") as Date;
-      return <div>{new Date(date).toLocaleDateString()}</div>;
+// A factory, like getExpenseColumns: the row actions need the category list to
+// populate the edit dialog, and a bare const cannot close over it.
+export function getIncomeColumns(
+  categories: IncomeCategoryOption[],
+): ColumnDef<IncomeData>[] {
+  return [
+    {
+      id: "select",
+      header: ({ table }) => (
+        <Checkbox
+          checked={
+            table.getIsAllPageRowsSelected() ||
+            (table.getIsSomePageRowsSelected() && "indeterminate")
+          }
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+          aria-label="Select all"
+          className="translate-y-0.5"
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(!!value)}
+          aria-label="Select row"
+          className="translate-y-0.5"
+        />
+      ),
+      enableSorting: false,
+      enableHiding: false,
     },
-    filterFn: "inNumberRange",
-  },
-  {
-    accessorKey: "amount",
-    header: ({ column }) => (
-      <div className="flex justify-end">
-        <DataTableColumnHeader column={column} label="Amount" />
-      </div>
-    ),
-    cell: ({ row }) => (
-      <div className="text-right font-medium text-green-600">
-        +{formatMoney(row.getValue("amount"))}
-      </div>
-    ),
-  },
-  {
-    accessorKey: "note",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} label="Note" />
-    ),
-    cell: ({ row }) => (
-      <div className="max-w-[240px] truncate">
-        {row.getValue("note") || "—"}
-      </div>
-    ),
-  },
-  {
-    id: "actions",
-    cell: ({ row }) => (
-      <div className="flex justify-end">
-        <IncomeRowActions income={row.original} />
-      </div>
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
-];
+    {
+      accessorKey: "date",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} label="Date" />
+      ),
+      cell: ({ row }) => {
+        const date = row.getValue("date") as Date;
+        return <div>{new Date(date).toLocaleDateString()}</div>;
+      },
+      filterFn: "inNumberRange",
+    },
+    {
+      accessorKey: "amount",
+      header: ({ column }) => (
+        <div className="flex justify-end">
+          <DataTableColumnHeader column={column} label="Amount" />
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-right font-medium text-green-600">
+          +{formatMoney(row.getValue("amount"))}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "categoryName",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} label="Category" />
+      ),
+      cell: ({ row }) => {
+        const name = row.original.categoryName;
+        return name ? (
+          <Badge variant="outline">{name}</Badge>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        );
+      },
+    },
+    {
+      accessorKey: "note",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} label="Note" />
+      ),
+      cell: ({ row }) => (
+        <div className="max-w-[240px] truncate">
+          {row.getValue("note") || "—"}
+        </div>
+      ),
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <div className="flex justify-end">
+          <IncomeRowActions income={row.original} categories={categories} />
+        </div>
+      ),
+      enableSorting: false,
+      enableHiding: false,
+    },
+  ];
+}

--- a/web/src/app/dashboard/income/_components/edit-income-modal.tsx
+++ b/web/src/app/dashboard/income/_components/edit-income-modal.tsx
@@ -31,7 +31,20 @@ import {
   ResponsiveModalDescription,
   ResponsiveModalFooter,
 } from "@/components/ui/responsive-modal";
-import { updateIncome, type IncomeData } from "@/lib/actions/income";
+import {
+  updateIncome,
+  type IncomeData,
+  type IncomeCategoryOption,
+} from "@/lib/actions/income";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   incomeEditSchema,
   type IncomeEditInput,
@@ -40,12 +53,14 @@ import { toast } from "@/lib/toast";
 
 interface EditIncomeModalProps {
   income: IncomeData;
+  categories: IncomeCategoryOption[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
 export function EditIncomeModal({
   income,
+  categories,
   open,
   onOpenChange,
 }: EditIncomeModalProps) {
@@ -58,6 +73,8 @@ export function EditIncomeModal({
     defaultValues: {
       amount: income.amount,
       date: income.date,
+      // ?? undefined, not ?? "" — Radix Select cannot hold an empty value.
+      categoryId: income.categoryId ?? undefined,
       source: income.source ?? "",
       note: income.note ?? "",
     },
@@ -68,6 +85,7 @@ export function EditIncomeModal({
       form.reset({
         amount: income.amount,
         date: income.date,
+        categoryId: income.categoryId ?? undefined,
         source: income.source ?? "",
         note: income.note ?? "",
       });
@@ -93,7 +111,7 @@ export function EditIncomeModal({
         <ResponsiveModalHeader>
           <ResponsiveModalTitle>Edit Income</ResponsiveModalTitle>
           <ResponsiveModalDescription>
-            Update the amount, date, source, or note for this income.
+            Update the amount, date, category, source, or note for this income.
           </ResponsiveModalDescription>
         </ResponsiveModalHeader>
         <Form {...form}>
@@ -167,6 +185,50 @@ export function EditIncomeModal({
                     <FormControl>
                       <Input placeholder="salary, freelance, etc." {...field} />
                     </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="categoryId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Category</FormLabel>
+                    {/* value, not defaultValue: this form calls reset() on open,
+                        and defaultValue would keep the previous row's pick. */}
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Uncategorised" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {/* Grouped by the rule that actually matters, so the
+                            consequence is visible at the moment of choosing. */}
+                        <SelectGroup>
+                          <SelectLabel>Counts as income</SelectLabel>
+                          {categories
+                            .filter((c) => c.countsAsEarnings)
+                            .map((c) => (
+                              <SelectItem key={c.id} value={c.id}>
+                                {c.name}
+                              </SelectItem>
+                            ))}
+                        </SelectGroup>
+                        <SelectGroup>
+                          <SelectLabel>Doesn&apos;t raise your budget</SelectLabel>
+                          {categories
+                            .filter((c) => !c.countsAsEarnings)
+                            .map((c) => (
+                              <SelectItem key={c.id} value={c.id}>
+                                {c.name}
+                              </SelectItem>
+                            ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/web/src/app/dashboard/income/_components/income-row-actions.tsx
+++ b/web/src/app/dashboard/income/_components/income-row-actions.tsx
@@ -12,16 +12,24 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { deleteIncome, type IncomeData } from "@/lib/actions/income";
+import {
+  deleteIncome,
+  type IncomeData,
+  type IncomeCategoryOption,
+} from "@/lib/actions/income";
 import { toast } from "@/lib/toast";
 import { EditIncomeModal } from "./edit-income-modal";
 import { MoveToBoxModal } from "@/app/dashboard/_components/move-to-box-modal";
 
 interface IncomeRowActionsProps {
   income: IncomeData;
+  categories: IncomeCategoryOption[];
 }
 
-export function IncomeRowActions({ income }: IncomeRowActionsProps) {
+export function IncomeRowActions({
+  income,
+  categories,
+}: IncomeRowActionsProps) {
   const router = useRouter();
   const [editOpen, setEditOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
@@ -67,6 +75,7 @@ export function IncomeRowActions({ income }: IncomeRowActionsProps) {
       </DropdownMenu>
 
       <EditIncomeModal
+        categories={categories}
         income={income}
         open={editOpen}
         onOpenChange={setEditOpen}

--- a/web/src/app/dashboard/income/_components/income-table-toolbar.tsx
+++ b/web/src/app/dashboard/income/_components/income-table-toolbar.tsx
@@ -5,6 +5,7 @@ import type { Table } from "@tanstack/react-table";
 
 import { DataTableAdvancedToolbar } from "@/components/data-table/data-table-advanced-toolbar";
 import { DataTableDateFilter } from "@/components/data-table/data-table-date-filter";
+import { DataTableFacetedFilter } from "@/components/data-table/data-table-faceted-filter";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { X, Download } from "lucide-react";
@@ -14,11 +15,13 @@ import { exportIncomeCsv, type IncomeFilters } from "@/lib/actions/income";
 interface IncomeTableToolbarProps<TData> {
   table: Table<TData>;
   filters: IncomeFilters;
+  categoryOptions: { label: string; value: string }[];
 }
 
 export function IncomeTableToolbar<TData>({
   table,
   filters,
+  categoryOptions,
 }: IncomeTableToolbarProps<TData>) {
   const isFiltered = table.getState().columnFilters.length > 0;
   const [isExporting, startExport] = React.useTransition();
@@ -47,6 +50,14 @@ export function IncomeTableToolbar<TData>({
         onChange={(event) => table.setGlobalFilter(event.target.value)}
         className="h-8 w-[150px] lg:w-[250px]"
       />
+      {table.getColumn("categoryName") && categoryOptions.length > 0 && (
+        <DataTableFacetedFilter
+          column={table.getColumn("categoryName")}
+          title="Category"
+          options={categoryOptions}
+          multiple
+        />
+      )}
       {table.getColumn("date") && (
         <DataTableDateFilter
           column={table.getColumn("date")!}

--- a/web/src/app/dashboard/income/income-table.tsx
+++ b/web/src/app/dashboard/income/income-table.tsx
@@ -9,9 +9,13 @@ import {
   ColumnFiltersState,
 } from "@tanstack/react-table";
 import { useQueryState, parseAsInteger, parseAsString } from "nuqs";
-import { IncomeData, IncomeFilters } from "@/lib/actions/income";
+import {
+  type IncomeData,
+  type IncomeFilters,
+  type IncomeCategoryOption,
+} from "@/lib/actions/income";
 import { DataTable } from "@/components/data-table/data-table";
-import { columns } from "./_components/columns";
+import { getIncomeColumns } from "./_components/columns";
 import { IncomeTableToolbar } from "./_components/income-table-toolbar";
 import { IncomeTableFloatingBar } from "./_components/income-table-floating-bar";
 import { DataTableAmountTotals } from "@/components/data-table/data-table-amount-totals";
@@ -21,6 +25,8 @@ interface IncomeTableProps {
   pageCount: number;
   total: number;
   totalAmount: number;
+  categories: IncomeCategoryOption[];
+  categoryOptions: { label: string; value: string }[];
 }
 
 export function IncomeTable({
@@ -28,7 +34,13 @@ export function IncomeTable({
   pageCount,
   total,
   totalAmount,
+  categories,
+  categoryOptions,
 }: IncomeTableProps) {
+  const columns = React.useMemo(
+    () => getIncomeColumns(categories),
+    [categories],
+  );
   const [page, setPage] = useQueryState(
     "page",
     parseAsInteger.withDefault(1).withOptions({ shallow: false }),
@@ -53,6 +65,10 @@ export function IncomeTable({
     "perPage",
     parseAsInteger.withDefault(10).withOptions({ shallow: false }),
   );
+  const [categoryId, setCategoryId] = useQueryState(
+    "categoryId",
+    parseAsString.withOptions({ shallow: false }),
+  );
 
   const columnFilters = React.useMemo<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = [];
@@ -62,8 +78,14 @@ export function IncomeTable({
         value: [from ? Number(from) : undefined, to ? Number(to) : undefined],
       });
     }
+    // Mounted on the categoryName column but keyed by id, exactly as the expense
+    // table does. Safe only because manualFiltering means the accessor value is
+    // never compared client-side.
+    if (categoryId) {
+      filters.push({ id: "categoryName", value: categoryId.split(".") });
+    }
     return filters;
-  }, [from, to]);
+  }, [from, to, categoryId]);
 
   const sorting: SortingState = React.useMemo(() => {
     if (!sort) return [];
@@ -98,6 +120,13 @@ export function IncomeTable({
       setFrom(null);
       setTo(null);
     }
+
+    const categoryFilter = newFilters.find((f) => f.id === "categoryName");
+    if (categoryFilter && Array.isArray(categoryFilter.value)) {
+      setCategoryId(categoryFilter.value.join("."));
+    } else {
+      setCategoryId(null);
+    }
   };
 
   const onGlobalFilterChange = (updater: Updater<string>) => {
@@ -109,6 +138,7 @@ export function IncomeTable({
     search: search || undefined,
     from: from || undefined,
     to: to || undefined,
+    categoryId: categoryId || undefined,
   };
 
   const table = useReactTable({
@@ -151,7 +181,11 @@ export function IncomeTable({
         />
       }
     >
-      <IncomeTableToolbar table={table} filters={currentFilters} />
+      <IncomeTableToolbar
+        table={table}
+        filters={currentFilters}
+        categoryOptions={categoryOptions}
+      />
     </DataTable>
   );
 }

--- a/web/src/app/dashboard/income/page.tsx
+++ b/web/src/app/dashboard/income/page.tsx
@@ -1,7 +1,7 @@
 import { ContentLayout } from "@/components/admin-panel/content-layout";
 import { TransactionsTabs } from "@/components/transactions-tabs";
 import { IncomeTable } from "./income-table";
-import { getIncome } from "@/lib/actions/income";
+import { getIncome, getIncomeCategories } from "@/lib/actions/income";
 
 interface PageProps {
   searchParams: Promise<{
@@ -11,6 +11,7 @@ interface PageProps {
     sort?: string;
     from?: string;
     to?: string;
+    categoryId?: string;
   }>;
 }
 
@@ -22,15 +23,18 @@ export default async function Page({ searchParams }: PageProps) {
   const sort = params.sort || "date.desc";
   const from = params.from || "";
   const to = params.to || "";
+  const categoryId = params.categoryId || "";
 
-  const { data, total, totalAmount, pageCount } = await getIncome({
-    page,
-    limit,
-    search,
-    sort,
-    from,
-    to,
-  });
+  const [{ data, total, totalAmount, pageCount }, categories] =
+    await Promise.all([
+      getIncome({ page, limit, search, sort, from, to, categoryId }),
+      getIncomeCategories(),
+    ]);
+
+  const categoryOptions = categories.map((c) => ({
+    label: c.name,
+    value: c.id,
+  }));
 
   return (
     <ContentLayout title="Transactions">
@@ -41,6 +45,8 @@ export default async function Page({ searchParams }: PageProps) {
           pageCount={pageCount}
           total={total}
           totalAmount={totalAmount}
+          categories={categories}
+          categoryOptions={categoryOptions}
         />
       </div>
     </ContentLayout>

--- a/web/src/components/categories-tabs.tsx
+++ b/web/src/components/categories-tabs.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+const TABS = [
+  { href: "/dashboard/categories", label: "Spending" },
+  { href: "/dashboard/categories/income", label: "Income" },
+];
+
+// Route-based tabs for the Categories area (Spending | Income), mirroring
+// TransactionsTabs. Each is its own route so the income view can stay a server
+// component while the spending page remains client-side.
+export function CategoriesTabs() {
+  const pathname = usePathname();
+  return (
+    <div className="flex gap-1 border-b">
+      {TABS.map((tab) => {
+        // Exact match, not startsWith: the income route is nested under the
+        // spending one, which would otherwise light up both tabs.
+        const active = pathname === tab.href;
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={cn(
+              "border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+              active
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/lib/actions/income.ts
+++ b/web/src/lib/actions/income.ts
@@ -8,6 +8,7 @@ import {
   incomeEditSchema,
   type IncomeEditInput,
 } from "@/lib/validations/income";
+import { currentBudgetPeriod } from "@/lib/budget";
 
 export type IncomeData = {
   id: string;
@@ -15,17 +16,28 @@ export type IncomeData = {
   source: string | null;
   note: string | null;
   date: Date;
+  categoryId: string | null;
+  categoryName: string | null;
+};
+
+// The 13 seeded system rows. There is no per-user income taxonomy and there is
+// not meant to be one, so this is the same list for everybody.
+export type IncomeCategoryOption = {
+  id: string;
+  name: string;
+  countsAsEarnings: boolean;
 };
 
 export type IncomeFilters = {
   search?: string;
   from?: string; // epoch ms
   to?: string; // epoch ms
+  categoryId?: string; // dot-separated ids, multi-select
 };
 
 function buildWhere(
   userId: string,
-  { search, from, to }: IncomeFilters,
+  { search, from, to, categoryId }: IncomeFilters,
 ): Prisma.IncomeWhereInput {
   const where: Prisma.IncomeWhereInput = {
     userId,
@@ -45,6 +57,11 @@ function buildWhere(
     if (to) where.date.lte = new Date(Number(to) + 86_399_999);
   }
 
+  if (categoryId) {
+    const ids = categoryId.split(".");
+    if (ids.length > 0) where.categoryId = { in: ids };
+  }
+
   return where;
 }
 
@@ -55,6 +72,7 @@ export async function getIncome({
   sort = "date.desc",
   from,
   to,
+  categoryId,
 }: {
   page?: number;
   limit?: number;
@@ -62,6 +80,7 @@ export async function getIncome({
   sort?: string;
   from?: string;
   to?: string;
+  categoryId?: string;
 }) {
   const session = await auth();
   if (!session?.user?.id) {
@@ -92,13 +111,19 @@ export async function getIncome({
     [sortField]: sortOrder,
   };
 
-  const where = buildWhere(session.user.id, { search, from, to });
+  const where = buildWhere(session.user.id, { search, from, to, categoryId });
 
   try {
     const [total, amountAgg, incomes] = await Promise.all([
       prisma.income.count({ where }),
       prisma.income.aggregate({ where, _sum: { amount: true } }),
-      prisma.income.findMany({ where, orderBy, skip, take: limit }),
+      prisma.income.findMany({
+        where,
+        orderBy,
+        skip,
+        take: limit,
+        include: { category: { select: { name: true } } },
+      }),
     ]);
 
     const data: IncomeData[] = incomes.map((i) => ({
@@ -107,6 +132,8 @@ export async function getIncome({
       source: i.source,
       note: i.note,
       date: i.date,
+      categoryId: i.categoryId,
+      categoryName: i.category?.name ?? null,
     }));
 
     return {
@@ -141,8 +168,7 @@ export async function deleteIncome(ids: string[]) {
     data: { isDeleted: true, deletedAt: new Date() },
   });
 
-  revalidatePath("/dashboard/income");
-  revalidatePath("/dashboard");
+  revalidateIncome();
   return { success: true };
 }
 
@@ -157,21 +183,51 @@ export async function updateIncome(id: string, input: IncomeEditInput) {
       message: parsed.error.issues[0]?.message ?? "Invalid input",
     };
   }
-  const { amount, date, source, note } = parsed.data;
+  const { amount, date, source, note, categoryId } = parsed.data;
 
   const income = await prisma.income.findUnique({
     where: { id, userId: session.user.id },
   });
   if (!income) return { success: false, message: "Income not found" };
 
+  // findFirst + OR, not findUnique({ id, userId }) as the expense side does:
+  // IncomeCategory.userId is nullable and every system row has it null, so an
+  // ownership check would reject the entire taxonomy.
+  let categoryUpdate: { categoryId?: string } = {};
+  if (categoryId) {
+    const category = await prisma.incomeCategory.findFirst({
+      where: {
+        id: categoryId,
+        OR: [{ userId: null }, { userId: session.user.id }],
+      },
+      select: { id: true },
+    });
+    if (!category) return { success: false, message: "Category not found" };
+    categoryUpdate = { categoryId: category.id };
+  }
+
   await prisma.income.update({
     where: { id },
-    data: { amount, date, source: source || null, note: note || null },
+    data: {
+      amount,
+      date,
+      source: source || null,
+      note: note || null,
+      ...categoryUpdate,
+    },
   });
 
-  revalidatePath("/dashboard/income");
-  revalidatePath("/dashboard");
+  revalidateIncome();
   return { success: true };
+}
+
+// Editing or deleting an income moves the budget basis, so every surface built
+// on it has to be refreshed — not just the income table.
+function revalidateIncome(): void {
+  revalidatePath("/dashboard");
+  revalidatePath("/dashboard/income");
+  revalidatePath("/dashboard/analytics");
+  revalidatePath("/dashboard/categories/income");
 }
 
 function csvCell(value: string): string {
@@ -191,13 +247,15 @@ export async function exportIncomeCsv(
   const incomes = await prisma.income.findMany({
     where,
     orderBy: { date: "desc" },
+    include: { category: { select: { name: true } } },
   });
 
-  const header = ["Date", "Amount", "Source", "Note"];
+  const header = ["Date", "Amount", "Category", "Source", "Note"];
   const rows = incomes.map((i) =>
     [
       i.date.toISOString().split("T")[0],
       String(Number(i.amount)),
+      i.category?.name ?? "",
       i.source ?? "",
       i.note ?? "",
     ]
@@ -206,4 +264,71 @@ export async function exportIncomeCsv(
   );
 
   return { success: true, csv: [header.join(","), ...rows].join("\n") };
+}
+
+// System rows (userId = null) plus, for forward-compatibility, anything the user
+// owns. Mirrors PrismaIncomeCategoryRepository.findAllForUser — that repository
+// lives in the bot's src/ and is not importable from here, so the clause is
+// copied rather than shared.
+export async function getIncomeCategories(): Promise<IncomeCategoryOption[]> {
+  const session = await auth();
+  if (!session?.user?.id) return [];
+
+  return prisma.incomeCategory.findMany({
+    where: { OR: [{ userId: null }, { userId: session.user.id }] },
+    orderBy: { name: "asc" },
+    select: { id: true, name: true, countsAsEarnings: true },
+  });
+}
+
+export type IncomeCategoryTotals = {
+  categories: (IncomeCategoryOption & { total: number })[];
+  // Income with no category. It counts as earnings — that is exactly what the
+  // NOT{countsAsEarnings:false} basis encodes — so the taxonomy page shows it
+  // on the earning side rather than hiding it.
+  uncategorised: number;
+  currency: string;
+  locale: string;
+};
+
+export async function getIncomeCategoryTotals(): Promise<IncomeCategoryTotals> {
+  const session = await auth();
+  const empty = {
+    categories: [],
+    uncategorised: 0,
+    currency: "INR",
+    locale: "en-IN",
+  };
+  if (!session?.user?.id) return empty;
+  const userId = session.user.id;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { payday: true, currency: true, locale: true },
+  });
+  const { start, end } = currentBudgetPeriod(user?.payday ?? 1);
+
+  const [categories, grouped] = await Promise.all([
+    prisma.incomeCategory.findMany({
+      where: { OR: [{ userId: null }, { userId }] },
+      orderBy: { name: "asc" },
+      select: { id: true, name: true, countsAsEarnings: true },
+    }),
+    prisma.income.groupBy({
+      by: ["categoryId"],
+      _sum: { amount: true },
+      where: { userId, isDeleted: false, date: { gte: start, lt: end } },
+    }),
+  ]);
+
+  const totals = new Map(
+    grouped.map((g) => [g.categoryId, Number(g._sum.amount ?? 0)]),
+  );
+
+  return {
+    categories: categories.map((c) => ({ ...c, total: totals.get(c.id) ?? 0 })),
+    uncategorised: totals.get(null) ?? 0,
+    currency: user?.currency ?? "INR",
+    locale: user?.locale ?? "en-IN",
+  };
 }

--- a/web/src/lib/validations/income.ts
+++ b/web/src/lib/validations/income.ts
@@ -5,6 +5,9 @@ import { z } from "zod";
 export const incomeEditSchema = z.object({
   amount: z.number().positive("Must be positive").max(1_000_000_000),
   date: z.date(),
+  // Re-assign only: the 13 system categories are the whole taxonomy, and Radix
+  // Select cannot hold an empty value, so there is no way to clear this.
+  categoryId: z.string().trim().max(50).optional(),
   source: z.string().trim().max(50).optional(),
   note: z.string().trim().max(100).optional(),
 });


### PR DESCRIPTION
**2 of 5** in completing the income-category feature. Web only — no schema, independent of #60.

## The gap

The bot has filed income under a category since the taxonomy shipped, but nothing in the dashboard showed it and nothing anywhere could change it. A refund mis-read as salary silently widened the budget with no way to fix it; a correctly-filed one left the user staring at a deposit that moved no budget, with nothing on screen explaining why.

## Income table

Category column, multi-select facet filter, Category in the CSV export, and a picker in the edit dialog — all mirroring the expense table, including the quirk where the filter mounts on the `categoryName` column while its option *values* are ids (safe because `manualFiltering` means the accessor is never compared client-side).

The picker groups options under **Counts as income** / **Doesn't raise your budget**, so the consequence is visible while choosing. There's no clear option — 13 fixed categories and Radix `Select` can't hold an empty value, so the widget enforces re-assign-only for free.

## Categories → Income tab

```
Categories        [ Spending | Income ]

Counts as income                          ₹62,000
  Salary ₹55,000   Freelance ₹7,000   Business Income   …

Doesn't raise your budget                  ₹7,000
  Refund ₹5,500   Money Lent Returned ₹1,500   …

These are fixed. To change what an income is filed under, edit
the row in Transactions → Income.
```

Read-only by design, per the decision that the 13 system rows are the whole taxonomy. A server component with zero client JS, nested at `/dashboard/categories/income` so the sidebar's `startsWith` match keeps Categories active. It shadows the sibling `[id]` segment — static wins over dynamic and ids are cuids, so `"income"` can never collide. The build output confirms both routes register.

Uncategorised income sits in the **earning** group rather than hidden, because that is what the budget basis does with it (`NOT{countsAsEarnings:false}` includes NULL). That also makes the group total exactly equal the basis — see the check below.

## Two things worth a reviewer's eye

- `updateIncome` resolves a category with `findFirst` + `OR`, **not** the expense side's `findUnique({ id, userId })`. `IncomeCategory.userId` is nullable and every system row has it null, so an ownership check would reject the entire taxonomy.
- `updateIncome` and `deleteIncome` both revalidated only `/dashboard/income` and `/dashboard`, so analytics kept a stale budget after an income edit. Both now also refresh analytics and the taxonomy page. Pre-existing bug; the new page would have made it visible.

## Verification

- `pnpm build` passes (the real check here — it catches server/client boundary and prop-type breaks lint misses); `tsc --noEmit` clean; `pnpm lint` 0 errors; `pnpm test` 71 passed.
- `diff -q` on the two schema copies passes — this PR touches no `.prisma`.

**The check that proves it's wired right:** the "Counts as income" total must equal the basis `getBudgetOverview` computes with `EARNED_ONLY` for the same cycle. Recategorise a row from Salary to Refund and reload `/dashboard` — that total, the budget basis and every bucket budget must drop together.

No new unit test: the grouping is two `filter()` calls, and web vitest here covers pure modules only.
