### PR TITLE
feat(recurring): income categories on recurring rules (re-targets #63 + #64 at main)

### DIFF
--- a/prisma/migrations/20260910090000_recurring_income_category/migration.sql
+++ b/prisma/migrations/20260910090000_recurring_income_category/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "RecurringRule" ADD COLUMN     "incomeCategoryId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "RecurringRule" ADD CONSTRAINT "RecurringRule_incomeCategoryId_fkey" FOREIGN KEY ("incomeCategoryId") REFERENCES "IncomeCategory"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- An INCOME rule could never have held a valid expense category or bucket, but
+-- PendingActionProcessor resolved the assistant's category name against the
+-- expense taxonomy regardless of kind and wrote both. Clear what it left.
+UPDATE "RecurringRule" SET "categoryId" = NULL, "bucket" = NULL WHERE "kind" = 'INCOME';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,16 +101,16 @@ model User {
   sessions      Session[]
 
   // Core relations
-  expenses       Expense[]
-  incomes        Income[]
-  budgetConfig   BudgetConfig?
-  categories     Category[]
+  expenses         Expense[]
+  incomes          Income[]
+  budgetConfig     BudgetConfig?
+  categories       Category[]
   incomeCategories IncomeCategory[]
-  logs           ParseLog[]
-  budgetNudges   BudgetNudge[]
-  recurringRules RecurringRule[]
-  boxes          Box[]
-  boxEntries     BoxEntry[]
+  logs             ParseLog[]
+  budgetNudges     BudgetNudge[]
+  recurringRules   RecurringRule[]
+  boxes            Box[]
+  boxEntries       BoxEntry[]
 
   conversationMessages ConversationMessage[]
   pendingActions       PendingAction[]
@@ -194,21 +194,27 @@ model Category {
 
 // A repeating income/expense the scheduler auto-posts each month on dayOfMonth.
 model RecurringRule {
-  id            String        @id @default(cuid())
-  userId        String
-  user          User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  kind          RecurringKind
-  amount        Decimal       @db.Decimal(12, 2)
-  dayOfMonth    Int // 1–28
-  bucket        Bucket? // for EXPENSE
-  categoryId    String?
-  category      Category?     @relation(fields: [categoryId], references: [id])
-  boxId         String? // for BOX: auto-contribute (IN) to this box each month
-  box           Box?          @relation(fields: [boxId], references: [id])
-  note          String?
-  isActive      Boolean       @default(true)
+  id               String          @id @default(cuid())
+  userId           String
+  user             User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  kind             RecurringKind
+  amount           Decimal         @db.Decimal(12, 2)
+  dayOfMonth       Int // 1–28
+  bucket           Bucket? // for EXPENSE
+  categoryId       String?
+  category         Category?       @relation(fields: [categoryId], references: [id])
+  // for INCOME. A separate FK because Category is the EXPENSE taxonomy and
+  // requires a bucket, which means nothing for income. `kind` decides which of
+  // the two is read; validated in the app layer, not a DB check, exactly as
+  // bucket and boxId already are.
+  incomeCategoryId String?
+  incomeCategory   IncomeCategory? @relation(fields: [incomeCategoryId], references: [id], onDelete: SetNull)
+  boxId            String? // for BOX: auto-contribute (IN) to this box each month
+  box              Box?            @relation(fields: [boxId], references: [id])
+  note             String?
+  isActive         Boolean         @default(true)
   // "YYYY-MM" of the last auto-post — idempotency for the daily job.
-  lastPostedKey String?
+  lastPostedKey    String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -309,7 +315,8 @@ model IncomeCategory {
   userId String?
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  incomes Income[]
+  incomes        Income[]
+  recurringRules RecurringRule[]
 
   createdAt DateTime @default(now())
 
@@ -425,7 +432,7 @@ model ProcessedMessage {
 // instead of being guessed from emoji-laden prose. The AI-metadata columns are
 // nullable: deterministic slash-command turns fill none of them.
 model ConversationMessage {
-  id String @id @default(cuid())
+  id      String @id @default(cuid())
   // Append order. createdAt is not safe to order by: two turns written in the
   // same millisecond tie, and across instances clocks drift — either way the
   // transcript replayed to the model comes back scrambled.

--- a/src/application/use-cases/PostRecurringCharges.spec.ts
+++ b/src/application/use-cases/PostRecurringCharges.spec.ts
@@ -199,4 +199,28 @@ describe("PostRecurringCharges", () => {
     );
     expect(expenseRepository.create).not.toHaveBeenCalled();
   });
+
+  // The rule's category has to reach the row it posts, or every auto-logged
+  // income is uncategorised — which counts as earnings, so a recurring
+  // reimbursement would widen the budget every month.
+  it("carries the rule's income category onto the posted row", async () => {
+    recurringRuleRepository.findAllActive.mockResolvedValue([
+      {
+        id: "rr3",
+        userId: "u1",
+        kind: "INCOME",
+        amount: 2500,
+        dayOfMonth: 25,
+        incomeCategoryId: "ic-reimbursement",
+        note: "travel claim",
+      },
+    ]);
+
+    await useCase.execute(new Date(Date.UTC(2026, 5, 26, 12)), true);
+
+    expect(incomeRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ categoryId: "ic-reimbursement" }),
+      expect.anything(),
+    );
+  });
 });

--- a/src/application/use-cases/ProcessIncomingMessage.ts
+++ b/src/application/use-cases/ProcessIncomingMessage.ts
@@ -111,6 +111,7 @@ export class ProcessIncomingMessageUseCase {
               boxRepository,
               recurringRuleRepository,
               messageService,
+              incomeCategoryRepository,
             ),
           ]
         : []),

--- a/src/application/use-cases/postRecurringRule.ts
+++ b/src/application/use-cases/postRecurringRule.ts
@@ -42,6 +42,9 @@ export async function postRecurringRule(
           confidence: 1,
           source: rule.note ?? "recurring",
           note: rule.note ?? undefined,
+          // Null until the rule carries one, which still counts as earnings —
+          // the right default for a recurring income rule.
+          categoryId: rule.incomeCategoryId ?? undefined,
         },
         tx,
       );

--- a/src/application/use-cases/processors/PendingActionProcessor.spec.ts
+++ b/src/application/use-cases/processors/PendingActionProcessor.spec.ts
@@ -25,6 +25,7 @@ describe("PendingActionProcessor", () => {
   let boxRepository: any;
   let recurringRuleRepository: any;
   let messageService: any;
+  let incomeCategoryRepository: any;
   let p: PendingActionProcessor;
 
   beforeEach(() => {
@@ -51,6 +52,12 @@ describe("PendingActionProcessor", () => {
       create: vi.fn().mockResolvedValue({ id: "r1" }),
     };
     messageService = { sendMessage: vi.fn().mockResolvedValue("m1") };
+    incomeCategoryRepository = {
+      findAllForUser: vi.fn().mockResolvedValue([
+        { id: "ic-salary", name: "Salary", countsAsEarnings: true },
+        { id: "ic-other", name: "Other Income", countsAsEarnings: true },
+      ]),
+    };
 
     p = new PendingActionProcessor(
       pendingActionRepository,
@@ -59,6 +66,7 @@ describe("PendingActionProcessor", () => {
       boxRepository,
       recurringRuleRepository,
       messageService,
+      incomeCategoryRepository,
     );
   });
 
@@ -232,6 +240,52 @@ describe("PendingActionProcessor", () => {
       expect(recurringRuleRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({ bucket: "NEEDS", categoryId: "c1" }),
       );
+    });
+
+    // The bug: this resolved every rule against the EXPENSE taxonomy whatever
+    // the kind, so an income rule for a user who happened to have a spending
+    // category called "Freelance" got that category AND its bucket attached.
+    it("never resolves an income rule against the expense categories", async () => {
+      pendingActionRepository.findLiveForUser.mockResolvedValue(
+        pending({
+          kind: "SET_RECURRING",
+          payload: {
+            kind: "INCOME",
+            amount: 45000,
+            dayOfMonth: 1,
+            incomeCategoryName: "Salary",
+            note: "salary",
+          },
+        }),
+      );
+      // A same-named expense category exists; it must not be consulted.
+      categoryRepository.findByNameForUser.mockResolvedValue({
+        id: "c-freelance",
+        name: "Salary",
+        bucket: "WANTS",
+      });
+
+      await p.process(ctx("act:p1:y"));
+
+      expect(categoryRepository.findByNameForUser).not.toHaveBeenCalled();
+      const created = recurringRuleRepository.create.mock.calls[0]![0];
+      expect(created.incomeCategoryId).toBe("ic-salary");
+      expect(created.categoryId).toBeUndefined();
+      expect(created.bucket).toBeUndefined();
+    });
+
+    it("falls back to Other Income when the assistant names nothing", async () => {
+      pendingActionRepository.findLiveForUser.mockResolvedValue(
+        pending({
+          kind: "SET_RECURRING",
+          payload: { kind: "INCOME", amount: 45000, dayOfMonth: 1 },
+        }),
+      );
+
+      await p.process(ctx("act:p1:y"));
+      expect(
+        recurringRuleRepository.create.mock.calls[0]![0].incomeCategoryId,
+      ).toBe("ic-other");
     });
   });
 

--- a/src/application/use-cases/processors/PendingActionProcessor.ts
+++ b/src/application/use-cases/processors/PendingActionProcessor.ts
@@ -8,6 +8,8 @@ import { IExpenseRepository } from "../../../domain/repositories/IExpenseReposit
 import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepository";
 import { IBoxRepository } from "../../../domain/repositories/IBoxRepository";
 import { IRecurringRuleRepository } from "../../../domain/repositories/IRecurringRuleRepository";
+import { IIncomeCategoryRepository } from "../../../domain/repositories/IIncomeCategoryRepository";
+import { resolveIncomeCategory } from "../../../domain/incomeCategoryTemplate";
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import { parseActCallback } from "../actCallback";
 import { parsePendingPayload } from "../../../domain/entities/PendingAction";
@@ -34,6 +36,7 @@ export class PendingActionProcessor implements MessageProcessor {
     private readonly boxRepository: IBoxRepository,
     private readonly recurringRuleRepository: IRecurringRuleRepository,
     private readonly messageService: IMessagingPlatform,
+    private readonly incomeCategoryRepository: IIncomeCategoryRepository,
   ) {}
 
   canHandle(context: ProcessContext): boolean {
@@ -107,8 +110,27 @@ export class PendingActionProcessor implements MessageProcessor {
           dayOfMonth: number;
           bucket?: "NEEDS" | "WANTS" | "SAVINGS";
           categoryName?: string;
+          incomeCategoryName?: string;
           note?: string;
         };
+        // Two taxonomies. This used to resolve against the EXPENSE categories
+        // whatever the kind, so an income rule could be handed an expense
+        // category and inherit its bucket.
+        if (p.kind === "INCOME") {
+          const incomeCategory = resolveIncomeCategory(
+            await this.incomeCategoryRepository.findAllForUser(userId),
+            p.incomeCategoryName,
+          );
+          await this.recurringRuleRepository.create({
+            userId,
+            kind: "INCOME",
+            amount: p.amount,
+            dayOfMonth: p.dayOfMonth,
+            incomeCategoryId: incomeCategory?.id,
+            note: p.note,
+          });
+          return `🔁 Set up: ${formatMoney(p.amount)} income on day ${p.dayOfMonth} every month.`;
+        }
         const category = p.categoryName
           ? await this.categoryRepository.findByNameForUser(
               userId,
@@ -126,7 +148,7 @@ export class PendingActionProcessor implements MessageProcessor {
           categoryId: category?.id,
           note: p.note,
         });
-        return `🔁 Set up: ${formatMoney(p.amount)} ${p.kind === "INCOME" ? "income" : "expense"} on day ${p.dayOfMonth} every month.`;
+        return `🔁 Set up: ${formatMoney(p.amount)} expense on day ${p.dayOfMonth} every month.`;
       }
 
       case "BOX_MOVE": {

--- a/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.spec.ts
@@ -3,6 +3,11 @@ import { RecurringSetupProcessor } from "./RecurringSetupProcessor";
 
 const user = { id: "u1", telegramId: "123" };
 
+const INCOME_CATEGORIES = [
+  { id: "ic-salary", name: "Salary", countsAsEarnings: true },
+  { id: "ic-other", name: "Other Income", countsAsEarnings: true },
+];
+
 describe("RecurringSetupProcessor", () => {
   let recurringRuleRepository: any;
   let categoryRepository: any;
@@ -164,6 +169,56 @@ describe("RecurringSetupProcessor", () => {
     expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
       "Recurring income",
     );
+  });
+
+  // An income rule posts an Income row every month. Without a category those
+  // rows are uncategorised, which counts as earnings — fine for salary, wrong
+  // for a recurring reimbursement.
+  it("files a recurring income under its income category", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "salary 50000 on 25th monthly",
+      incomeCategories: INCOME_CATEGORIES,
+      parsed: {
+        intent: "RECURRING",
+        recurringKind: "INCOME",
+        amount: 50000,
+        dayOfMonth: 25,
+        category: "Salary",
+        note: "salary",
+        confidence: 0.9,
+      },
+    } as any);
+
+    const created = recurringRuleRepository.create.mock.calls[0]![0];
+    expect(created.incomeCategoryId).toBe("ic-salary");
+    // Income has no bucket and must never borrow an expense category.
+    expect(created.bucket).toBeUndefined();
+    expect(created.categoryId).toBeUndefined();
+    expect(messageService.sendMessage.mock.calls[0][0].body).toContain(
+      "Salary",
+    );
+  });
+
+  it("falls back to Other Income when the parser names nothing", async () => {
+    await processor.process({
+      user,
+      platformUserId: "123",
+      textMessage: "50000 on 25th monthly",
+      incomeCategories: INCOME_CATEGORIES,
+      parsed: {
+        intent: "RECURRING",
+        recurringKind: "INCOME",
+        amount: 50000,
+        dayOfMonth: 25,
+        confidence: 0.9,
+      },
+    } as any);
+
+    expect(
+      recurringRuleRepository.create.mock.calls[0]![0].incomeCategoryId,
+    ).toBe("ic-other");
   });
 
   it("asks for a day when dayOfMonth is missing", async () => {

--- a/src/application/use-cases/processors/RecurringSetupProcessor.ts
+++ b/src/application/use-cases/processors/RecurringSetupProcessor.ts
@@ -9,6 +9,7 @@ import { ICategoryRepository } from "../../../domain/repositories/ICategoryRepos
 import { IMessagingPlatform } from "../../interfaces/IMessagingPlatform";
 import { BUCKET_META, formatMoney, sanitizeMd } from "../budgetMath";
 import { normalizeCategoryName } from "../categoryName";
+import { resolveIncomeCategory } from "../../../domain/incomeCategoryTemplate";
 import { NEW_CATEGORY_LINE } from "../expenseFlow";
 
 const MAX_AMOUNT = 1_000_000_000;
@@ -49,18 +50,29 @@ export class RecurringSetupProcessor implements MessageProcessor {
     const kind = parsed.recurringKind ?? "EXPENSE";
 
     if (kind === "INCOME") {
+      // Income has its own taxonomy and no bucket. The rows were loaded
+      // upstream for the parser prompt; a rule set from a pre-parse path has
+      // none, and a null category still counts as earnings.
+      const incomeCategory = resolveIncomeCategory(
+        context.incomeCategories ?? [],
+        parsed.category,
+      );
       const rule = await this.recurringRuleRepository.create({
         userId: user.id,
         kind: "INCOME",
         amount,
         dayOfMonth: day,
+        incomeCategoryId: incomeCategory?.id,
         note: parsed.note,
       });
+      const filed = incomeCategory
+        ? ` · ${sanitizeMd(incomeCategory.name)}`
+        : "";
       return this.finish(
         platformUserId,
         rule.id,
         day,
-        `🔁 Recurring income set: ${formatMoney(amount)}${parsed.note ? ` (${sanitizeMd(parsed.note)})` : ""} on day ${day} — I'll auto-log it each month.`,
+        `🔁 Recurring income set: ${formatMoney(amount)}${filed}${parsed.note ? ` (${sanitizeMd(parsed.note)})` : ""} on day ${day} — I'll auto-log it each month.`,
       );
     }
 

--- a/src/application/use-cases/query/AssistantWriteTools.spec.ts
+++ b/src/application/use-cases/query/AssistantWriteTools.spec.ts
@@ -145,6 +145,56 @@ describe("AssistantWriteTools", () => {
         pendingActionRepository.create.mock.calls[0]![0].payload.bucket,
       ).toBe("NEEDS");
     });
+
+    // Income has its own taxonomy. This used to resolve every rule against the
+    // expense categories, so an income rule inherited a spending category and
+    // its bucket.
+    it("stages an income rule against the income taxonomy, with no bucket", async () => {
+      await writes.proposeRecurring("u1", {
+        kind: "INCOME",
+        amount: 45000,
+        dayOfMonth: 1,
+        bucket: "NEEDS", // meaningless for income
+        category: "Salary",
+      });
+
+      expect(categoryRepository.findByNameForUser).not.toHaveBeenCalled();
+      const payload = pendingActionRepository.create.mock.calls[0]![0].payload;
+      expect(payload.incomeCategoryName).toBe("Salary");
+      expect(payload.categoryName).toBeUndefined();
+      expect(payload.bucket).toBeUndefined();
+    });
+
+    it("rejects an unknown income category with the income names", async () => {
+      const res = await writes.proposeRecurring("u1", {
+        kind: "INCOME",
+        amount: 45000,
+        dayOfMonth: 1,
+        category: "Food", // a real EXPENSE category, wrong taxonomy
+      });
+
+      expect(res).toMatchObject({
+        ok: false,
+        error: "unknown_income_category",
+      });
+      expect((res as any).available_categories).toContain("Salary");
+      expect((res as any).available_categories).toContain("Refund");
+      expect(pendingActionRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("matches an income category case-insensitively", async () => {
+      await writes.proposeRecurring("u1", {
+        kind: "INCOME",
+        amount: 45000,
+        dayOfMonth: 1,
+        category: "salary",
+      });
+
+      expect(
+        pendingActionRepository.create.mock.calls[0]![0].payload
+          .incomeCategoryName,
+      ).toBe("Salary");
+    });
   });
 
   describe("payload validation happens before staging", () => {

--- a/src/application/use-cases/query/AssistantWriteTools.ts
+++ b/src/application/use-cases/query/AssistantWriteTools.ts
@@ -1,4 +1,5 @@
 import { Bucket } from "@prisma/client";
+import { INCOME_CATEGORY_TEMPLATE } from "../../../domain/incomeCategoryTemplate";
 import {
   IAssistantWriteTools,
   ProposalResult,
@@ -27,6 +28,14 @@ type ResolvedBucket =
 // makes (box name, expense id, category, bucket) is resolved against real rows
 // HERE — so a confirmed action can never apply to something invented, and an
 // unresolvable reference comes back as a soft error with the valid options.
+// The income taxonomy is 13 fixed system rows, seeded for every user, so it can
+// be validated against the template without a repository round-trip.
+function resolveIncomeCategoryName(name: string): string | undefined {
+  const wanted = name.trim().toLowerCase();
+  return INCOME_CATEGORY_TEMPLATE.find((c) => c.name.toLowerCase() === wanted)
+    ?.name;
+}
+
 export class AssistantWriteTools implements IAssistantWriteTools {
   constructor(
     private readonly pendingActionRepository: IPendingActionRepository,
@@ -46,21 +55,47 @@ export class AssistantWriteTools implements IAssistantWriteTools {
       note?: string | undefined;
     },
   ): Promise<ProposalResult> {
-    const bucket = await this.resolveBucket(
-      userId,
-      input.bucket,
-      input.category,
-    );
-    if (!bucket.resolved) return bucket.failure;
+    // Two taxonomies, and only `kind` says which one `category` meant. This
+    // used to resolve every rule against the EXPENSE categories, so an income
+    // rule could be staged with an expense category and inherit its bucket.
+    let payload;
+    if (input.kind === "INCOME") {
+      const match = input.category
+        ? resolveIncomeCategoryName(input.category)
+        : undefined;
+      if (input.category && !match) {
+        return {
+          ok: false,
+          error: "unknown_income_category",
+          message: `"${input.category}" is not one of the income categories.`,
+          available_categories: INCOME_CATEGORY_TEMPLATE.map((c) => c.name),
+        };
+      }
+      // No bucket: the 50/30/20 split is a property of spending.
+      payload = {
+        kind: input.kind,
+        amount: input.amount,
+        dayOfMonth: input.dayOfMonth,
+        ...(match ? { incomeCategoryName: match } : {}),
+        ...(input.note ? { note: input.note } : {}),
+      };
+    } else {
+      const bucket = await this.resolveBucket(
+        userId,
+        input.bucket,
+        input.category,
+      );
+      if (!bucket.resolved) return bucket.failure;
 
-    const payload = {
-      kind: input.kind,
-      amount: input.amount,
-      dayOfMonth: input.dayOfMonth,
-      ...(bucket.bucket ? { bucket: bucket.bucket } : {}),
-      ...(input.category ? { categoryName: input.category } : {}),
-      ...(input.note ? { note: input.note } : {}),
-    };
+      payload = {
+        kind: input.kind,
+        amount: input.amount,
+        dayOfMonth: input.dayOfMonth,
+        ...(bucket.bucket ? { bucket: bucket.bucket } : {}),
+        ...(input.category ? { categoryName: input.category } : {}),
+        ...(input.note ? { note: input.note } : {}),
+      };
+    }
 
     const label = input.note ?? input.category ?? input.kind.toLowerCase();
     const summary =

--- a/src/data/ai/assistantTools.ts
+++ b/src/data/ai/assistantTools.ts
@@ -1,4 +1,5 @@
 import { Bucket } from "@prisma/client";
+import { INCOME_CATEGORY_TEMPLATE } from "../../domain/incomeCategoryTemplate";
 import {
   DateRange,
   IFinancialDataTools,
@@ -222,7 +223,10 @@ function writeTools(categoryProp: Record<string, unknown>): ToolDef[] {
         ...BUCKET_PROP,
         category: {
           type: "string",
-          description: "Category name for an expense rule.",
+          description:
+            "For an EXPENSE rule, one of the user's spending categories. For an INCOME rule, one of the income categories: " +
+            INCOME_CATEGORY_TEMPLATE.map((c) => c.name).join(", ") +
+            ". The two are separate taxonomies — never use a spending category on an income rule.",
         },
         note: { type: "string", description: "Short label, e.g. 'rent'." },
       },

--- a/src/data/repositories/PrismaRecurringRuleRepository.ts
+++ b/src/data/repositories/PrismaRecurringRuleRepository.ts
@@ -17,6 +17,7 @@ export class PrismaRecurringRuleRepository implements IRecurringRuleRepository {
         dayOfMonth: data.dayOfMonth,
         bucket: data.bucket ?? null,
         categoryId: data.categoryId ?? null,
+        incomeCategoryId: data.incomeCategoryId ?? null,
         boxId: data.boxId ?? null,
         note: data.note ?? null,
       },

--- a/src/domain/entities/PendingAction.ts
+++ b/src/domain/entities/PendingAction.ts
@@ -21,8 +21,12 @@ export const SetRecurringPayload = z.object({
   kind: z.enum(["INCOME", "EXPENSE"]),
   amount: z.number().positive().max(1_000_000_000),
   dayOfMonth: z.number().int().min(1).max(28),
+  // bucket + categoryName apply to an EXPENSE rule (Category, which requires a
+  // bucket); incomeCategoryName applies to an INCOME rule (IncomeCategory,
+  // which has none). `kind` decides which is read.
   bucket: z.enum(BUCKETS).optional(),
   categoryName: z.string().min(1).max(50).optional(),
+  incomeCategoryName: z.string().min(1).max(50).optional(),
   note: z.string().max(200).optional(),
 });
 

--- a/src/domain/productFacts.ts
+++ b/src/domain/productFacts.ts
@@ -107,7 +107,10 @@ export function buildProductFacts(dashboardUrl: string): ProductFacts {
         command: "/report",
         what: "This cycle's summary and biggest spending leaks.",
       },
-      { command: "/recurring", what: "See repeating income and expenses." },
+      {
+        command: "/recurring",
+        what: "See repeating income and expenses. A repeating income is filed under an income category, so a monthly reimbursement does not raise your budget.",
+      },
       {
         command: "/boxes",
         what: "See savings boxes and progress toward targets.",

--- a/src/domain/repositories/IRecurringRuleRepository.ts
+++ b/src/domain/repositories/IRecurringRuleRepository.ts
@@ -6,8 +6,11 @@ export interface CreateRecurringRuleDTO {
   kind: RecurringKind;
   amount: number;
   dayOfMonth: number;
+  // bucket + categoryId are EXPENSE-only; incomeCategoryId is INCOME-only;
+  // boxId is BOX-only. `kind` decides which apply.
   bucket?: Bucket | undefined;
   categoryId?: string | undefined;
+  incomeCategoryId?: string | undefined;
   boxId?: string | undefined;
   note?: string | undefined;
 }

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -101,16 +101,16 @@ model User {
   sessions      Session[]
 
   // Core relations
-  expenses       Expense[]
-  incomes        Income[]
-  budgetConfig   BudgetConfig?
-  categories     Category[]
+  expenses         Expense[]
+  incomes          Income[]
+  budgetConfig     BudgetConfig?
+  categories       Category[]
   incomeCategories IncomeCategory[]
-  logs           ParseLog[]
-  budgetNudges   BudgetNudge[]
-  recurringRules RecurringRule[]
-  boxes          Box[]
-  boxEntries     BoxEntry[]
+  logs             ParseLog[]
+  budgetNudges     BudgetNudge[]
+  recurringRules   RecurringRule[]
+  boxes            Box[]
+  boxEntries       BoxEntry[]
 
   conversationMessages ConversationMessage[]
   pendingActions       PendingAction[]
@@ -194,21 +194,27 @@ model Category {
 
 // A repeating income/expense the scheduler auto-posts each month on dayOfMonth.
 model RecurringRule {
-  id            String        @id @default(cuid())
-  userId        String
-  user          User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  kind          RecurringKind
-  amount        Decimal       @db.Decimal(12, 2)
-  dayOfMonth    Int // 1–28
-  bucket        Bucket? // for EXPENSE
-  categoryId    String?
-  category      Category?     @relation(fields: [categoryId], references: [id])
-  boxId         String? // for BOX: auto-contribute (IN) to this box each month
-  box           Box?          @relation(fields: [boxId], references: [id])
-  note          String?
-  isActive      Boolean       @default(true)
+  id               String          @id @default(cuid())
+  userId           String
+  user             User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  kind             RecurringKind
+  amount           Decimal         @db.Decimal(12, 2)
+  dayOfMonth       Int // 1–28
+  bucket           Bucket? // for EXPENSE
+  categoryId       String?
+  category         Category?       @relation(fields: [categoryId], references: [id])
+  // for INCOME. A separate FK because Category is the EXPENSE taxonomy and
+  // requires a bucket, which means nothing for income. `kind` decides which of
+  // the two is read; validated in the app layer, not a DB check, exactly as
+  // bucket and boxId already are.
+  incomeCategoryId String?
+  incomeCategory   IncomeCategory? @relation(fields: [incomeCategoryId], references: [id], onDelete: SetNull)
+  boxId            String? // for BOX: auto-contribute (IN) to this box each month
+  box              Box?            @relation(fields: [boxId], references: [id])
+  note             String?
+  isActive         Boolean         @default(true)
   // "YYYY-MM" of the last auto-post — idempotency for the daily job.
-  lastPostedKey String?
+  lastPostedKey    String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -309,7 +315,8 @@ model IncomeCategory {
   userId String?
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  incomes Income[]
+  incomes        Income[]
+  recurringRules RecurringRule[]
 
   createdAt DateTime @default(now())
 
@@ -425,7 +432,7 @@ model ProcessedMessage {
 // instead of being guessed from emoji-laden prose. The AI-metadata columns are
 // nullable: deterministic slash-command turns fill none of them.
 model ConversationMessage {
-  id String @id @default(cuid())
+  id      String @id @default(cuid())
   // Append order. createdAt is not safe to order by: two turns written in the
   // same millisecond tie, and across instances clocks drift — either way the
   // transcript replayed to the model comes back scrambled.

--- a/web/src/app/dashboard/recurring/_components/recurring-form-modal.tsx
+++ b/web/src/app/dashboard/recurring/_components/recurring-form-modal.tsx
@@ -16,7 +16,9 @@ import {
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -41,12 +43,14 @@ import {
 } from "@/lib/validations/recurring";
 import { toast } from "@/lib/toast";
 import type { CategoryStat } from "@/lib/actions/categories";
+import type { IncomeCategoryOption } from "@/lib/actions/income";
 import type { BoxView } from "@/lib/actions/boxes";
 import { CategoryCombobox } from "@/components/category-combobox";
 
 interface RecurringFormModalProps {
   rule?: RecurringRuleView;
   categories: CategoryStat[];
+  incomeCategories: IncomeCategoryOption[];
   boxes: BoxView[];
   onSaved: () => void;
   trigger?: React.ReactNode;
@@ -55,6 +59,7 @@ interface RecurringFormModalProps {
 export function RecurringFormModal({
   rule,
   categories,
+  incomeCategories,
   boxes,
   onSaved,
   trigger,
@@ -71,6 +76,7 @@ export function RecurringFormModal({
       dayOfMonth: rule?.dayOfMonth ?? 1,
       bucket: rule?.bucket ?? "NEEDS",
       categoryId: rule?.categoryId ?? undefined,
+      incomeCategoryId: rule?.incomeCategoryId ?? undefined,
       boxId: rule?.boxId ?? undefined,
       note: rule?.note ?? "",
     },
@@ -86,6 +92,7 @@ export function RecurringFormModal({
         dayOfMonth: rule?.dayOfMonth ?? 1,
         bucket: rule?.bucket ?? "NEEDS",
         categoryId: rule?.categoryId ?? undefined,
+        incomeCategoryId: rule?.incomeCategoryId ?? undefined,
         boxId: rule?.boxId ?? undefined,
         note: rule?.note ?? "",
       });
@@ -217,6 +224,55 @@ export function RecurringFormModal({
                           if (category) form.setValue("bucket", category.bucket);
                         }}
                       />
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+
+              {kind === "INCOME" && (
+                <FormField
+                  control={form.control}
+                  name="incomeCategoryId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Category (Optional)</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Uncategorised" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {/* Grouped by the rule that decides whether this
+                              raises the budget every month. */}
+                          <SelectGroup>
+                            <SelectLabel>Counts as income</SelectLabel>
+                            {incomeCategories
+                              .filter((c) => c.countsAsEarnings)
+                              .map((c) => (
+                                <SelectItem key={c.id} value={c.id}>
+                                  {c.name}
+                                </SelectItem>
+                              ))}
+                          </SelectGroup>
+                          <SelectGroup>
+                            <SelectLabel>
+                              Doesn&apos;t raise your budget
+                            </SelectLabel>
+                            {incomeCategories
+                              .filter((c) => !c.countsAsEarnings)
+                              .map((c) => (
+                                <SelectItem key={c.id} value={c.id}>
+                                  {c.name}
+                                </SelectItem>
+                              ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/web/src/app/dashboard/recurring/page.tsx
+++ b/web/src/app/dashboard/recurring/page.tsx
@@ -19,6 +19,10 @@ import {
 } from "@/lib/actions/recurring";
 import { getCategories, type CategoryStat } from "@/lib/actions/categories";
 import { getBoxes, type BoxView } from "@/lib/actions/boxes";
+import {
+  getIncomeCategories,
+  type IncomeCategoryOption,
+} from "@/lib/actions/income";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { RecurringFormModal } from "./_components/recurring-form-modal";
 import { toast } from "@/lib/toast";
@@ -28,19 +32,25 @@ export default function RecurringPage() {
   const [rules, setRules] = useState<RecurringRuleView[]>([]);
   const [categories, setCategories] = useState<CategoryStat[]>([]);
   const [boxes, setBoxes] = useState<BoxView[]>([]);
+  const [incomeCategories, setIncomeCategories] = useState<
+    IncomeCategoryOption[]
+  >([]);
   const [loading, setLoading] = useState(true);
   const [pending, startTransition] = useTransition();
 
   const load = async () => {
     try {
-      const [fetchedRules, fetchedCats, fetchedBoxes] = await Promise.all([
-        getRecurringRules(),
-        getCategories(),
-        getBoxes(),
-      ]);
+      const [fetchedRules, fetchedCats, fetchedBoxes, fetchedIncomeCats] =
+        await Promise.all([
+          getRecurringRules(),
+          getCategories(),
+          getBoxes(),
+          getIncomeCategories(),
+        ]);
       setRules(fetchedRules);
       setCategories(fetchedCats);
       setBoxes(fetchedBoxes);
+      setIncomeCategories(fetchedIncomeCats);
     } catch (err) {
       toast.error("Failed to load recurring data");
     } finally {
@@ -80,6 +90,7 @@ export default function RecurringPage() {
         {!loading && (
           <RecurringFormModal
             categories={categories}
+            incomeCategories={incomeCategories}
             boxes={boxes}
             onSaved={load}
           />
@@ -127,6 +138,7 @@ export default function RecurringPage() {
                         <RecurringFormModal
                           rule={r}
                           categories={categories}
+            incomeCategories={incomeCategories}
                           boxes={boxes}
                           onSaved={load}
                           trigger={
@@ -201,6 +213,7 @@ export default function RecurringPage() {
                         <RecurringFormModal
                           rule={r}
                           categories={categories}
+            incomeCategories={incomeCategories}
                           boxes={boxes}
                           onSaved={load}
                           trigger={
@@ -268,6 +281,7 @@ export default function RecurringPage() {
                         <RecurringFormModal
                           rule={r}
                           categories={categories}
+            incomeCategories={incomeCategories}
                           boxes={boxes}
                           onSaved={load}
                           trigger={

--- a/web/src/lib/actions/recurring.ts
+++ b/web/src/lib/actions/recurring.ts
@@ -17,6 +17,8 @@ export type RecurringRuleView = {
   bucket: Bucket | null;
   categoryId: string | null;
   categoryName: string | null;
+  incomeCategoryId: string | null;
+  incomeCategoryName: string | null;
   boxId: string | null;
   boxName: string | null;
   note: string | null;
@@ -30,6 +32,7 @@ export async function getRecurringRules(): Promise<RecurringRuleView[]> {
     where: { userId: session.user.id, isActive: true },
     include: {
       category: { select: { name: true } },
+      incomeCategory: { select: { name: true } },
       box: { select: { name: true } },
     },
     orderBy: [{ kind: "asc" }, { dayOfMonth: "asc" }],
@@ -43,6 +46,8 @@ export async function getRecurringRules(): Promise<RecurringRuleView[]> {
     bucket: r.bucket,
     categoryId: r.categoryId,
     categoryName: r.category?.name ?? null,
+    incomeCategoryId: r.incomeCategoryId,
+    incomeCategoryName: r.incomeCategory?.name ?? null,
     boxId: r.boxId,
     boxName: r.box?.name ?? null,
     note: r.note,
@@ -67,6 +72,7 @@ export async function createRecurringRule(
 
   let bucket: Bucket | null = null;
   let categoryId: string | null = null;
+  let incomeCategoryId: string | null = null;
   let boxId: string | null = null;
 
   if (data.kind === "EXPENSE") {
@@ -79,6 +85,19 @@ export async function createRecurringRule(
         categoryId = existing.id;
         bucket = existing.bucket;
       }
+    }
+  } else if (data.kind === "INCOME") {
+    // Its own taxonomy, and no bucket. findFirst + OR because every system
+    // row has a null userId, which an ownership check would reject.
+    if (data.incomeCategoryId) {
+      const existing = await prisma.incomeCategory.findFirst({
+        where: {
+          id: data.incomeCategoryId,
+          OR: [{ userId: null }, { userId }],
+        },
+        select: { id: true },
+      });
+      if (existing) incomeCategoryId = existing.id;
     }
   } else if (data.kind === "BOX") {
     if (!data.boxId) return { success: false, error: "Pick a box" };
@@ -97,6 +116,7 @@ export async function createRecurringRule(
       dayOfMonth: data.dayOfMonth,
       bucket,
       categoryId,
+      incomeCategoryId,
       boxId,
       note: data.note ?? null,
     },
@@ -139,6 +159,7 @@ export async function updateRecurringRule(
 
   let bucket: Bucket | null = null;
   let categoryId: string | null = null;
+  let incomeCategoryId: string | null = null;
   let boxId: string | null = null;
 
   if (data.kind === "EXPENSE") {
@@ -151,6 +172,19 @@ export async function updateRecurringRule(
         categoryId = existing.id;
         bucket = existing.bucket;
       }
+    }
+  } else if (data.kind === "INCOME") {
+    // Its own taxonomy, and no bucket. findFirst + OR because every system
+    // row has a null userId, which an ownership check would reject.
+    if (data.incomeCategoryId) {
+      const existing = await prisma.incomeCategory.findFirst({
+        where: {
+          id: data.incomeCategoryId,
+          OR: [{ userId: null }, { userId }],
+        },
+        select: { id: true },
+      });
+      if (existing) incomeCategoryId = existing.id;
     }
   } else if (data.kind === "BOX") {
     if (!data.boxId) return { success: false, error: "Pick a box" };
@@ -169,6 +203,7 @@ export async function updateRecurringRule(
       dayOfMonth: data.dayOfMonth,
       bucket,
       categoryId,
+      incomeCategoryId,
       boxId,
       note: data.note ?? null,
     },

--- a/web/src/lib/validations/recurring.ts
+++ b/web/src/lib/validations/recurring.ts
@@ -11,6 +11,9 @@ export const recurringRuleSchema = z.object({
     .max(28, "Use 1–28 to avoid month-end issues"),
   bucket: z.enum(["NEEDS", "WANTS", "SAVINGS"]).optional(),
   categoryId: z.string().trim().max(50).optional(),
+  // INCOME rules only. A separate field because income has its own taxonomy
+  // and no bucket; `kind` decides which of the two applies.
+  incomeCategoryId: z.string().trim().max(50).optional(),
   boxId: z.string().trim().max(50).optional(),
   note: z.string().trim().max(100).optional(),
 });


### PR DESCRIPTION
## Why this exists

#63 and #64 both merged **green**, but into their stacked base branches rather than `main` — and those bases (`feat/income-category-completion`, `feat/recurring-income-category`) had already been merged and closed by then. Their content never reached `main`:

```
git show origin/main:prisma/schema.prisma | grep -c incomeCategoryId   → 0
git ls-tree -r origin/main | grep -c recurring_income_category         → 0
```

`feat/recurring-income-category` accumulated both, so this single PR carries the whole remainder. No new work — it is exactly #63 + #64, with current `main` merged in (which brought #62's analytics and wrapped changes; resolved cleanly, no conflicts).

## Contents

- **#63** — `RecurringRule.incomeCategoryId` FK + migration, `postRecurringRule`, `RecurringSetupProcessor`, and the cross-taxonomy bug where `PendingActionProcessor` resolved an INCOME rule's category against the *expense* repository and attached its bucket. Migration also clears the `categoryId`/`bucket` that bug wrote onto existing INCOME rules.
- **#64** — the income-category picker on the recurring form, grouped "Counts as income" / "Doesn't raise your budget".

## Verification, re-run on the merged result

| Check | Result |
|---|---|
| `pnpm test:unit` | 392 passed (47 files) |
| web `pnpm test` | 71 passed |
| `tsc --noEmit` root + web | clean |
| `pnpm lint` root + web | 0 errors |
| `diff -q` schema copies | in sync |
| `pnpm build` (web) | compiled successfully |

## Deploy

Carries the migration, so the same note as #63 applies: CI's `diff -q` forces `web/prisma/schema.prisma` into the commit, which matches the web service's `watchPatterns`, so web rebuilds in parallel with the bot's `prisma migrate deploy`. Prisma emits explicit column lists, so a web instance live before the migration would 500 on `getRecurringRules`.

The bot normally wins by minutes (preDeploy vs. a full `next build`). To be deterministic, run `prisma migrate deploy` on the bot service before merging — it is idempotent, so the preDeploy run becomes a no-op.

## Cleanup after merge

These branches are now spent and can be deleted: `feat/income-categories`, `feat/income-category-completion`, `feat/income-category-web`, `feat/recurring-income-category-web`.
