### PR TITLE
fix(web): divide savings rates by earnings, not gross income

### DIFF
--- a/web/src/lib/actions/analytics.ts
+++ b/web/src/lib/actions/analytics.ts
@@ -521,7 +521,13 @@ export async function getCashflowAnalytics(
     }),
     prisma.income.findMany({
       where: { userId: ctx.userId, isDeleted: false, date: { gte, lt } },
-      select: { amount: true, date: true },
+      // EARNED_ONLY is a where-fragment and cannot split one findMany into two
+      // totals, so carry the flag per row instead.
+      select: {
+        amount: true,
+        date: true,
+        category: { select: { countsAsEarnings: true } },
+      },
     }),
     prisma.boxEntry.findMany({
       where: { userId: ctx.userId, isDeleted: false, date: { gte, lt } },
@@ -539,6 +545,9 @@ export async function getCashflowAnalytics(
   const indexOf = cycleIndexer(windows);
   const agg = windows.map(() => ({
     income: 0,
+    // Income minus refunds, repaid loans and transfers. Used only as a rate
+    // DENOMINATOR — see the savings rows below for why the numerator stays gross.
+    earned: 0,
     spend: 0,
     savingsBucket: 0,
     boxIn: 0,
@@ -557,7 +566,11 @@ export async function getCashflowAnalytics(
   for (const inc of incomes) {
     const i = indexOf(inc.date);
     if (i < 0) continue;
-    agg[i]!.income += Number(inc.amount);
+    const amount = Number(inc.amount);
+    agg[i]!.income += amount;
+    // Uncategorised counts as earnings, matching sumEarnedForMonth's
+    // NOT{countsAsEarnings:false} — absence is not a refund.
+    if (inc.category?.countsAsEarnings !== false) agg[i]!.earned += amount;
   }
 
   for (const b of boxEntries) {
@@ -596,19 +609,24 @@ export async function getCashflowAnalytics(
   });
 
   const savings: SavingsRow[] = windows.map((w, i) => {
-    const { income, spend, savingsBucket, boxContributed } = agg[i]!;
+    const { income, earned, spend, savingsBucket, boxContributed } = agg[i]!;
     const trueSaved = savingsBucket + boxContributed;
     return {
       cycle: w.label,
       cycleKey: w.key,
       income,
+      // Gross numerator, earned denominator. `income - spend` is already right:
+      // a refund is in both sides and cancels. Dropping it from income alone
+      // would leave the refunded expense in spend and invent a loss that never
+      // happened. Only the divisor is wrong — dividing by gross treats money
+      // coming back as something you earned, understating the rate.
       unspent: income - spend,
       trueSaved,
-      // Income is taken per cycle as actually logged. user.monthlyIncome is a
+      // Earnings are taken per cycle as actually logged. user.monthlyIncome is a
       // current setting, not history — applying it backwards would invent
       // income for months before the user set it.
-      unspentRatePct: income > 0 ? ((income - spend) / income) * 100 : null,
-      trueSavingsRatePct: income > 0 ? (trueSaved / income) * 100 : null,
+      unspentRatePct: earned > 0 ? ((income - spend) / earned) * 100 : null,
+      trueSavingsRatePct: earned > 0 ? (trueSaved / earned) * 100 : null,
     };
   });
 
@@ -628,7 +646,9 @@ export async function getCashflowAnalytics(
     cashflow,
     savings,
     boxes,
-    cyclesWithoutIncome: savings.filter((s) => s.income <= 0).length,
+    // A cycle whose only deposits were refunds had no income, however much
+    // money moved through it.
+    cyclesWithoutIncome: agg.filter((a) => a.earned <= 0).length,
     insights: {
       cashflow: previous
         ? deltaInsight({

--- a/web/src/lib/actions/wrapped.ts
+++ b/web/src/lib/actions/wrapped.ts
@@ -4,7 +4,12 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import { Bucket } from "@prisma/client";
-import { BUCKETS, BUCKET_META, currentMonthRange } from "@/lib/budget";
+import {
+  BUCKETS,
+  BUCKET_META,
+  currentMonthRange,
+  EARNED_ONLY,
+} from "@/lib/budget";
 import { DEFAULT_TZ, isMonthEndWindow, zonedParts } from "@/lib/time";
 
 export type WrappedBucketSlice = {
@@ -55,34 +60,46 @@ export async function getWrappedStats(): Promise<WrappedStats | null> {
   const { start, end } = currentMonthRange(now);
   const where = { userId, isDeleted: false, date: { gte: start, lt: end } };
 
-  const [bucketGroups, incomeAgg, biggest, txnCount, categoryGroups] =
-    await Promise.all([
-      prisma.expense.groupBy({
-        by: ["bucket"],
-        _sum: { amount: true },
-        where,
-      }),
-      prisma.income.aggregate({ _sum: { amount: true }, where }),
-      prisma.expense.findFirst({
-        where,
-        orderBy: { amount: "desc" },
-        select: {
-          amount: true,
-          note: true,
-          rawText: true,
-          bucket: true,
-          category: { select: { name: true } },
-        },
-      }),
-      prisma.expense.count({ where }),
-      prisma.expense.groupBy({
-        by: ["categoryId"],
-        _sum: { amount: true },
-        where,
-        orderBy: { _sum: { amount: "desc" } },
-        take: 1,
-      }),
-    ]);
+  const [
+    bucketGroups,
+    incomeAgg,
+    earnedAgg,
+    biggest,
+    txnCount,
+    categoryGroups,
+  ] = await Promise.all([
+    prisma.expense.groupBy({
+      by: ["bucket"],
+      _sum: { amount: true },
+      where,
+    }),
+    prisma.income.aggregate({ _sum: { amount: true }, where }),
+    // Same window, minus refunds and repaid loans. The rate divides by this;
+    // the totals stay gross. See below.
+    prisma.income.aggregate({
+      _sum: { amount: true },
+      where: { ...where, ...EARNED_ONLY },
+    }),
+    prisma.expense.findFirst({
+      where,
+      orderBy: { amount: "desc" },
+      select: {
+        amount: true,
+        note: true,
+        rawText: true,
+        bucket: true,
+        category: { select: { name: true } },
+      },
+    }),
+    prisma.expense.count({ where }),
+    prisma.expense.groupBy({
+      by: ["categoryId"],
+      _sum: { amount: true },
+      where,
+      orderBy: { _sum: { amount: "desc" } },
+      take: 1,
+    }),
+  ]);
 
   if (txnCount === 0) return null;
 
@@ -104,9 +121,15 @@ export async function getWrappedStats(): Promise<WrappedStats | null> {
   });
 
   const totalIncome = Number(incomeAgg._sum.amount ?? 0);
+  const totalEarned = Number(earnedAgg._sum.amount ?? 0);
+  // netSaved stays gross and is already correct: a refund sits on both sides
+  // and cancels. Removing it from income alone would leave the refunded expense
+  // in spend and invent a loss. The rate is the part that was wrong — dividing
+  // by gross counts money coming back as something earned. The story copy
+  // already says "of everything you earned"; now the maths agrees.
   const netSaved = totalIncome - totalSpent;
   const savingsRatePct =
-    totalIncome > 0 ? Math.round((netSaved / totalIncome) * 100) : 0;
+    totalEarned > 0 ? Math.round((netSaved / totalEarned) * 100) : 0;
 
   // Top category by spend (skip uncategorized rows).
   let topCategory: WrappedStats["topCategory"] = null;


### PR DESCRIPTION
**3 of 5** in completing the income-category feature. Web only, no schema, independent of #60 and #61.

## The bug

`wrapped-story.tsx` renders **"of everything you earned"** over a number computed against every rupee that landed, refunds included. A month with a ₹5,000 purchase later refunded ₹5,000 reports a *lower* savings rate than the same month without either transaction.

## The obvious fix is wrong

Filtering refunds out of income while the refunded expense stays in spend invents a loss that never happened:

| | income | spend | netSaved | rate |
|---|---|---|---|---|
| Gross (today) | 55,000 | 35,000 | 20,000 ✅ | 36% |
| `EARNED_ONLY` on income alone | 50,000 | 35,000 | **15,000 ❌** | 30% |
| **This PR** | 55,000 | 35,000 | 20,000 ✅ | **40% ✅** |

*(salary ₹50,000, real spend ₹30,000, plus a ₹5,000 purchase refunded ₹5,000 — the truth is 20,000 saved on 50,000 earned = 40%)*

`netSaved` is **already correct** — the refund sits on both sides and cancels. Only the divisor was wrong, so only the divisor changes. Cashflow bars, running balance, `netSaved` and `unspent` all stay gross, because a cash chart should match what the bank statement says arrived.

## Mechanics

- `getCashflowAnalytics` reads income with `findMany`, not an aggregate, so `EARNED_ONLY` can't split it into two totals — the `countsAsEarnings` flag comes back per row and is accumulated alongside. Uncategorised counts as earnings, matching `sumEarnedForMonth`'s `NOT{countsAsEarnings:false}`: absence is not a refund.
- Wrapped can use `EARNED_ONLY` directly; one extra aggregate in the existing `Promise.all`.
- `cyclesWithoutIncome` now tests earnings — a cycle whose only deposits were refunds had no income, however much money moved through it.

No copy changes: Wrapped already claimed "earned", the maths just didn't.

## Known limitation

This assumes the offsetting expense falls in the same cycle. A loan repaid months after the spend still skews one cycle. Noted in the code rather than solved — properly pairing a return to its original expense needs a link the data model doesn't have.

## Verification

`pnpm build` ✓ · `tsc --noEmit` clean · `pnpm lint` 0 errors · `pnpm test` 71 passed.

No new test: the change is a divisor swap and a per-row flag inside two Prisma-coupled server actions, and web vitest here covers pure modules only. Extracting a `savingsRate(net, earned)` helper purely to have something to assert on would be inventing a seam. The table above is the specification — worth checking by eye against the diff.
